### PR TITLE
Fix: 'char' as identifier breaks QML parsing on some Qt6 builds

### DIFF
--- a/shell/components/PolkitDialog.qml
+++ b/shell/components/PolkitDialog.qml
@@ -454,7 +454,7 @@ StyledWindow {
     }
 
     component CharItem: Item {
-        id: char
+        id: ch
 
         required property int index
         property real nonAnimWidthScale: 1
@@ -471,7 +471,7 @@ StyledWindow {
 
             anchors.centerIn: parent
             implicitSize: charList.implicitHeight * 1.5
-            shape: root.shapeQueue[char.index % root.shapeQueue.length] ?? MaterialShape.Circle
+            shape: root.shapeQueue[ch.index % root.shapeQueue.length] ?? MaterialShape.Circle
             color: Colours.palette.m3onSurface
 
             Behavior on color {
@@ -499,14 +499,14 @@ StyledWindow {
                         type: Anim.FastSpatial
                     }
                     Anim {
-                        target: char
+                        target: ch
                         property: "implicitWidth"
                         from: charList.implicitHeight
                         to: charList.implicitHeight * 1.3
                         type: Anim.DefaultEffects
                     }
                     PropertyAction {
-                        target: char
+                        target: ch
                         property: "nonAnimWidthScale"
                         value: 1.5
                     }
@@ -527,13 +527,13 @@ StyledWindow {
                         type: Anim.FastSpatial
                     }
                     Anim {
-                        target: char
+                        target: ch
                         property: "implicitWidth"
                         to: charList.implicitHeight
                         type: Anim.DefaultEffects
                     }
                     PropertyAction {
-                        target: char
+                        target: ch
                         property: "nonAnimWidthScale"
                         value: 1
                     }
@@ -544,7 +544,7 @@ StyledWindow {
                 id: removeAnim
 
                 PropertyAction {
-                    target: char
+                    target: ch
                     property: "ListView.delayRemove"
                     value: true
                 }
@@ -562,7 +562,7 @@ StyledWindow {
                     }
                 }
                 PropertyAction {
-                    target: char
+                    target: ch
                     property: "ListView.delayRemove"
                     value: false
                 }

--- a/shell/modules/launcher/services/Emojis.qml
+++ b/shell/modules/launcher/services/Emojis.qml
@@ -31,7 +31,7 @@ QtObject {
                         continue;
 
                     result.push({
-                        char: line.substring(0, spaceIdx),
+                        ch: line.substring(0, spaceIdx),
                         name: line.substring(spaceIdx + 1).trim()
                     });
                 }
@@ -76,8 +76,8 @@ QtObject {
         freqWriter.running = true;
     }
 
-    function recordUsage(char: string): void {
-        frequencies[char] = (frequencies[char] || 0) + 1;
+    function recordUsage(ch: string): void {
+        frequencies[ch] = (frequencies[ch] || 0) + 1;
         saveFrequencies();
     }
 
@@ -87,12 +87,12 @@ QtObject {
         const favEmojis = GlobalConfig.launcher.favouriteEmojis || [];
         const favSet = new Set(favEmojis);
         return [...items].sort((a, b) => {
-            const aIsFav = favSet.has(a.char);
-            const bIsFav = favSet.has(b.char);
+            const aIsFav = favSet.has(a.ch);
+            const bIsFav = favSet.has(b.ch);
             if (aIsFav !== bIsFav)
                 return aIsFav ? -1 : 1;
-            const freqA = frequencies[a.char] || 0;
-            const freqB = frequencies[b.char] || 0;
+            const freqA = frequencies[a.ch] || 0;
+            const freqB = frequencies[b.ch] || 0;
             if (freqA !== freqB)
                 return freqB - freqA;
             return 0;

--- a/shell/modules/lock/center/InputField.qml
+++ b/shell/modules/lock/center/InputField.qml
@@ -116,7 +116,7 @@ Item {
     }
 
     component CharItem: Item {
-        id: char
+        id: ch
 
         required property int index
         property real nonAnimWidthScale: 1
@@ -133,7 +133,7 @@ Item {
 
             anchors.centerIn: parent
             implicitSize: charList.implicitHeight * 1.5
-            shape: root.shapeQueue[char.index % root.shapeQueue.length] ?? MaterialShape.Circle
+            shape: root.shapeQueue[ch.index % root.shapeQueue.length] ?? MaterialShape.Circle
             color: Colours.palette.m3onSurface
 
             Behavior on color {
@@ -161,14 +161,14 @@ Item {
                         type: Anim.FastSpatial
                     }
                     Anim {
-                        target: char
+                        target: ch
                         property: "implicitWidth"
                         from: charList.implicitHeight
                         to: charList.implicitHeight * 1.3
                         type: Anim.DefaultEffects
                     }
                     PropertyAction {
-                        target: char
+                        target: ch
                         property: "nonAnimWidthScale"
                         value: 1.5
                     }
@@ -189,13 +189,13 @@ Item {
                         type: Anim.FastSpatial
                     }
                     Anim {
-                        target: char
+                        target: ch
                         property: "implicitWidth"
                         to: charList.implicitHeight
                         type: Anim.DefaultEffects
                     }
                     PropertyAction {
-                        target: char
+                        target: ch
                         property: "nonAnimWidthScale"
                         value: 1
                     }
@@ -206,7 +206,7 @@ Item {
                 id: removeAnim
 
                 PropertyAction {
-                    target: char
+                    target: ch
                     property: "ListView.delayRemove"
                     value: true
                 }
@@ -224,7 +224,7 @@ Item {
                     }
                 }
                 PropertyAction {
-                    target: char
+                    target: ch
                     property: "ListView.delayRemove"
                     value: false
                 }


### PR DESCRIPTION
Fixes char as ch, fixes for fedora