### PR TITLE
feat: Add icon size configuration to BarDock

### DIFF
--- a/sdata/arch-dist/installDP.sh
+++ b/sdata/arch-dist/installDP.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# installDP.sh — Arch package installation for Caelestia KDE Port
+# installDP.sh - Arch package installation for Caelestia KDE Port
 
 set -uo pipefail
 
@@ -10,7 +10,7 @@ log "Installing Arch packages..."
 
 # Ensure yay
 if ! command -v yay >/dev/null 2>&1; then
-    log "yay not found — installing..."
+    log "yay not found - installing..."
     sudo pacman -S --needed --noconfirm base-devel git || true
     tmpdir="$(mktemp -d)"
     git clone https://aur.archlinux.org/yay-bin.git "$tmpdir"

--- a/sdata/fedora-dist/installDP_fedora.sh
+++ b/sdata/fedora-dist/installDP_fedora.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# installDP_fedora.sh — Fedora package installation for Caelestia KDE Port
+# installDP_fedora.sh - Fedora package installation for Caelestia KDE Port
 
 set -uo pipefail
 

--- a/setup.sh
+++ b/setup.sh
@@ -276,20 +276,20 @@ collect_installer_preferences() {
     done
 }
 
-# ══════════════════════════════════════════════════════════════
+# =============================================================
 #  BANNER
 # ==============================================================
 bash "$SCRIPTS_DIR/00-banner.sh"
 
-# ══════════════════════════════════════════════════════════════
+# =============================================================
 #  ASK USER PREFERENCES (all prompts up front)
-# ══════════════════════════════════════════════════════════════
+# =============================================================
 collect_installer_preferences
 
 # Keep display/idle timers inhibited while installer runs so long steps are not interrupted.
 enable_install_awake_guard
 
-# ══════════════════════════════════════════════════════════════
+# =============================================================
 #  ONE-TIME SUDO PASSWORD (kept alive for the full install)
 # ==============================================================
 echo -e "${YELLOW}This installer needs sudo for package installation.${RST}"
@@ -308,15 +308,15 @@ export SUDO_PASS
 # Temporarily grant NOPASSWD to the user to prevent yay/makepkg from prompting
 printf '%s\n' "$SUDO_PASS" | sudo -S sh -c "echo '$USER ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/caelestia-installer-temp && chmod 0440 /etc/sudoers.d/caelestia-installer-temp"
 
-# ══════════════════════════════════════════════════════════════
-#  STEP 0 — System update (after configuration + auth)
-# ══════════════════════════════════════════════════════════════
+# =============================================================
+#  STEP 0 - System update (after configuration + auth)
+# =============================================================
 echo
 echo -e "${CYAN}---------------------------------------------${RST}"
 if [[ "$BASE_DISTRO" == "arch" ]]; then
-    echo -e "${CYAN}  Step 0/11 — System Update (pacman -Syu)${RST}"
+    echo -e "${CYAN}  Step 0/11 - System Update (pacman -Syu)${RST}"
 else
-    echo -e "${CYAN}  Step 0/11 — System Update (dnf upgrade)${RST}"
+    echo -e "${CYAN}  Step 0/11 - System Update (dnf upgrade)${RST}"
 fi
 echo -e "${CYAN}---------------------------------------------${RST}"
 echo
@@ -336,11 +336,11 @@ else
     fi
 fi
 
-# ══════════════════════════════════════════════════════════════
-#  STEP 1 — Ensure prerequisites
-# ══════════════════════════════════════════════════════════════
+# =============================================================
+#  STEP 1 - Ensure prerequisites
+# =============================================================
 echo
-echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "${CYAN}---------------------------------------------${RST}"
 if [[ "$BASE_DISTRO" == "arch" ]]; then
     echo -e "${CYAN}  Step 1/11 - Prerequisites (yay)${RST}"
 else

--- a/shell/modules/bar/components/Dock.qml
+++ b/shell/modules/bar/components/Dock.qml
@@ -63,10 +63,7 @@ Item {
         root.modelDataArray = newArr;
     }
 
