### PR TITLE
Add an uninstall script for easy reversion

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,6 +1,7 @@
-# Caelestia for KDE Plasma
+<div align="center">
 
-Premium KDE Plasma desktop environment with celestial aesthetic, custom Quickshell widgets, Material Design 3 theming, and extensive system integration.
+# ✧ C A E L E S T I A <img src="assets/caelestia.svg" width="35" align="top"> ✧
+### A KDE adaptation of the celestial aesthetic
 
 ![Arch Linux](https://img.shields.io/badge/Arch_Linux-1793d1?logo=arch-linux&logoColor=white&style=for-the-badge)
 ![Fedora](https://img.shields.io/badge/Fedora-51A2DA?logo=fedora&logoColor=white&style=for-the-badge)
@@ -8,130 +9,286 @@ Premium KDE Plasma desktop environment with celestial aesthetic, custom Quickshe
 ![Quickshell](https://img.shields.io/badge/Quickshell-FF6B6B?style=for-the-badge)
 ![License: GPLv3](https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge&color=86dbce)
 
-![logo](https://github.com/user-attachments/assets/5662c83d-7181-4846-9fb8-79d0363c8c4f)
+<br/>
+<img width="400" height="230" alt="logo" src="https://github.com/user-attachments/assets/5662c83d-7181-4846-9fb8-79d0363c8c4f" />
 
-## Quick Start
+<br/>
+<br/>
 
-### Requirements
+> *“Ad astra per aspera.”*
 
-- Arch Linux / Fedora Linux / Arch-based derivative (EndeavourOS, CachyOS, Manjaro, etc.)
-- KDE Plasma 6.0+
+</div>
 
-### Installation
+---
 
-```bash
-git clone https://github.com/ladybug-me/caelestia-dots-kde ~/caelestia-dots-kde
-cd ~/caelestia-dots-kde
-bash ./setup.sh
-```
+<div align="center">
+    <h2>✦ What is this? ✦</h2>
+</div>
 
-The installer is idempotent and prints all commands before execution. Follow the interactive prompts—you can safely retry or skip errors as needed.
+> [!NOTE]  
+> This is a **community KDE port** of the beautiful [Caelestia Hyprland dotfiles](https://github.com/caelestia-dots/caelestia), meticulously adapted by **[ladybug-me](https://github.com/ladybug-me)** to bring the heavens to **KDE Plasma**.
 
-### Uninstallation
+<details> 
+  <summary><b>✨ What this is / isn't</b></summary>
+  <br/>
 
-```bash
-bash ./uninstall.sh
-```
+  - **Technically:** A curated collection of KDE Plasma configuration files, custom widgets, and idempotent installation scripts.
+  - **Visually:** The ethereal caelestia aesthetic seamlessly ported to KDE Plasma utilizing cutting-edge Quickshell widgets.
+  - **NOT:** A direct replacement for the original Hyprland dotfiles (which remain superior for dedicated minimal window managers).
+  - **NOT:** A fully unattended system setup script (installs packages and configs, but no low-level system drivers or core tuning).
+  
+</details>
 
-Restoration backups are stored in `caelestia-dots-kde/backups/`. For manual restoration:
+<details> 
+  <summary><b>🌌 Why KDE instead of Hyprland?</b></summary>
+  <br/>
 
-```bash
-mv ~/.configBACKUP ~/.config
-mv ~/.localBACKUP ~/.local
-```
+  - KDE Plasma offers broader compatibility with existing tools, hardware, and ecosystems.
+  - Provides a familiar, highly robust desktop environment.
+  - Integrates strongly with the Arch Linux community and the AUR.
+  - Proves that heavy DEs can still achieve an ultra-customized, highly aesthetic ricing spirit.
+  
+</details>
 
-### Updates
+<details> 
+  <summary><b>🚀 Key Features</b></summary>
+  <br/>
 
-Clone the latest version and run `setup.sh` again. Shell settings are preserved during updates.
+  - **Material Design 3 Theming:** Cohesive dark theme driven by Darkly + Kvantum + dynamic color extraction.
+  - **Quickshell Widgets:** Native, robust KDE integration with a modern Qt-based widget system.
+    
+  - **Kde Plasma 6.7:** Built to work with the latest release.
+  - **Custom KDE Bridge:** Quickshell-KDE integration via a custom KWin script for fluid widget interaction.
+  - **Custom Hyprctl:** Rewritten to integrate Hyprland-like calls seamlessly via Quickshell.
+  - **Transparent Installation:** Every command is printed before execution. Safe and idempotent.
+  - **QoL Features:** Dino Game with Kuru Kuru Runner 🦖 , Google lens 📸 , Screenshot tool 📷 , Screen recording with sound 📹 , Color picker 🎨 , Emoji picker 😂 , Clipboard history , Shortcuts Cheatsheet 📝.
+  - **Window Tiling:** Optional *Polonium* support for dynamic tiling window management on Plasma.
+  
+</details>
 
-## Features
+<details> 
+  <summary><b>📥 Installation</b></summary>
+  <br/>
 
-- **Material Design 3 Theming** — Dark theme with Darkly + Kvantum + dynamic color extraction
-- **Quickshell Widgets** — Native Qt-based custom widget system for KDE
-- **Custom KWin Bridge** — Seamless Quickshell-KDE integration
-- **Quality-of-Life Tools** — Screenshot, screen recording, color picker, emoji selector, clipboard history, dino game, Google Lens
-- **Optional Tiling** — Polonium support for dynamic window management
-- **Transparent Installation** — Every command logged; safe and repeatable
+  1. **Clone this repository:**
+     ```bash
+     git clone https://github.com/ladybug-me/caelestia-dots-kde ~/caelestia-dots-kde
+     cd ~/caelestia-dots-kde
+     ```
+  2. **Run the installer:**
+     ```bash
+     bash ./setup.sh
+     ```
+  3. **Follow the interactive prompts:** You can safely retry or ignore errors as needed.
+     
+  > **Note:** The installer might occasionally prompt for your password multiple times due to sudo timeouts. This is a known quirk and will be optimized in future releases.
+  
+  **Requirements:**
+  - Arch Linux or an Arch-based distro (EndeavourOS, CachyOS, Manjaro, etc.), or Fedora Linux.
+  - KDE Plasma 6.0+
 
-## Gallery
+  **Tested on:**
+  - CachyOS
+  - Manjaro KDE
+  - Fedora 44 KDE Edition
+  
+</details>
 
-| Desktop | Theming |
+<details> 
+  <summary><b>💫 Updates</b></summary>
+  <br/>
+
+  - Updating is simple, just clone the latest version and run the installer.
+  - Shell settings are **not** changed during updates. 
+
+
+</details>
+
+
+<div align="center">
+    <h2>✦ Visuals ✦</h2>
+</div>
+
+| Caelestia on KDE Plasma Shell | Theming in Action |
 |:---:|:---:|
-| <img width="460" height="259" alt="shell" src="https://github.com/user-attachments/assets/14681aaf-77d9-4a65-af7d-8a4fc0b795cc" /> | <img width="460" height="259" alt="theme" src="https://github.com/user-attachments/assets/d1b73dcb-82c9-465d-ba7e-da79ce263917" /> |
+| <img width="460" height="259" alt="shell" src="https://github.com/user-attachments/assets/14681aaf-77d9-4a65-af7d-8a4fc0b795cc" /> | <img width="460" height="259" alt="Rengoku" src="https://github.com/user-attachments/assets/d1b73dcb-82c9-465d-ba7e-da79ce263917" /> |
 
-## Technology Stack
+---
 
-| Component | Purpose |
-| --- | --- |
-| [KDE Plasma](https://kde.org/plasma/) | Desktop Environment |
-| [Quickshell](https://quickshell.outfoxxed.me/) | Widget System |
-| [Darkly](https://github.com/vinceliuice/Darkly) | Theme Framework |
-| [Kvantum](https://github.com/tsujan/Kvantum) | Qt Theme Engine |
-| [KWin](https://invent.kde.org/plasma/kwin) | Window Manager |
-| [Polonium](https://github.com/zeroxoneafour/polonium) | Window Tiling (optional) |
+<div align="center">
+    <h2>✦ Software Stack ✦</h2>
+</div>
 
-## Keybinds
+
+| Component | Purpose | Notes |
+| --- | --- | --- |
+| **[KDE Plasma](https://kde.org/plasma/)** | Desktop Environment | Full-featured modern DE |
+| **[Quickshell](https://quickshell.outfoxxed.me/)** | Widget System | Qt-based, replaces AGS for this port |
+| **[Darkly](https://github.com/vinceliuice/Darkly)** | Theme Framework | Used for Plasma style + window decoration |
+| **[Kvantum](https://github.com/tsujan/Kvantum)** | Qt Theme Engine | For consistent, deep application styling |
+| **[KWin](https://invent.kde.org/plasma/kwin)** | Window Manager | KDE's robust compositing window manager |
+| **[Polonium](https://github.com/zeroxoneafour/polonium)** | Window Tiling | Optional KDE tiling plugin |
+
+
+<details> 
+  <summary><b>📦 Expand to view the comprehensive package lists</b></summary>
+  <br/>
+
+  The setup scripts install a curated suite of packages organized by category.
+
+  - **Audio:** `cava`, `pavucontrol-qt`, `wireplumber`, `pipewire-pulse`, `playerctl`
+  - **Backlight & Power:** `geoclue`, `brightnessctl`, `ddcutil`, `upower`
+  - **Core Utilities:** `bc`, `coreutils`, `cliphist`, `ripgrep`, `jq`, `rsync`, `go-yq`
+  - **Fonts & Themes:** `breeze-plus`, `darkly-bin`, `eza`, `starship`, `matugen-bin`, `ttf-jetbrains-mono-nerd`, `ttf-material-symbols-variable-git`, `otf-space-grotesk`
+  - **KDE & Desktop:** `kvantum`, `systemsettings`, `kde-material-you-colors`, `xdg-desktop-portal-kde`
+  - **Screen Capture & OCR:** `hyprshot`, `slurp`, `swappy`, `tesseract`, `wf-recorder`
+  - **Optional Features:** `polonium`
+  - **Custom Build:** `caelestia-quickshell-git`
+
+  See [`sdata/`](https://github.com/ladybug-me/caelestia-dots-kde/tree/main/sdata/) for the complete custom PKGBUILDs structure.
+</details>
+
+---
+
+<div align="center">
+    <h2>✦ Keybinds ✦</h2>
+</div>
 
 | Shortcut | Action |
 | --- | --- |
-| `Super + /` | Show keybind cheatsheet |
-| `Super + Enter` | Open terminal |
-| `Super + Space` | Application launcher |
-| `Super + B` | Toggle sidebar |
-| `Super + V` | Clipboard history |
-| `Super + Shift + S` | Screenshot |
-| `Super + Shift + A` | Google Lens |
-| `Super + Shift + C` | Color picker |
+| `Super + /` | Show keybind list (cheatsheet) |
+| `Super + Enter` | Open terminal (Foot) |
+| `Super + 1–5` | Switch to workspace 1–5 |
+| `Super + Space` | Application launcher (Fuzzel) |
+| `Super + B` | Toggle notification panel (Sidebar) |
+| `Super + V` | Open Clipboard History |
+| `Super + Shift + A` | Open Google lens |
+| `Super + Shift + S` | Open Screenshot tool |
+| `Super + Ctrl + S` | Open Screen Recorder |
+| `Super + Shift + C` | Open Color Picker |
+| `Super + Shift + V` | Open Emoji Selector |
 
-## Customization
+---
 
-Press `Super + Space` to launch the app menu, then type `>` to access Caelestia Tweaks.
+<div align="center">
+    <h2>✦ Customization ✦</h2>
+</div>
 
-**Wallpaper** — Use the built-in wallpaper manager (do not use KDE's default manager to ensure color extraction)
+- **Wallpaper:** Press `Super + Space` to open the App launcher. Then type `>` to open Caelestia Tweaks and select Wallpaper.
+- **Theme Colors:** Type `>` in app launcher and select `Scheme`. **NOTE:** When switching between dark and light theme, you need to go to `Kde Settings -> Colors & Themes -> Colors` and select Material You Dark or Light based on your preference.
+- **Keyboard Shortcuts:** Modify [`src/keyboardshortcuts/shortcuts.md`](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/src/keyboardshortcuts/shortcuts.md) and execute [`src/keyboardshortcuts/register.sh`](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/src/keyboardshortcuts/register.sh) to apply them.
+  - *Note:* You may need to update `~/.local/bin/hyprctl` for `Super + /` keybindings display.
+- **The Greeter:** The gifs that play on popout of `Good Morning, User` can be customized by going to [`shell/assets/`](https://github.com/ladybug-me/caelestia-dots-kde/tree/main/shell/assets/) and replacing the [morning.gif](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/shell/assets/morning.gif), [evening.gif](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/shell/assets/evening.gif), [afternoon.gif](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/shell/assets/afternoon.gif) and [night.gif](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/shell/assets/night.gif) files.
+Then rebuild the shell by running setup.sh again.
+---
 
-**Theme Colors** — Select schemes with dynamic color support for automatic color updates based on wallpaper
+<div align="center">
+    <h2>✦ Troubleshooting ✦</h2>
+</div>
 
-**Keyboard Shortcuts** — Edit [`src/keyboardshortcuts/shortcuts.md`](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/src/keyboardshortcuts/shortcuts.md) and run [`src/keyboardshortcuts/register.sh`](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/src/keyboardshortcuts/register.sh)
+<details>
+  <summary><b>🛠️ Caelestia widgets not appearing</b></summary>
+  <br/>
+  
+  - Log out and log back in.
+  - Run: `caelestia shell -d` in the terminal and check for any diagnostic errors.
+  
+</details>
 
-**Greeter GIFs** — Replace GIF files in [`shell/assets/`](https://github.com/ladybug-me/caelestia-dots-kde/tree/main/shell/assets/) and rebuild with `setup.sh`
+<details>
+  <summary><b>🎨 Colors not applying correctly</b></summary>
+  <br/>
+    
+  - Run `systemctl status --user kde-material-you-colors.service` to check for errors.
+  - Rerunning the installer is often the easiest fix if a dependency was missed.
+  - Only the Color Schemes labeled with dynamic support color change with wallpaper. (In app launcher, type `>` to open Caelestia Tweaks > Scheme)
+  - **IMPORTANT:** Do not use the default KDE wallpaper manager. Use the Caelestia built-in wallpaper manager to ensure colors are extracted and applied.
+  
+</details>
 
-## Troubleshooting
+<details>
+  <summary><b>⚠️ Installation failed at step X</b></summary>
+  <br/>
 
-**Widgets not appearing**
-- Log out and back in
-- Run `caelestia shell -d` to check for diagnostic errors
+  - Sudo timeout: If a system update takes a long time, sudo might time out. 
+  - Rerun the installer: `bash ./setup.sh` and look for **red errors**. The installer is idempotent and safe to run multiple times.
+  - It will prompt you to retry, ignore, or exit on errors.
 
-**Colors not updating**
-- Check status: `systemctl status --user kde-material-you-colors.service`
-- Verify only dynamic-supported color schemes are selected
-- Use the Caelestia wallpaper manager, not KDE's default manager
+</details>
 
-**Installation failed**
-- Rerun `bash ./setup.sh` -- the installer is idempotent and safe to retry
-- Follow installer prompts for error handling
+<details>
+  <summary><b>⏪ Reverting changes & backup restoration</b></summary>
+  <br/>
 
-**Restoration from backups**
-- Backups are stored in `caelestia-dots-kde/backups/`
-- To restore: `cp -r caelestia-dots-kde/backups/config ~/.config`
+  The installer creates automatic backups before modifying critical KDE configuration files. These are stored in `caelestia-dots-kde/backups/`.
 
-**Shell shortcuts not working**
-- Restart the keyd service: `systemctl restart keyd`
-- After kernel updates, reboot if you see "no uinput device" errors
+  **To safely restore your previous configuration:**
 
-## Credits
+  1. **Rename current configs:**
+     ```bash
+     mv ~/.config ~/.configBACKUP
+     mv ~/.local ~/.localBACKUP
+     ```
+  2. **Restore backed-up folders:**
+     ```bash
+     cp -r caelestia-dots-kde/backups/config ~/.config
+     cp -r caelestia-dots-kde/backups/local ~/.local
+     ```
+  3. **Restore specific settings:**
+     ```bash
+     cp caelestia-dots-kde/backups/kglobalshortcutsrc ~/.config/
+     cp caelestia-dots-kde/backups/kwinrc ~/.config/
+     ```
 
-- **[Caelestia](https://github.com/caelestia)** — Original design and dotfiles
-- **[ladybug-me](https://github.com/ladybug-me)** — KDE Plasma port
-- **[KDE Plasma](https://kde.org/plasma/)** — Desktop environment
-- **[Quickshell](https://quickshell.outfoxxed.me/)** — Widget framework
-- **[Darkly](https://github.com/vinceliuice/Darkly)** — Theme base
+</details>
 
-## Links
+<details>
+  <summary><b>⌨️ Shell shortcuts not working</b></summary>
+  <br/>
+  
+  The most probable cause is a `keyd` service failure.
+  Run: `systemctl restart keyd`.
+  
+  *Special case:* If a kernel update happened, you might see "no uinput device" when running `sudo keyd`. Rebooting will fix this.
 
-- **GitHub:** [ladybug-me/caelestia-dots-kde](https://github.com/ladybug-me/caelestia-dots-kde)
-- **Issues:** [GitHub Issues](https://github.com/ladybug-me/caelestia-dots-kde/issues)
-- **Original:** [caelestia-dots/caelestia](https://github.com/caelestia-dots/caelestia)
+</details>
 
-## License
+<details>
+  <summary><b>😟 Note for Fedora users: </b></summary>
+  <br/>
+  
+  - I have done everything, everypatch, every script possible to make it work on fedora but maybe for someone it might require manual intervention. Follow the installer's carefully placed logs to find any issue and fix it manually.
 
-GNU General Public License v3.0. See [LICENSE](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/LICENSE) for details.
+  - Know that it **works on Fedora** 😄.
+
+</details>
+
+---
+
+<div align="center">
+    <h2>✦ Credits ✦</h2>
+</div>
+
+- **[Caelestia](https://github.com/caelestia)** for the incredible, otherworldly design language and the original dotfiles.
+- **[ladybug-me](https://github.com/ladybug-me)** for meticulously adapting the dotfiles to KDE Plasma.
+- **[Quickshell](https://quickshell.outfoxxed.me/)** — The robust Qt widget framework.
+- **[Darkly](https://github.com/vinceliuice/Darkly)** — For the gorgeous KDE theme base.
+- **[KDE Plasma](https://kde.org/plasma/)** — The powerhouse desktop environment.
+
+---
+
+<div align="center">
+    <h2>✦ Support & License ✦</h2>
+</div>
+
+- **Issues & Bugs:** [GitHub Issues](https://github.com/ladybug-me/caelestia-dots-kde/issues)
+- **Original Project:** [caelestia-dots/caelestia](https://github.com/caelestia-dots/caelestia)
+- **KDE Community:** [r/kde](https://www.reddit.com/r/kde/)
+
+This project is licensed under the **GNU General Public License v3.0** — the same license as the original Caelestia project. 
+Feel free to use, modify, and distribute this work, provided any derivative work is also licensed under GPLv3. See the [LICENSE](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/LICENSE) for full details.
+
+<div align="center">
+    <br/>
+    <p><i>May your desktop always reflect the stars.</i></p>
+</div>

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,7 +1,6 @@
-<div align="center">
+# Caelestia for KDE Plasma
 
-# ✧ C A E L E S T I A <img src="assets/caelestia.svg" width="35" align="top"> ✧
-### A KDE adaptation of the celestial aesthetic
+Premium KDE Plasma desktop environment with celestial aesthetic, custom Quickshell widgets, Material Design 3 theming, and extensive system integration.
 
 ![Arch Linux](https://img.shields.io/badge/Arch_Linux-1793d1?logo=arch-linux&logoColor=white&style=for-the-badge)
 ![Fedora](https://img.shields.io/badge/Fedora-51A2DA?logo=fedora&logoColor=white&style=for-the-badge)
@@ -9,286 +8,130 @@
 ![Quickshell](https://img.shields.io/badge/Quickshell-FF6B6B?style=for-the-badge)
 ![License: GPLv3](https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge&color=86dbce)
 
-<br/>
-<img width="400" height="230" alt="logo" src="https://github.com/user-attachments/assets/5662c83d-7181-4846-9fb8-79d0363c8c4f" />
+![logo](https://github.com/user-attachments/assets/5662c83d-7181-4846-9fb8-79d0363c8c4f)
 
-<br/>
-<br/>
+## Quick Start
 
-> *“Ad astra per aspera.”*
+### Requirements
 
-</div>
+- Arch Linux / Fedora Linux / Arch-based derivative (EndeavourOS, CachyOS, Manjaro, etc.)
+- KDE Plasma 6.0+
 
----
+### Installation
 
-<div align="center">
-    <h2>✦ What is this? ✦</h2>
-</div>
+```bash
+git clone https://github.com/ladybug-me/caelestia-dots-kde ~/caelestia-dots-kde
+cd ~/caelestia-dots-kde
+bash ./setup.sh
+```
 
-> [!NOTE]  
-> This is a **community KDE port** of the beautiful [Caelestia Hyprland dotfiles](https://github.com/caelestia-dots/caelestia), meticulously adapted by **[ladybug-me](https://github.com/ladybug-me)** to bring the heavens to **KDE Plasma**.
+The installer is idempotent and prints all commands before execution. Follow the interactive prompts—you can safely retry or skip errors as needed.
 
-<details> 
-  <summary><b>✨ What this is / isn't</b></summary>
-  <br/>
+### Uninstallation
 
-  - **Technically:** A curated collection of KDE Plasma configuration files, custom widgets, and idempotent installation scripts.
-  - **Visually:** The ethereal caelestia aesthetic seamlessly ported to KDE Plasma utilizing cutting-edge Quickshell widgets.
-  - **NOT:** A direct replacement for the original Hyprland dotfiles (which remain superior for dedicated minimal window managers).
-  - **NOT:** A fully unattended system setup script (installs packages and configs, but no low-level system drivers or core tuning).
-  
-</details>
+```bash
+bash ./uninstall.sh
+```
 
-<details> 
-  <summary><b>🌌 Why KDE instead of Hyprland?</b></summary>
-  <br/>
+Restoration backups are stored in `caelestia-dots-kde/backups/`. For manual restoration:
 
-  - KDE Plasma offers broader compatibility with existing tools, hardware, and ecosystems.
-  - Provides a familiar, highly robust desktop environment.
-  - Integrates strongly with the Arch Linux community and the AUR.
-  - Proves that heavy DEs can still achieve an ultra-customized, highly aesthetic ricing spirit.
-  
-</details>
+```bash
+mv ~/.configBACKUP ~/.config
+mv ~/.localBACKUP ~/.local
+```
 
-<details> 
-  <summary><b>🚀 Key Features</b></summary>
-  <br/>
+### Updates
 
-  - **Material Design 3 Theming:** Cohesive dark theme driven by Darkly + Kvantum + dynamic color extraction.
-  - **Quickshell Widgets:** Native, robust KDE integration with a modern Qt-based widget system.
-    
-  - **Kde Plasma 6.7:** Built to work with the latest release.
-  - **Custom KDE Bridge:** Quickshell-KDE integration via a custom KWin script for fluid widget interaction.
-  - **Custom Hyprctl:** Rewritten to integrate Hyprland-like calls seamlessly via Quickshell.
-  - **Transparent Installation:** Every command is printed before execution. Safe and idempotent.
-  - **QoL Features:** Dino Game with Kuru Kuru Runner 🦖 , Google lens 📸 , Screenshot tool 📷 , Screen recording with sound 📹 , Color picker 🎨 , Emoji picker 😂 , Clipboard history , Shortcuts Cheatsheet 📝.
-  - **Window Tiling:** Optional *Polonium* support for dynamic tiling window management on Plasma.
-  
-</details>
+Clone the latest version and run `setup.sh` again. Shell settings are preserved during updates.
 
-<details> 
-  <summary><b>📥 Installation</b></summary>
-  <br/>
+## Features
 
-  1. **Clone this repository:**
-     ```bash
-     git clone https://github.com/ladybug-me/caelestia-dots-kde ~/caelestia-dots-kde
-     cd ~/caelestia-dots-kde
-     ```
-  2. **Run the installer:**
-     ```bash
-     bash ./setup.sh
-     ```
-  3. **Follow the interactive prompts:** You can safely retry or ignore errors as needed.
-     
-  > **Note:** The installer might occasionally prompt for your password multiple times due to sudo timeouts. This is a known quirk and will be optimized in future releases.
-  
-  **Requirements:**
-  - Arch Linux or an Arch-based distro (EndeavourOS, CachyOS, Manjaro, etc.), or Fedora Linux.
-  - KDE Plasma 6.0+
+- **Material Design 3 Theming** — Dark theme with Darkly + Kvantum + dynamic color extraction
+- **Quickshell Widgets** — Native Qt-based custom widget system for KDE
+- **Custom KWin Bridge** — Seamless Quickshell-KDE integration
+- **Quality-of-Life Tools** — Screenshot, screen recording, color picker, emoji selector, clipboard history, dino game, Google Lens
+- **Optional Tiling** — Polonium support for dynamic window management
+- **Transparent Installation** — Every command logged; safe and repeatable
 
-  **Tested on:**
-  - CachyOS
-  - Manjaro KDE
-  - Fedora 44 KDE Edition
-  
-</details>
+## Gallery
 
-<details> 
-  <summary><b>💫 Updates</b></summary>
-  <br/>
-
-  - Updating is simple, just clone the latest version and run the installer.
-  - Shell settings are **not** changed during updates. 
-
-
-</details>
-
-
-<div align="center">
-    <h2>✦ Visuals ✦</h2>
-</div>
-
-| Caelestia on KDE Plasma Shell | Theming in Action |
+| Desktop | Theming |
 |:---:|:---:|
-| <img width="460" height="259" alt="shell" src="https://github.com/user-attachments/assets/14681aaf-77d9-4a65-af7d-8a4fc0b795cc" /> | <img width="460" height="259" alt="Rengoku" src="https://github.com/user-attachments/assets/d1b73dcb-82c9-465d-ba7e-da79ce263917" /> |
+| <img width="460" height="259" alt="shell" src="https://github.com/user-attachments/assets/14681aaf-77d9-4a65-af7d-8a4fc0b795cc" /> | <img width="460" height="259" alt="theme" src="https://github.com/user-attachments/assets/d1b73dcb-82c9-465d-ba7e-da79ce263917" /> |
 
----
+## Technology Stack
 
-<div align="center">
-    <h2>✦ Software Stack ✦</h2>
-</div>
+| Component | Purpose |
+| --- | --- |
+| [KDE Plasma](https://kde.org/plasma/) | Desktop Environment |
+| [Quickshell](https://quickshell.outfoxxed.me/) | Widget System |
+| [Darkly](https://github.com/vinceliuice/Darkly) | Theme Framework |
+| [Kvantum](https://github.com/tsujan/Kvantum) | Qt Theme Engine |
+| [KWin](https://invent.kde.org/plasma/kwin) | Window Manager |
+| [Polonium](https://github.com/zeroxoneafour/polonium) | Window Tiling (optional) |
 
-
-| Component | Purpose | Notes |
-| --- | --- | --- |
-| **[KDE Plasma](https://kde.org/plasma/)** | Desktop Environment | Full-featured modern DE |
-| **[Quickshell](https://quickshell.outfoxxed.me/)** | Widget System | Qt-based, replaces AGS for this port |
-| **[Darkly](https://github.com/vinceliuice/Darkly)** | Theme Framework | Used for Plasma style + window decoration |
-| **[Kvantum](https://github.com/tsujan/Kvantum)** | Qt Theme Engine | For consistent, deep application styling |
-| **[KWin](https://invent.kde.org/plasma/kwin)** | Window Manager | KDE's robust compositing window manager |
-| **[Polonium](https://github.com/zeroxoneafour/polonium)** | Window Tiling | Optional KDE tiling plugin |
-
-
-<details> 
-  <summary><b>📦 Expand to view the comprehensive package lists</b></summary>
-  <br/>
-
-  The setup scripts install a curated suite of packages organized by category.
-
-  - **Audio:** `cava`, `pavucontrol-qt`, `wireplumber`, `pipewire-pulse`, `playerctl`
-  - **Backlight & Power:** `geoclue`, `brightnessctl`, `ddcutil`, `upower`
-  - **Core Utilities:** `bc`, `coreutils`, `cliphist`, `ripgrep`, `jq`, `rsync`, `go-yq`
-  - **Fonts & Themes:** `breeze-plus`, `darkly-bin`, `eza`, `starship`, `matugen-bin`, `ttf-jetbrains-mono-nerd`, `ttf-material-symbols-variable-git`, `otf-space-grotesk`
-  - **KDE & Desktop:** `kvantum`, `systemsettings`, `kde-material-you-colors`, `xdg-desktop-portal-kde`
-  - **Screen Capture & OCR:** `hyprshot`, `slurp`, `swappy`, `tesseract`, `wf-recorder`
-  - **Optional Features:** `polonium`
-  - **Custom Build:** `caelestia-quickshell-git`
-
-  See [`sdata/`](https://github.com/ladybug-me/caelestia-dots-kde/tree/main/sdata/) for the complete custom PKGBUILDs structure.
-</details>
-
----
-
-<div align="center">
-    <h2>✦ Keybinds ✦</h2>
-</div>
+## Keybinds
 
 | Shortcut | Action |
 | --- | --- |
-| `Super + /` | Show keybind list (cheatsheet) |
-| `Super + Enter` | Open terminal (Foot) |
-| `Super + 1–5` | Switch to workspace 1–5 |
-| `Super + Space` | Application launcher (Fuzzel) |
-| `Super + B` | Toggle notification panel (Sidebar) |
-| `Super + V` | Open Clipboard History |
-| `Super + Shift + A` | Open Google lens |
-| `Super + Shift + S` | Open Screenshot tool |
-| `Super + Ctrl + S` | Open Screen Recorder |
-| `Super + Shift + C` | Open Color Picker |
-| `Super + Shift + V` | Open Emoji Selector |
+| `Super + /` | Show keybind cheatsheet |
+| `Super + Enter` | Open terminal |
+| `Super + Space` | Application launcher |
+| `Super + B` | Toggle sidebar |
+| `Super + V` | Clipboard history |
+| `Super + Shift + S` | Screenshot |
+| `Super + Shift + A` | Google Lens |
+| `Super + Shift + C` | Color picker |
 
----
+## Customization
 
-<div align="center">
-    <h2>✦ Customization ✦</h2>
-</div>
+Press `Super + Space` to launch the app menu, then type `>` to access Caelestia Tweaks.
 
-- **Wallpaper:** Press `Super + Space` to open the App launcher. Then type `>` to open Caelestia Tweaks and select Wallpaper.
-- **Theme Colors:** Type `>` in app launcher and select `Scheme`. **NOTE:** When switching between dark and light theme, you need to go to `Kde Settings -> Colors & Themes -> Colors` and select Material You Dark or Light based on your preference.
-- **Keyboard Shortcuts:** Modify [`src/keyboardshortcuts/shortcuts.md`](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/src/keyboardshortcuts/shortcuts.md) and execute [`src/keyboardshortcuts/register.sh`](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/src/keyboardshortcuts/register.sh) to apply them.
-  - *Note:* You may need to update `~/.local/bin/hyprctl` for `Super + /` keybindings display.
-- **The Greeter:** The gifs that play on popout of `Good Morning, User` can be customized by going to [`shell/assets/`](https://github.com/ladybug-me/caelestia-dots-kde/tree/main/shell/assets/) and replacing the [morning.gif](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/shell/assets/morning.gif), [evening.gif](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/shell/assets/evening.gif), [afternoon.gif](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/shell/assets/afternoon.gif) and [night.gif](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/shell/assets/night.gif) files.
-Then rebuild the shell by running setup.sh again.
----
+**Wallpaper** — Use the built-in wallpaper manager (do not use KDE's default manager to ensure color extraction)
 
-<div align="center">
-    <h2>✦ Troubleshooting ✦</h2>
-</div>
+**Theme Colors** — Select schemes with dynamic color support for automatic color updates based on wallpaper
 
-<details>
-  <summary><b>🛠️ Caelestia widgets not appearing</b></summary>
-  <br/>
-  
-  - Log out and log back in.
-  - Run: `caelestia shell -d` in the terminal and check for any diagnostic errors.
-  
-</details>
+**Keyboard Shortcuts** — Edit [`src/keyboardshortcuts/shortcuts.md`](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/src/keyboardshortcuts/shortcuts.md) and run [`src/keyboardshortcuts/register.sh`](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/src/keyboardshortcuts/register.sh)
 
-<details>
-  <summary><b>🎨 Colors not applying correctly</b></summary>
-  <br/>
-    
-  - Run `systemctl status --user kde-material-you-colors.service` to check for errors.
-  - Rerunning the installer is often the easiest fix if a dependency was missed.
-  - Only the Color Schemes labeled with dynamic support color change with wallpaper. (In app launcher, type `>` to open Caelestia Tweaks > Scheme)
-  - **IMPORTANT:** Do not use the default KDE wallpaper manager. Use the Caelestia built-in wallpaper manager to ensure colors are extracted and applied.
-  
-</details>
+**Greeter GIFs** — Replace GIF files in [`shell/assets/`](https://github.com/ladybug-me/caelestia-dots-kde/tree/main/shell/assets/) and rebuild with `setup.sh`
 
-<details>
-  <summary><b>⚠️ Installation failed at step X</b></summary>
-  <br/>
+## Troubleshooting
 
-  - Sudo timeout: If a system update takes a long time, sudo might time out. 
-  - Rerun the installer: `bash ./setup.sh` and look for **red errors**. The installer is idempotent and safe to run multiple times.
-  - It will prompt you to retry, ignore, or exit on errors.
+**Widgets not appearing**
+- Log out and back in
+- Run `caelestia shell -d` to check for diagnostic errors
 
-</details>
+**Colors not updating**
+- Check status: `systemctl status --user kde-material-you-colors.service`
+- Verify only dynamic-supported color schemes are selected
+- Use the Caelestia wallpaper manager, not KDE's default manager
 
-<details>
-  <summary><b>⏪ Reverting changes & backup restoration</b></summary>
-  <br/>
+**Installation failed**
+- Rerun `bash ./setup.sh` -- the installer is idempotent and safe to retry
+- Follow installer prompts for error handling
 
-  The installer creates automatic backups before modifying critical KDE configuration files. These are stored in `caelestia-dots-kde/backups/`.
+**Restoration from backups**
+- Backups are stored in `caelestia-dots-kde/backups/`
+- To restore: `cp -r caelestia-dots-kde/backups/config ~/.config`
 
-  **To safely restore your previous configuration:**
+**Shell shortcuts not working**
+- Restart the keyd service: `systemctl restart keyd`
+- After kernel updates, reboot if you see "no uinput device" errors
 
-  1. **Rename current configs:**
-     ```bash
-     mv ~/.config ~/.configBACKUP
-     mv ~/.local ~/.localBACKUP
-     ```
-  2. **Restore backed-up folders:**
-     ```bash
-     cp -r caelestia-dots-kde/backups/config ~/.config
-     cp -r caelestia-dots-kde/backups/local ~/.local
-     ```
-  3. **Restore specific settings:**
-     ```bash
-     cp caelestia-dots-kde/backups/kglobalshortcutsrc ~/.config/
-     cp caelestia-dots-kde/backups/kwinrc ~/.config/
-     ```
+## Credits
 
-</details>
+- **[Caelestia](https://github.com/caelestia)** — Original design and dotfiles
+- **[ladybug-me](https://github.com/ladybug-me)** — KDE Plasma port
+- **[KDE Plasma](https://kde.org/plasma/)** — Desktop environment
+- **[Quickshell](https://quickshell.outfoxxed.me/)** — Widget framework
+- **[Darkly](https://github.com/vinceliuice/Darkly)** — Theme base
 
-<details>
-  <summary><b>⌨️ Shell shortcuts not working</b></summary>
-  <br/>
-  
-  The most probable cause is a `keyd` service failure.
-  Run: `systemctl restart keyd`.
-  
-  *Special case:* If a kernel update happened, you might see "no uinput device" when running `sudo keyd`. Rebooting will fix this.
+## Links
 
-</details>
+- **GitHub:** [ladybug-me/caelestia-dots-kde](https://github.com/ladybug-me/caelestia-dots-kde)
+- **Issues:** [GitHub Issues](https://github.com/ladybug-me/caelestia-dots-kde/issues)
+- **Original:** [caelestia-dots/caelestia](https://github.com/caelestia-dots/caelestia)
 
-<details>
-  <summary><b>😟 Note for Fedora users: </b></summary>
-  <br/>
-  
-  - I have done everything, everypatch, every script possible to make it work on fedora but maybe for someone it might require manual intervention. Follow the installer's carefully placed logs to find any issue and fix it manually.
+## License
 
-  - Know that it **works on Fedora** 😄.
-
-</details>
-
----
-
-<div align="center">
-    <h2>✦ Credits ✦</h2>
-</div>
-
-- **[Caelestia](https://github.com/caelestia)** for the incredible, otherworldly design language and the original dotfiles.
-- **[ladybug-me](https://github.com/ladybug-me)** for meticulously adapting the dotfiles to KDE Plasma.
-- **[Quickshell](https://quickshell.outfoxxed.me/)** — The robust Qt widget framework.
-- **[Darkly](https://github.com/vinceliuice/Darkly)** — For the gorgeous KDE theme base.
-- **[KDE Plasma](https://kde.org/plasma/)** — The powerhouse desktop environment.
-
----
-
-<div align="center">
-    <h2>✦ Support & License ✦</h2>
-</div>
-
-- **Issues & Bugs:** [GitHub Issues](https://github.com/ladybug-me/caelestia-dots-kde/issues)
-- **Original Project:** [caelestia-dots/caelestia](https://github.com/caelestia-dots/caelestia)
-- **KDE Community:** [r/kde](https://www.reddit.com/r/kde/)
-
-This project is licensed under the **GNU General Public License v3.0** — the same license as the original Caelestia project. 
-Feel free to use, modify, and distribute this work, provided any derivative work is also licensed under GPLv3. See the [LICENSE](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/LICENSE) for full details.
-
-<div align="center">
-    <br/>
-    <p><i>May your desktop always reflect the stars.</i></p>
-</div>
+GNU General Public License v3.0. See [LICENSE](https://github.com/ladybug-me/caelestia-dots-kde/blob/main/LICENSE) for details.

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,598 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════╗
+# ║        Caelestia KDE Port — Uninstaller                      ║
+# ║                                                              ║
+# ║  Reverses every action performed by setup.sh.                ║
+# ║  Restores backups where they exist; removes files that       ║
+# ║  have no prior version to restore.                           ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+set -uo pipefail
+
+BUNDLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Colors ────────────────────────────────────────────────────────────────────
+RED="\033[0;31m"; GREEN="\033[0;32m"; YELLOW="\033[1;33m"
+CYAN="\033[0;36m"; BOLD="\033[1m"; RST="\033[0m"
+
+die()  { echo -e "${RED}[FATAL] $*${RST}" >&2; exit 1; }
+info() { echo -e "${CYAN}[INFO]  $*${RST}"; }
+ok()   { echo -e "${GREEN}[OK]    $*${RST}"; }
+warn() { echo -e "${YELLOW}[WARN]  $*${RST}"; }
+skip() { echo -e "        [SKIP]  $*"; }
+
+# ── OS detection ───────────────────────────────────────────────────────────────
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case "$ID" in
+        arch|cachyos|endeavouros|manjaro|artix) BASE_DISTRO="arch" ;;
+        fedora|nobara|bazzite|rhel|centos|almalinux|rocky) BASE_DISTRO="fedora" ;;
+        *)
+            if echo "${ID_LIKE:-}" | grep -iq "arch"; then BASE_DISTRO="arch"
+            elif echo "${ID_LIKE:-}" | grep -iq "fedora"; then BASE_DISTRO="fedora"
+            else BASE_DISTRO="unknown"; fi
+            ;;
+    esac
+else
+    BASE_DISTRO="unknown"
+fi
+
+if [[ "$BASE_DISTRO" == "unknown" ]]; then
+    echo -e "${YELLOW}Could not detect distribution. Select base:${RST}"
+    echo "  1) Arch-based   2) Fedora-based   3) Exit"
+    read -r -p "Choice [1-3]: " _dc
+    case "$_dc" in
+        1) BASE_DISTRO="arch" ;;
+        2) BASE_DISTRO="fedora" ;;
+        *) die "Exiting." ;;
+    esac
+fi
+
+# ── Banner ─────────────────────────────────────────────────────────────────────
+echo
+echo -e "${BOLD}${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "${BOLD}${CYAN}   Caelestia KDE Port — Uninstaller${RST}"
+echo -e "${BOLD}${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo
+echo -e "${YELLOW}This will remove the Caelestia KDE shell, all installed${RST}"
+echo -e "${YELLOW}config files, services, and shell customisations.${RST}"
+echo -e "${YELLOW}Backups created by the installer (in $BUNDLE_DIR/backups/)${RST}"
+echo -e "${YELLOW}will be offered for restoration where available.${RST}"
+echo
+
+# ── Sudo setup ─────────────────────────────────────────────────────────────────
+while true; do
+    IFS= read -s -p "Enter your sudo password: " SUDO_PASS; echo
+    sudo -k
+    if printf '%s\n' "$SUDO_PASS" | sudo -S -v &>/dev/null; then break
+    else echo -e "${RED}Incorrect password, try again.${RST}"; fi
+done
+export SUDO_PASS
+
+# Keepalive loop
+(while true; do printf '%s\n' "$SUDO_PASS" | sudo -S -v; sleep 55; done) 2>/dev/null &
+_SUDO_LOOP=$!
+trap 'kill $_SUDO_LOOP 2>/dev/null; true' EXIT
+
+# ── Confirmation ───────────────────────────────────────────────────────────────
+echo
+echo -e "${RED}Are you sure you want to uninstall Caelestia KDE? [y/N]:${RST} "
+read -r _confirm
+[[ "${_confirm,,}" == "y" || "${_confirm,,}" == "yes" ]] || die "Uninstall cancelled."
+
+echo
+echo -e "${YELLOW}Remove installed packages as well? This will uninstall${RST}"
+echo -e "${YELLOW}tools like fish, foot, btop, fastfetch, and others.${RST}"
+echo -e "Remove packages? [y/N]: "
+read -r _remove_pkgs
+REMOVE_PACKAGES=false
+[[ "${_remove_pkgs,,}" == "y" || "${_remove_pkgs,,}" == "yes" ]] && REMOVE_PACKAGES=true
+
+# ── Helper: find most-recent backup dir ───────────────────────────────────────
+latest_backup() {
+    # Prints the most recent timestamped backup dir, or empty string
+    local newest
+    newest="$(ls -dt "$BUNDLE_DIR"/backups/[0-9]*_[0-9]* 2>/dev/null | head -1)"
+    echo "$newest"
+}
+
+# ── Helper: restore a config dir/file from backup ─────────────────────────────
+restore_or_remove() {
+    local name="$1"           # e.g. "fish"
+    local target="$2"         # full destination path
+    local backup_subdir="$3"  # "config" or "local"
+    local backup_dir
+    backup_dir="$(latest_backup)"
+
+    rm -rf "$target"
+
+    if [[ -n "$backup_dir" ]] && [[ -e "$backup_dir/$backup_subdir/$name" ]]; then
+        cp -r "$backup_dir/$backup_subdir/$name" "$target"
+        ok "Restored $name from backup"
+    else
+        skip "No backup for $name — removed without restore"
+    fi
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# STEP 1 — Stop and disable all services
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "${CYAN}  Step 1 — Stop & disable services${RST}"
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+
+for svc in qs-kwin-bridge cliphist ydotoold kde-material-you-colors; do
+    if systemctl --user is-enabled --quiet "${svc}.service" 2>/dev/null ||
+       systemctl --user is-active  --quiet "${svc}.service" 2>/dev/null; then
+        systemctl --user disable --now "${svc}.service" 2>/dev/null || true
+        ok "Disabled user service: $svc"
+    else
+        skip "User service not active: $svc"
+    fi
+done
+
+# Stop and disable keyd (system service)
+if systemctl is-enabled --quiet keyd 2>/dev/null ||
+   systemctl is-active  --quiet keyd 2>/dev/null; then
+    printf '%s\n' "$SUDO_PASS" | sudo -S systemctl disable --now keyd 2>/dev/null || true
+    ok "Disabled system service: keyd"
+else
+    skip "keyd not active"
+fi
+
+# Kill any running Caelestia / Quickshell processes
+pkill -f "caelestia shell" 2>/dev/null || true
+pkill -f "quickshell"      2>/dev/null || true
+ok "Stopped any running shell processes"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# STEP 2 — Remove service files
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "${CYAN}  Step 2 — Remove service & autostart files${RST}"
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+
+USER_SYSTEMD="$HOME/.config/systemd/user"
+
+for svc_file in \
+    "$USER_SYSTEMD/qs-kwin-bridge.service" \
+    "$USER_SYSTEMD/cliphist.service" \
+    "$USER_SYSTEMD/ydotoold.service" \
+    "$USER_SYSTEMD/kde-material-you-colors.service"
+do
+    if [[ -f "$svc_file" ]]; then
+        rm -f "$svc_file"
+        ok "Removed: $svc_file"
+    fi
+done
+
+# Autostart desktop entry
+if [[ -f "$HOME/.config/autostart/caelestiashell.desktop" ]]; then
+    rm -f "$HOME/.config/autostart/caelestiashell.desktop"
+    ok "Removed autostart entry: caelestiashell.desktop"
+fi
+
+systemctl --user daemon-reload 2>/dev/null || true
+
+# ══════════════════════════════════════════════════════════════════════════════
+# STEP 3 — Remove installed shell files
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "${CYAN}  Step 3 — Remove shell installation${RST}"
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+
+# Quickshell config (QML files)
+if [[ -d "$HOME/.config/quickshell/caelestia" ]]; then
+    rm -rf "$HOME/.config/quickshell/caelestia"
+    ok "Removed ~/.config/quickshell/caelestia"
+fi
+
+# Native plugin library
+if [[ -d "$HOME/.local/lib/caelestia" ]]; then
+    rm -rf "$HOME/.local/lib/caelestia"
+    ok "Removed ~/.local/lib/caelestia"
+fi
+
+# QML module tree (remove only caelestia-specific entries to be safe)
+for qml_mod in Caelestia M3Shapes; do
+    if [[ -d "$HOME/.local/lib/qt6/qml/$qml_mod" ]]; then
+        rm -rf "$HOME/.local/lib/qt6/qml/$qml_mod"
+        ok "Removed QML module: $qml_mod"
+    fi
+done
+
+# Legacy share path
+if [[ -d "$HOME/.local/share/caelestia-shell" ]]; then
+    rm -rf "$HOME/.local/share/caelestia-shell"
+    ok "Removed ~/.local/share/caelestia-shell"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# STEP 4 — Remove bridge scripts from ~/.local/bin
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "${CYAN}  Step 4 — Remove bridge scripts${RST}"
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+
+for f in \
+    "$HOME/.local/bin/hyprctl" \
+    "$HOME/.local/bin/kcolorpicker" \
+    "$HOME/.local/bin/qs-kwin-bridge.py" \
+    "$HOME/.local/bin/caelestia-shortcuts" \
+    "$HOME/.local/bin/caelestia-record" \
+    "$HOME/.local/bin/ydotoold-wrapper"
+do
+    if [[ -f "$f" ]]; then
+        rm -f "$f"
+        ok "Removed: $f"
+    fi
+done
+
+# KWin bridge script
+if [[ -d "$HOME/.local/share/kwin/scripts/quickshell-kde-bridge" ]]; then
+    rm -rf "$HOME/.local/share/kwin/scripts/quickshell-kde-bridge"
+    ok "Removed KWin script: quickshell-kde-bridge"
+fi
+
+# Desktop entries deployed from src/keyboardshortcuts/applications/
+if [[ -d "$BUNDLE_DIR/src/keyboardshortcuts/applications" ]]; then
+    for df in "$BUNDLE_DIR/src/keyboardshortcuts/applications/"*.desktop; do
+        [[ -f "$df" ]] || continue
+        target="$HOME/.local/share/applications/$(basename "$df")"
+        if [[ -f "$target" ]]; then
+            rm -f "$target"
+            ok "Removed desktop entry: $(basename "$target")"
+        fi
+    done
+    update-desktop-database "$HOME/.local/share/applications/" 2>/dev/null || true
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# STEP 5 — Restore / remove config directories
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "${CYAN}  Step 5 — Restore / remove config directories${RST}"
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+
+for cfg in btop fastfetch fish foot hypr kitty micro nvim rofi thunar uwsm zed zen vscode; do
+    if [[ -e "$HOME/.config/$cfg" ]]; then
+        restore_or_remove "$cfg" "$HOME/.config/$cfg" "config"
+    fi
+done
+
+# starship.toml
+if [[ -f "$HOME/.config/starship.toml" ]]; then
+    restore_or_remove "starship.toml" "$HOME/.config/starship.toml" "config"
+fi
+
+# kmixrc (written fresh by installer — just remove it)
+if [[ -f "$HOME/.config/kmixrc" ]]; then
+    rm -f "$HOME/.config/kmixrc"
+    ok "Removed ~/.config/kmixrc"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# STEP 6 — Revert KDE settings
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "${CYAN}  Step 6 — Revert KDE settings${RST}"
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+
+# Re-enable KDE OSDs
+kwriteconfig6 --file plasmarc         --group "OSD"              --key "Enabled"            "true"  2>/dev/null || true
+kwriteconfig6 --file plasmarc         --group "OSD"              --key "ShowOnActiveScreen"  "true"  2>/dev/null || true
+kwriteconfig6 --file kdeglobals       --group "KDE"              --key "OSDEnabled"          "true"  2>/dev/null || true
+kwriteconfig6 --file plasmanotifyrc   --group "Notifications"    --key "LoudnessChangedOSD" "true"  2>/dev/null || true
+kwriteconfig6 --file powerdevilrc     --group "BrightnessControl"--key "showOSD"            "true"  2>/dev/null || true
+kwriteconfig6 --file powerdevilrc     --group "AC"               --key "brightnessosd"       "true"  2>/dev/null || true
+ok "Re-enabled KDE OSD notifications"
+
+# Reset Plasma theme to Breeze
+kwriteconfig6 --file plasmarc --group "Theme" --key "name" "default"  2>/dev/null || true
+kwriteconfig6 --file kdeglobals --group "KDE"     --key "widgetStyle"  "Breeze" 2>/dev/null || true
+kwriteconfig6 --file kdeglobals --group "General" --key "ColorScheme"  "BreezeLight" 2>/dev/null || true
+ok "Reset Plasma theme to Breeze"
+
+# Reset window decoration to Breeze
+kwriteconfig6 --file kwinrc --group "org.kde.kdecoration2" --key "library" "org.kde.breeze" 2>/dev/null || true
+kwriteconfig6 --file kwinrc --group "org.kde.kdecoration2" --key "theme"   "@breeze"        2>/dev/null || true
+ok "Reset window decoration to Breeze"
+
+# Reset cursor theme to breeze_cursors
+kwriteconfig6 --file kcminputrc --group Mouse --key cursorTheme "breeze_cursors" 2>/dev/null || true
+ok "Reset cursor theme to breeze_cursors"
+
+# Disable Caelestia KWin plugins
+kwriteconfig6 --file kwinrc --group "Plugins" --key "quickshell-kde-bridgeEnabled" "false" 2>/dev/null || true
+kwriteconfig6 --file kwinrc --group "Plugins" --key "poloniumEnabled"              "false" 2>/dev/null || true
+ok "Disabled KWin plugins: quickshell-kde-bridge, polonium"
+
+# Restore desktop count to 1 (KDE default)
+kwriteconfig6 --file kwinrc --group "Desktops" --key "Number" "1" 2>/dev/null || true
+kwriteconfig6 --file kwinrc --group "Desktops" --key "Rows"   "1" 2>/dev/null || true
+for i in $(seq 1 5); do
+    kwriteconfig6 --file kwinrc --group "Desktops" --key "Name_$i" "Desktop $i" 2>/dev/null || true
+done
+ok "Restored desktop count to 1"
+
+# Remove workspace shortcuts added by the installer
+for i in $(seq 1 5); do
+    kwriteconfig6 --file kglobalshortcutsrc --group "kwin" \
+        --key "Switch to Desktop $i"  "none,none,Switch to Desktop $i"          2>/dev/null || true
+    kwriteconfig6 --file kglobalshortcutsrc --group "kwin" \
+        --key "Window to Desktop $i"  "none,none,Move Window to Desktop $i"     2>/dev/null || true
+done
+ok "Cleared installer workspace shortcuts from kglobalshortcutsrc"
+
+# Restore backed-up kglobalshortcutsrc if available
+_bk_dir="$(latest_backup)"
+if [[ -n "$_bk_dir" ]] && [[ -f "$_bk_dir/config/kglobalshortcutsrc" ]]; then
+    cp "$_bk_dir/config/kglobalshortcutsrc" "$HOME/.config/kglobalshortcutsrc"
+    ok "Restored kglobalshortcutsrc from backup"
+elif ls "$BUNDLE_DIR/backups/kglobalshortcutsrc_"* >/dev/null 2>&1; then
+    _bk_file="$(ls -t "$BUNDLE_DIR/backups/kglobalshortcutsrc_"* 2>/dev/null | head -1)"
+    if [[ -f "$_bk_file" ]]; then
+        cp "$_bk_file" "$HOME/.config/kglobalshortcutsrc"
+        ok "Restored kglobalshortcutsrc from $( basename "$_bk_file")"
+    fi
+fi
+
+# Restore Konsole config if backed up
+if [[ -n "$_bk_dir" ]]; then
+    if [[ -f "$_bk_dir/config/konsolerc" ]]; then
+        cp "$_bk_dir/config/konsolerc" "$HOME/.config/konsolerc"
+        ok "Restored konsolerc from backup"
+    fi
+    if [[ -d "$_bk_dir/local/konsole" ]]; then
+        rm -rf "$HOME/.local/share/konsole"
+        cp -r  "$_bk_dir/local/konsole" "$HOME/.local/share/konsole"
+        ok "Restored ~/.local/share/konsole from backup"
+    fi
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# STEP 7 — Revert shell changes
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "${CYAN}  Step 7 — Revert shell changes${RST}"
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+
+# Revert default login shell back to bash (unless user explicitly chose fish beforehand)
+if command -v bash >/dev/null 2>&1; then
+    _BASH_PATH="$(command -v bash)"
+    printf '%s\n' "$SUDO_PASS" | sudo -S chsh -s "$_BASH_PATH" "$USER" 2>/dev/null || \
+        warn "Could not change login shell back to bash. Run: chsh -s $_BASH_PATH"
+    ok "Login shell reverted to bash"
+fi
+
+# Remove env var lines appended to ~/.bashrc by the installer
+if [[ -f "$HOME/.bashrc" ]]; then
+    sed -i '/export QML2_IMPORT_PATH=.*caelestia\|export CAELESTIA_LIB_DIR=/d' "$HOME/.bashrc" 2>/dev/null || true
+    ok "Removed Caelestia env vars from ~/.bashrc"
+fi
+
+# Remove env var lines appended to fish config
+if [[ -f "$HOME/.config/fish/config.fish" ]]; then
+    sed -i '/QML2_IMPORT_PATH\|CAELESTIA_LIB_DIR/d' "$HOME/.config/fish/config.fish" 2>/dev/null || true
+    ok "Removed Caelestia env vars from fish config"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# STEP 8 — Remove system-level files (keyd, udev, sudoers, symlinks)
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "${CYAN}  Step 8 — Remove system-level files${RST}"
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+
+# keyd config
+if [[ -f /etc/keyd/quickshell.conf ]]; then
+    printf '%s\n' "$SUDO_PASS" | sudo -S rm -f /etc/keyd/quickshell.conf
+    ok "Removed /etc/keyd/quickshell.conf"
+    # Remove the directory only if it's now empty
+    printf '%s\n' "$SUDO_PASS" | sudo -S rmdir /etc/keyd 2>/dev/null || true
+fi
+
+# udev rule for uinput
+if [[ -f /etc/udev/rules.d/80-uinput.rules ]]; then
+    printf '%s\n' "$SUDO_PASS" | sudo -S rm -f /etc/udev/rules.d/80-uinput.rules
+    printf '%s\n' "$SUDO_PASS" | sudo -S udevadm control --reload-rules 2>/dev/null || true
+    ok "Removed udev rule: 80-uinput.rules"
+fi
+
+# sudoers file for ydotoold
+if [[ -f /etc/sudoers.d/ydotoold-nopasswd ]]; then
+    printf '%s\n' "$SUDO_PASS" | sudo -S rm -f /etc/sudoers.d/ydotoold-nopasswd
+    ok "Removed sudoers rule: ydotoold-nopasswd"
+fi
+
+# Compatibility symlinks
+for link in /usr/local/bin/sass /usr/local/bin/qdbus6 /usr/local/bin/caelestia; do
+    if [[ -L "$link" ]]; then
+        printf '%s\n' "$SUDO_PASS" | sudo -S rm -f "$link"
+        ok "Removed symlink: $link"
+    fi
+done
+
+# Remove the user from the 'input' group if it was added by the installer
+if groups "$USER" | grep -q '\binput\b'; then
+    printf '%s\n' "$SUDO_PASS" | sudo -S gpasswd -d "$USER" input 2>/dev/null || \
+        warn "Could not remove $USER from input group. Run: sudo gpasswd -d $USER input"
+    ok "Removed $USER from 'input' group (takes effect on next login)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# STEP 9 — Remove packages (optional)
+# ══════════════════════════════════════════════════════════════════════════════
+if [[ "$REMOVE_PACKAGES" == "true" ]]; then
+    echo
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+    echo -e "${CYAN}  Step 9 — Remove packages${RST}"
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+
+    ARCH_PACKAGES=(
+        caelestia-cli quickshell-git
+        cmake ninja
+        wl-clipboard cliphist inotify-tools app2unit wireplumber trash-cli
+        jq aubio lm_sensors libcava libqalculate
+        foot fish eza fastfetch starship btop
+        adw-gtk-theme papirus-icon-theme
+        ttf-jetbrains-mono-nerd ttf-material-symbols-variable
+        ttf-rubik-vf ttf-cascadia-code-nerd darkly
+        swappy brightnessctl ddcutil imagemagick
+        tesseract tesseract-data-eng satty spectacle sassc
+        kvantum kvantum-qt5 kde-material-you-colors
+        keyd
+    )
+
+    FEDORA_PACKAGES=(
+        quickshell-git caelestia-cli
+        cmake ninja-build
+        wl-clipboard cliphist inotify-tools app2unit wireplumber trash-cli
+        jq aubio lm_sensors lm_sensors-devel libcava libcava-devel libqalculate libqalculate-devel
+        foot fish eza fastfetch starship btop
+        adw-gtk3-theme google-rubik-fonts papirus-icon-theme
+        swappy brightnessctl ddcutil imagemagick
+        tesseract tesseract-langpack-eng spectacle
+        fuzzel satty slurp grim sassc
+        ffmpeg gpu-screen-recorder
+        qt6-qtdeclarative qt6-qtdeclarative-devel
+        qt6-qtsvg qt6-qtsvg-devel qt6-qtshadertools-devel
+        pipewire-devel aubio-devel
+        dbus-devel dbus-glib-devel python3-devel
+        kvantum kde-material-you-colors
+        keyd
+    )
+
+    if [[ "$BASE_DISTRO" == "arch" ]]; then
+        warn "The following packages will be removed:"
+        printf '  %s\n' "${ARCH_PACKAGES[@]}"
+        echo
+        read -r -p "Proceed? [y/N]: " _pkg_confirm
+        if [[ "${_pkg_confirm,,}" == "y" || "${_pkg_confirm,,}" == "yes" ]]; then
+            # Remove packages that are actually installed; ignore errors for missing ones
+            mapfile -t _installed < <(yay -Qq "${ARCH_PACKAGES[@]}" 2>/dev/null)
+            if [[ ${#_installed[@]} -gt 0 ]]; then
+                yay -Rns --noconfirm "${_installed[@]}" 2>/dev/null || \
+                    warn "Some packages could not be removed automatically. Check manually."
+            fi
+            ok "Arch packages removed"
+        else
+            skip "Package removal skipped"
+        fi
+    elif [[ "$BASE_DISTRO" == "fedora" ]]; then
+        warn "The following packages will be removed:"
+        printf '  %s\n' "${FEDORA_PACKAGES[@]}"
+        echo
+        read -r -p "Proceed? [y/N]: " _pkg_confirm
+        if [[ "${_pkg_confirm,,}" == "y" || "${_pkg_confirm,,}" == "yes" ]]; then
+            printf '%s\n' "$SUDO_PASS" | sudo -S dnf remove -y "${FEDORA_PACKAGES[@]}" 2>/dev/null || \
+                warn "Some packages could not be removed. Check manually."
+            ok "Fedora packages removed"
+        else
+            skip "Package removal skipped"
+        fi
+    fi
+
+    # Remove caelestia-cli pip package (both global and user)
+    if command -v caelestia >/dev/null 2>&1 || python3 -m caelestia --help &>/dev/null 2>&1; then
+        printf '%s\n' "$SUDO_PASS" | sudo -S pip3 uninstall -y caelestia 2>/dev/null || true
+        pip3 uninstall -y caelestia 2>/dev/null || true
+        ok "Removed caelestia pip package"
+    fi
+
+    # Remove uv-installed tools
+    if command -v uv >/dev/null 2>&1; then
+        uv tool uninstall kde-material-you-colors 2>/dev/null || true
+        ok "Removed kde-material-you-colors (uv)"
+    fi
+
+    # Remove Polonium KWin script if installed
+    if command -v kpackagetool6 >/dev/null 2>&1; then
+        if kpackagetool6 -t KWin/Script -s polonium >/dev/null 2>&1; then
+            kpackagetool6 -t KWin/Script -r polonium 2>/dev/null || true
+            ok "Removed Polonium KWin script"
+        fi
+    fi
+else
+    skip "Package removal skipped (user chose to keep packages)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# STEP 10 — Clean up cache and build artefacts
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "${CYAN}  Step 10 — Clean up cache & build artefacts${RST}"
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+
+# CMake build dirs inside the repo
+for build_dir in "$BUNDLE_DIR/shell/build" "$BUNDLE_DIR/shell/plugin/build"; do
+    if [[ -d "$build_dir" ]]; then
+        rm -rf "$build_dir"
+        ok "Removed build dir: $build_dir"
+    fi
+done
+
+# Installer cache
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/caelestia-kde"
+if [[ -d "$CACHE_DIR" ]]; then
+    echo -e "${YELLOW}Remove installer cache at $CACHE_DIR? [y/N]:${RST} "
+    read -r _cache_confirm
+    if [[ "${_cache_confirm,,}" == "y" || "${_cache_confirm,,}" == "yes" ]]; then
+        rm -rf "$CACHE_DIR"
+        ok "Removed installer cache"
+    else
+        skip "Kept installer cache at $CACHE_DIR"
+    fi
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# STEP 11 — Reload KDE
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "${CYAN}  Step 11 — Reload KDE${RST}"
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+
+qdbus6 org.kde.KWin /KWin reconfigure                    2>/dev/null || true
+systemctl --user restart plasma-kglobalaccel.service      2>/dev/null || true
+kbuildsycoca6 --noincremental                             2>/dev/null || true
+
+if command -v lookandfeeltool >/dev/null 2>&1; then
+    lookandfeeltool --apply "org.kde.breeze.desktop" 2>/dev/null || true
+fi
+
+ok "KDE reloaded"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Done
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "${GREEN}  Caelestia KDE has been uninstalled.${RST}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo
+echo -e "  Backups of your original configs are in:  ${BOLD}$BUNDLE_DIR/backups/${RST}"
+echo
+echo -e "${YELLOW}  Please log out and back in to fully apply all changes.${RST}"
+echo
+
+# Prompt user for immediate logout (same behavior as setup finalizer)
+read -r -p "Would you like to log out now? (y/N): " response
+case "$response" in
+    [yY][eE][sS]|[yY])
+        echo "Logging out..."
+        qdbus6 org.kde.Shutdown /Shutdown org.kde.Shutdown.logout 2>/dev/null || true
+        ;;
+    *)
+        echo "Exiting script. Please remember to log out manually later."
+        ;;
+esac


### PR DESCRIPTION
## Description

Briefly describe the changes in this PR.

Added an uninstall script to undo setup.sh

<!--- ONE FEATURE PER PULL REQUEST ONLY -->
<!--- Don't include personal config defaults or unrelated changes -->

## Type of change

- [ ] Bug fix
- [X] New feature (Quickshell widget, KDE setting, etc.)
- [ ] Configuration improvement
- [ ] Documentation update
- [ ] Other (please describe)

## What does this change affect?

- [ ] KDE Plasma settings
- [ ] Quickshell widgets
- [X] Installation/deployment scripts
- [ ] Theme/colors
- [ ] Other (please describe)

## Testing

How have you tested these changes? (e.g., "Ran installer on fresh Arch install", "Tested widget reload on existing install", etc.)
Yes, fully tested and working

## Is this ready for review?

- [X] Yes, ready to merge
- [ ] Still in progress / Questions for maintainers

## Additional context

Add any other context or screenshots here (especially helpful for widget/UI changes).