-    readonly property int padding: Tokens.padding.medium
-    readonly property int spacing: Tokens.spacing.small
-    readonly property real configuredItemSize: Math.max(16, Config.bar.dock.iconSize || 32)
-
+    readonly property real configuredItemSize: Math.max(16, Math.min(Tokens.sizes.bar.innerWidth, Config.bar.dock.iconSize || 32))
     StyledRect {
         id: container
 

--- a/shell/modules/bar/components/Dock.qml
+++ b/shell/modules/bar/components/Dock.qml
@@ -65,6 +65,7 @@ Item {
 
     readonly property int padding: Tokens.padding.medium
     readonly property int spacing: Tokens.spacing.small
+    readonly property real configuredItemSize: Math.max(16, Config.bar.dock.iconSize || 32)
 
     StyledRect {
         id: container
@@ -137,7 +138,7 @@ Item {
             return result;
         }
 
-        property real itemSize: Tokens.sizes.bar.innerWidth * 0.8
+        property real itemSize: root.configuredItemSize
         property int maxHorizontalItems: Math.max(0, Math.floor((availableSize - padding * 2 - itemSize * 0.5) / (itemSize + spacing)))
         property real maxHorizontalSize: maxHorizontalItems >= 1 ? ((maxHorizontalItems + 0.5) * itemSize + maxHorizontalItems * spacing + padding * 2) : availableSize
 
@@ -160,8 +161,8 @@ Item {
                 id: listView
 
                 anchors.centerIn: parent
-                width: bar.isHorizontal ? (container.width - padding * 2) : Tokens.sizes.bar.innerWidth * 0.8
-                height: bar.isHorizontal ? Tokens.sizes.bar.innerWidth * 0.8 : (container.height - padding * 2)
+                width: bar.isHorizontal ? (container.width - padding * 2) : container.itemSize
+                height: bar.isHorizontal ? container.itemSize : (container.height - padding * 2)
                 orientation: bar.isHorizontal ? ListView.Horizontal : ListView.Vertical
                 spacing: root.spacing
                 interactive: bar.isHorizontal ? contentWidth > width + 1 : contentHeight > height + 1
@@ -222,8 +223,8 @@ Item {
             Item {
                 id: delegateContainer
 
-                width: Tokens.sizes.bar.innerWidth * 0.8
-                height: Tokens.sizes.bar.innerWidth * 0.8
+                width: container.itemSize
+                height: container.itemSize
                 implicitWidth: width
                 implicitHeight: height
 
@@ -476,7 +477,7 @@ Item {
         // Don't close dock context menu
         if (bar.popouts.hasCurrent && bar.popouts.currentName === "dockcontext") return;
 
-        const itemSize = Tokens.sizes.bar.innerWidth * 0.8;
+        const itemSize = container.itemSize;
         const itemWidthWithSpacing = itemSize + spacing;
         const adjustedPos = isHorizontal ? relPos - container.x - padding : relPos - container.y - padding;
         

--- a/shell/modules/nexus/pages/panels/taskbar/BarDock.qml
+++ b/shell/modules/nexus/pages/panels/taskbar/BarDock.qml
@@ -68,7 +68,7 @@ PageBase {
             subtext: qsTr("Size of app icons in the dock")
             value: Config.bar.dock.iconSize
             from: 20
-            to: 64
+            to: Math.max(20, Tokens.sizes.bar.innerWidth)
             stepSize: 2
             onMoved: v => GlobalConfig.bar.dock.iconSize = v
         }

--- a/shell/modules/nexus/pages/panels/taskbar/BarDock.qml
+++ b/shell/modules/nexus/pages/panels/taskbar/BarDock.qml
@@ -62,6 +62,17 @@ PageBase {
             onToggled: GlobalConfig.bar.dock.monitorCenter = checked
         }
 
+        StepperRow {
+            Layout.fillWidth: true
+            label: qsTr("Icon size")
+            subtext: qsTr("Size of app icons in the dock")
+            value: Config.bar.dock.iconSize
+            from: 20
+            to: 64
+            stepSize: 2
+            onMoved: v => GlobalConfig.bar.dock.iconSize = v
+        }
+
         ToggleRow {
             Layout.fillWidth: true
             last: true

--- a/shell/plugin/src/Caelestia/Config/barconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/barconfig.hpp
@@ -136,6 +136,7 @@ class BarDock : public ConfigObject {
 
     CONFIG_PROPERTY(bool, monitorCenter, true)
     CONFIG_PROPERTY(bool, recolourIcons, false)
+    CONFIG_PROPERTY(int, iconSize, 32)
 
 public:
     explicit BarDock(QObject* parent = nullptr)


### PR DESCRIPTION
closes: https://github.com/ladybug-me/caelestia-dots-kde/issues/22

## Type of change

- [ ] Bug fix
- [X] New feature (Quickshell widget, KDE setting, etc.)
- [ ] Configuration improvement
- [ ] Documentation update
- [ ] Other (please describe)

## What does this change affect?

- [ ] KDE Plasma settings
- [ ] Quickshell widgets
- [ ] Installation/deployment scripts
- [ ] Theme/colors
- [X] Other (please describe)

Icon size increasing

## Testing

How have you tested these changes? (e.g., "Ran installer on fresh Arch install", "Tested widget reload on existing install", etc.)
Tested on fresh install

## Is this ready for review?

- [X] Yes, ready to merge
- [ ] Still in progress / Questions for maintainers

## Additional context

Add any other context or screenshots here (especially helpful for widget/UI changes).

