### PR TITLE
Sync/dev upstream 2026 07 21

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -147,14 +147,20 @@ if [[ "${CAELESTIA_TMUX_MASTER:-0}" == "0" ]]; then
         echo "Missing build tools: ${MISSING_PKGS[*]}. Installing..."
         if [[ "$BASE_DISTRO" == "arch" ]]; then
             if [[ "${CAELESTIA_USE_TMUX:-1}" == "1" ]]; then
+                # Refresh pacman package databases first to avoid stale-mirror 404s
+                sudo pacman -Syy >/dev/null 2>&1 || true
                 sudo pacman -S --needed --noconfirm base-devel cmake tmux
             else
+                sudo pacman -Syy >/dev/null 2>&1 || true
                 sudo pacman -S --needed --noconfirm base-devel cmake
             fi
         elif [[ "$BASE_DISTRO" == "fedora" ]]; then
             if [[ "${CAELESTIA_USE_TMUX:-1}" == "1" ]]; then
+                # Refresh dnf metadata before installing
+                sudo dnf makecache --refresh -y >/dev/null 2>&1 || true
                 sudo dnf install -y gcc-c++ cmake make tmux
             else
+                sudo dnf makecache --refresh -y >/dev/null 2>&1 || true
                 sudo dnf install -y gcc-c++ cmake make
             fi
         else

--- a/shell/components/PolkitDialog.qml
+++ b/shell/components/PolkitDialog.qml
@@ -11,6 +11,7 @@ import qs.components
 import qs.components.containers
 import qs.components.controls
 import qs.services
+import qs.utils
 import M3Shapes
 
 StyledWindow {

--- a/shell/components/controls/ButtonBase.qml
+++ b/shell/components/controls/ButtonBase.qml
@@ -13,6 +13,7 @@ StyledRect {
     }
 
     property bool checked
+    property alias text: label.text
     property alias disabled: stateLayer.disabled
     property bool isToggle
     property bool isRound
@@ -25,8 +26,10 @@ StyledRect {
     property int type: ButtonBase.Filled
 
     property real padding
-    property real horizontalPadding: padding
-    property real verticalPadding: padding
+    property real horizontalPadding: padding || Tokens.padding.medium
+    property real verticalPadding: padding || Tokens.padding.small
+
+    readonly property alias label: label
 
     readonly property alias pressed: stateLayer.pressed
     readonly property alias hovered: stateLayer.containsMouse
@@ -49,6 +52,9 @@ StyledRect {
     property real defaultRadius: Tokens.rounding.large
 
     signal clicked
+
+    implicitWidth: label.implicitWidth + horizontalPadding * 2
+    implicitHeight: label.implicitHeight + verticalPadding * 2
 
     onCheckedChanged: internalChecked = checked
 
@@ -77,6 +83,14 @@ StyledRect {
                 root.internalChecked = !root.internalChecked;
             root.clicked();
         }
+    }
+
+    StyledText {
+        id: label
+
+        anchors.centerIn: parent
+        color: root.onColour
+        font: root.font
     }
 
     Behavior on radius {

--- a/shell/components/controls/IconButton.qml
+++ b/shell/components/controls/IconButton.qml
@@ -6,8 +6,9 @@ import qs.services
 ButtonBase {
     id: root
 
-    property alias icon: label.text
-    readonly property alias label: label
+    property alias icon: iconLabel.text
+
+    label.visible: false
 
     font: Tokens.font.icon.medium
     padding: type === IconButton.Text ? Tokens.padding.extraSmall / 2 : Tokens.padding.small
@@ -28,14 +29,14 @@ ButtonBase {
     implicitWidth: implicitHeight
     implicitHeight: {
         // Ensure even size so icon is centered properly
-        const h = label.implicitHeight + padding * 2;
+        const h = iconLabel.implicitHeight + padding * 2;
         if (h % 2 !== 0)
             return h + 1;
         return h;
     }
 
     MaterialIcon {
-        id: label
+        id: iconLabel
 
         anchors.centerIn: parent
         anchors.verticalCenterOffset: 1 // AHHHHHHH material symbols whyyyy

--- a/shell/components/controls/IconTextButton.qml
+++ b/shell/components/controls/IconTextButton.qml
@@ -9,6 +9,7 @@ ButtonBase {
 
     property alias icon: iconLabel.text
     property alias text: label.text
+    property alias spacing: row.spacing
 
     readonly property alias iconLabel: iconLabel
     readonly property alias label: label

--- a/shell/components/controls/IconTextButton.qml
+++ b/shell/components/controls/IconTextButton.qml
@@ -8,11 +8,11 @@ ButtonBase {
     id: root
 
     property alias icon: iconLabel.text
-    property alias text: label.text
     property alias spacing: row.spacing
 
     readonly property alias iconLabel: iconLabel
-    readonly property alias label: label
+
+    label.visible: false
 
     horizontalPadding: Tokens.padding.medium
     verticalPadding: Tokens.padding.small
@@ -65,10 +65,11 @@ ButtonBase {
         }
 
         StyledText {
-            id: label
+            id: textLabel
 
             Layout.alignment: Qt.AlignVCenter
             Layout.topMargin: 1
+            text: root.text
             color: root.onColour
             font: root.font
         }

--- a/shell/components/controls/IconTextButton.qml
+++ b/shell/components/controls/IconTextButton.qml
@@ -11,6 +11,7 @@ ButtonBase {
     property alias spacing: row.spacing
 
     readonly property alias iconLabel: iconLabel
+    readonly property alias contentLabel: textLabel
 
     label.visible: false
 

--- a/shell/components/controls/IconTextButton.qml
+++ b/shell/components/controls/IconTextButton.qml
@@ -8,11 +8,13 @@ ButtonBase {
     id: root
 
     property alias icon: iconLabel.text
-    property alias text: label.text
     property alias spacing: row.spacing
 
     readonly property alias iconLabel: iconLabel
-    readonly property alias label: label
+    readonly property alias contentLabel: label
+
+    label.text: root.text
+    Component.onCompleted: root.label.visible = false
 
     horizontalPadding: Tokens.padding.medium
     verticalPadding: Tokens.padding.small

--- a/shell/components/controls/TextButton.qml
+++ b/shell/components/controls/TextButton.qml
@@ -6,9 +6,6 @@ import qs.services
 ButtonBase {
     id: root
 
-    property alias text: label.text
-    readonly property alias label: label
-
     horizontalPadding: Tokens.padding.medium
     verticalPadding: Tokens.padding.small
 
@@ -31,14 +28,6 @@ ButtonBase {
         return type === TextButton.Filled ? Colours.palette.m3onSurface : Colours.palette.m3onSecondaryContainer;
     }
 
-    implicitWidth: label.implicitWidth + horizontalPadding * 2
-    implicitHeight: label.implicitHeight + verticalPadding * 2
-
-    StyledText {
-        id: label
-
-        anchors.centerIn: parent
-        color: root.onColour
-        font: root.font
-    }
+    implicitWidth: root.label.implicitWidth + horizontalPadding * 2
+    implicitHeight: root.label.implicitHeight + verticalPadding * 2
 }

--- a/shell/modules/ServiceLoader.qml
+++ b/shell/modules/ServiceLoader.qml
@@ -1,0 +1,20 @@
+import QtQuick
+import Quickshell
+import Caelestia.Config
+import qs.services
+
+Scope {
+    Component.onCompleted: {
+        // Force certain singletons to load on shell init instead of lazily
+
+        IdleInhibitor;
+        GameMode;
+        Notifs;
+        Players;
+        Brightness;
+        Weather.reload();
+
+        if (GlobalConfig.utilities.vpn.enabled)
+            VPN;
+    }
+}

--- a/shell/modules/ServiceLoader.qml
+++ b/shell/modules/ServiceLoader.qml
@@ -12,7 +12,7 @@ Scope {
         Notifs;
         Players;
         Brightness;
-        Weather.reload();
+        Weather;
 
         if (GlobalConfig.utilities.vpn.enabled)
             VPN;

--- a/shell/modules/background/DesktopIcons.qml
+++ b/shell/modules/background/DesktopIcons.qml
@@ -245,8 +245,8 @@ Item {
                     if (!iconName) return "";
                     for (let i = 0; i < iconSetDirs.length; i++) {
                         let url = iconSetBase + "/" + iconSetDirs[i] + "/" + iconName + ".svg";
-                        // Qt.resolvedUrl normalises it; we return it for use as Image.source
-                        return url; // try first candidate; Image will report Error and we fallback
+                        // Qt.resolvedUrl normalises it; return the first candidate in priority order.
+                        return url;
                     }
                     return "";
                 }

--- a/shell/modules/bar/components/Tray.qml
+++ b/shell/modules/bar/components/Tray.qml
@@ -6,6 +6,7 @@ import Quickshell.Services.SystemTray
 import Caelestia.Config
 import qs.components
 import qs.services
+import qs.utils
 
 StyledRect {
     id: root

--- a/shell/modules/bar/components/workspaces/OccupiedBg.qml
+++ b/shell/modules/bar/components/workspaces/OccupiedBg.qml
@@ -5,6 +5,7 @@ import Quickshell
 import Caelestia.Config
 import qs.components
 import qs.services
+import qs.utils
 
 Item {
     id: root

--- a/shell/modules/bar/popouts/Content.qml
+++ b/shell/modules/bar/popouts/Content.qml
@@ -6,6 +6,7 @@ import Quickshell
 import Quickshell.Services.SystemTray
 import Caelestia.Config
 import qs.components
+import qs.utils
 
 Item {
     id: root

--- a/shell/modules/bar/popouts/PeripheralBattery.qml
+++ b/shell/modules/bar/popouts/PeripheralBattery.qml
@@ -6,6 +6,7 @@ import Quickshell.Services.UPower
 import Caelestia.Config
 import qs.components
 import qs.services
+import qs.utils
 
 Column {
     id: root

--- a/shell/modules/dashboard/Content.qml
+++ b/shell/modules/dashboard/Content.qml
@@ -8,6 +8,7 @@ import Caelestia
 import Caelestia.Config
 import qs.components
 import qs.components.filedialog
+import qs.utils
 import "../../services"
 
 Item {

--- a/shell/modules/dashboard/Tabs.qml
+++ b/shell/modules/dashboard/Tabs.qml
@@ -8,6 +8,7 @@ import Caelestia.Config
 import qs.components
 import qs.components.controls
 import qs.services
+import qs.utils
 
 Item {
     id: root

--- a/shell/modules/launcher/AnimationsList.qml
+++ b/shell/modules/launcher/AnimationsList.qml
@@ -8,6 +8,7 @@ import qs.components
 import qs.components.containers
 import qs.components.controls
 import qs.services
+import qs.utils
 import "items"
 import "services"
 

--- a/shell/modules/launcher/AppList.qml
+++ b/shell/modules/launcher/AppList.qml
@@ -7,6 +7,7 @@ import qs.components
 import qs.components.containers
 import qs.components.controls
 import qs.services
+import qs.utils
 import qs.modules.launcher.items
 import qs.modules.launcher.services
 

--- a/shell/modules/launcher/KeybindsList.qml
+++ b/shell/modules/launcher/KeybindsList.qml
@@ -7,6 +7,7 @@ import qs.components
 import qs.components.containers
 import qs.components.controls
 import qs.services
+import qs.utils
 import "items"
 import "services"
 

--- a/shell/modules/launcher/WindowSwitcherList.qml
+++ b/shell/modules/launcher/WindowSwitcherList.qml
@@ -5,6 +5,7 @@ import Quickshell
 import Caelestia.Config
 import qs.components.controls
 import qs.services
+import qs.utils
 import "items"
 import "services"
 

--- a/shell/modules/lock/center/InputField.qml
+++ b/shell/modules/lock/center/InputField.qml
@@ -6,6 +6,7 @@ import M3Shapes
 import Caelestia.Config
 import qs.components
 import qs.services
+import qs.utils
 import qs.modules.lock
 
 Item {

--- a/shell/modules/nexus/NexusState.qml
+++ b/shell/modules/nexus/NexusState.qml
@@ -15,6 +15,7 @@ QtObject {
     property string wallpaperFilterType: "all"
     property BluetoothDevice selectedBtDevice
     property DesktopEntry selectedApp
+    property bool networkDetailsFromSaved
 
     signal close
     signal subPageOpened(idx: int)

--- a/shell/modules/nexus/PageCompRegistry.qml
+++ b/shell/modules/nexus/PageCompRegistry.qml
@@ -10,6 +10,7 @@ import qs.modules.nexus.pages
 import qs.modules.nexus.pages.apps
 import qs.modules.nexus.pages.audio
 import qs.modules.nexus.pages.bluetooth
+import qs.modules.nexus.pages.network
 import qs.modules.nexus.pages.panels
 import qs.modules.nexus.pages.services
 import qs.modules.nexus.pages.wallandstyle
@@ -131,6 +132,24 @@ QtObject {
             StackPage {
                 Component {
                     NetworkPage {}
+                }
+                Component {
+                    EthernetDetailPage {}
+                }
+                Component {
+                    AddNetworkPage {}
+                }
+                Component {
+                    NetworkDetailPage {}
+                }
+                Component {
+                    AddVpnPage {}
+                }
+                Component {
+                    AllNetworksPage {}
+                }
+                Component {
+                    SavedNetworksPage {}
                 }
             }
         },

--- a/shell/modules/nexus/common/AudioDeviceList.qml
+++ b/shell/modules/nexus/common/AudioDeviceList.qml
@@ -7,6 +7,7 @@ import Quickshell.Services.Pipewire
 import Caelestia.Config
 import qs.components
 import qs.services
+import qs.utils
 import qs.modules.nexus.common
 
 ItemList {

--- a/shell/modules/nexus/common/InfoRow.qml
+++ b/shell/modules/nexus/common/InfoRow.qml
@@ -8,6 +8,7 @@ import qs.modules.nexus.common
 ConnectedRect {
     id: root
 
+    property alias icon: icon.text
     property alias label: label.text
     property string subtext
     property alias value: value.text
@@ -23,6 +24,14 @@ ConnectedRect {
         anchors.leftMargin: Tokens.padding.largeIncreased
         anchors.rightMargin: Tokens.padding.largeIncreased
         spacing: Tokens.spacing.medium
+
+        MaterialIcon {
+            id: icon
+
+            visible: text
+            color: Colours.palette.m3onSurfaceVariant
+            fontStyle: Tokens.font.icon.medium
+        }
 
         ColumnLayout {
             Layout.fillWidth: true

--- a/shell/modules/nexus/common/NetworkList.qml
+++ b/shell/modules/nexus/common/NetworkList.qml
@@ -1,0 +1,174 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.utils
+import qs.modules.nexus
+
+ItemList {
+    id: root
+
+    required property NexusState nState
+    property int limit: 0
+    property bool enableFilter
+
+    signal networkSelected(ap: Nmcli.AccessPoint)
+
+    function networkFilter(ap: Nmcli.AccessPoint): bool {
+        return true;
+    }
+
+    showList: Nmcli.wifiEnabled
+    placeholderIcon: Nmcli.wifiEnabled ? "wifi_find" : "signal_wifi_off"
+    placeholderText: Nmcli.wifiEnabled ? qsTr("No networks found") : qsTr("Wi-Fi disabled")
+    extraHeight: Nmcli.scanning ? Tokens.rounding.extraSmall : 0
+    list.anchors.top: scanningIndicator.bottom
+
+    model: ScriptModel {
+        values: {
+            const connecting = Nmcli.connectingSsid();
+            const rank = n => n.active ? 0 : n.ssid === connecting ? 1 : Nmcli.hasSavedProfile(n.ssid) ? 2 : 3;
+            const sorted = [...Nmcli.networks].sort((a, b) => rank(a) - rank(b) || b.strength - a.strength);
+            if (root.limit > 0 && sorted.length > root.limit)
+                sorted.length = root.limit;
+            return root.enableFilter ? sorted.filter(root.networkFilter) : sorted;
+        }
+    }
+
+    delegate: StateLayer {
+        id: network
+
+        required property int index
+        required property var modelData
+        property bool currentSelected
+        property real textOpacity: disabled ? 0.5 : 1
+
+        disabled: currentSelected || Nmcli.connectingSsid() === modelData.ssid
+
+        anchors.left: root.list.contentItem.left
+        anchors.right: root.list.contentItem.right
+        implicitHeight: networkLayout.implicitHeight + networkLayout.anchors.margins * 2
+        radius: Tokens.rounding.extraSmall
+        bottomLeftRadius: root?.last && index === root.list.count - 1 ? Tokens.rounding.extraLarge : radius
+        bottomRightRadius: root?.last && index === root.list.count - 1 ? Tokens.rounding.extraLarge : radius
+        anchors.fill: undefined
+
+        onClicked: {
+            if (!modelData.active) {
+                NetworkConnection.handleConnect(modelData);
+                currentSelected = true;
+                root.networkSelected(modelData);
+            } else {
+                root.nState.selectedNetworkSsid = modelData.ssid;
+                root.nState.networkDetailsFromSaved = false;
+                root.nState.openSubPage(3);
+            }
+        }
+
+        Behavior on textOpacity {
+            Anim {
+                type: Anim.DefaultEffects
+            }
+        }
+
+        Connections {
+            function onActiveChanged(): void {
+                if (network.modelData.active)
+                    network.currentSelected = false;
+            }
+
+            target: network.modelData
+        }
+
+        Connections {
+            function onNetworkSelected(ap: Nmcli.AccessPoint): void {
+                if (ap !== network.modelData)
+                    network.currentSelected = false;
+            }
+
+            target: root
+        }
+
+        RowLayout {
+            id: networkLayout
+
+            anchors.fill: parent
+            anchors.margins: Tokens.padding.large
+            anchors.leftMargin: Tokens.padding.extraLarge
+            anchors.rightMargin: Tokens.padding.extraLarge
+            spacing: Tokens.spacing.medium
+
+            MaterialIcon {
+                text: Icons.getNetworkIcon(network.modelData.strength)
+                color: network.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                fontStyle: Tokens.font.icon.medium
+                opacity: network.textOpacity
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+                opacity: network.textOpacity
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: network.modelData.ssid
+                    font: Tokens.font.body.small
+                    elide: Text.ElideRight
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("Security: %1%2").arg(network.modelData.security).arg(network.modelData.active ? qsTr(" • Connected") : Nmcli.hasSavedProfile(network.modelData.ssid) ? qsTr(" • Saved") : "")
+                    color: Colours.palette.m3outline
+                    font: Tokens.font.label.small
+                    elide: Text.ElideRight
+                }
+            }
+
+            AnimLoader {
+                sourceComp: Nmcli.connectingSsid() === network.modelData.ssid ? loadingComp : iconComp
+
+                Component {
+                    id: iconComp
+
+                    MaterialIcon {
+                        text: network.modelData.active ? "settings" : "lock"
+                        color: network.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.medium
+                        opacity: network.textOpacity
+                    }
+                }
+
+                Component {
+                    id: loadingComp
+
+                    LoadingIndicator {
+                        implicitSize: Math.round(Tokens.font.icon.medium.pointSize * 1.3)
+                    }
+                }
+            }
+        }
+    }
+
+    StyledProgressBar {
+        id: scanningIndicator
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.margins: 1
+        implicitHeight: Nmcli.scanning ? Tokens.rounding.extraSmall : 0
+        indeterminate: true
+
+        Behavior on implicitHeight {
+            Anim {
+                type: Anim.DefaultEffects
+            }
+        }
+    }
+}

--- a/shell/modules/nexus/pages/NetworkPage.qml
+++ b/shell/modules/nexus/pages/NetworkPage.qml
@@ -56,146 +56,99 @@ PageBase {
             onToggled: Nmcli.enableWifi(checked)
         }
 
-        ItemList {
-            id: networkList
+        NetworkList {
+            Layout.bottomMargin: Nmcli.wifiEnabled && Nmcli.networks.length > GlobalConfig.nexus.maxNetworksShown ? 0 : -parent.spacing
+            nState: root.nState
+            limit: GlobalConfig.nexus.maxNetworksShown
 
-            showList: Nmcli.wifiEnabled
-            placeholderIcon: Nmcli.wifiEnabled ? "wifi_find" : "signal_wifi_off"
-            placeholderText: Nmcli.wifiEnabled ? qsTr("No networks found") : qsTr("Wi-Fi disabled")
-            extraHeight: Nmcli.scanning ? Tokens.rounding.extraSmall : 0 // Inline so it isn't affected by anim
-            list.anchors.top: scanningIndicator.bottom
+            onNetworkSelected: root.networkSelected(ap)
 
-            model: ScriptModel {
-                values: {
-                    const connecting = Nmcli.connectingSsid();
-                    // Lower rank sorts higher in the list
-                    const rank = n => n.active ? 0 : n.ssid === connecting ? 1 : Nmcli.hasSavedProfile(n.ssid) ? 2 : 3;
-                    return [...Nmcli.networks].sort((a, b) => rank(a) - rank(b) || b.strength - a.strength);
+            Behavior on Layout.bottomMargin {
+                Anim {
+                    type: Anim.DefaultEffects
+                }
+            }
+        }
+
+        ConnectedRect {
+            Layout.fillWidth: true
+            Layout.preferredHeight: Nmcli.wifiEnabled && Nmcli.networks.length > GlobalConfig.nexus.maxNetworksShown ? showAllLayout.implicitHeight + Tokens.padding.medium * 2 : 0
+            clip: true
+
+            Behavior on Layout.preferredHeight {
+                Anim {
+                    type: Anim.DefaultEffects
                 }
             }
 
-            delegate: StateLayer {
-                id: network
-
-                required property Nmcli.AccessPoint modelData
-                property bool currentSelected
-                property real textOpacity: disabled ? 0.5 : 1
-
-                disabled: currentSelected || Nmcli.connectingSsid() === modelData.ssid
-
-                anchors.left: networkList.list.contentItem.left
-                anchors.right: networkList.list.contentItem.right
-                implicitHeight: networkLayout.implicitHeight + networkLayout.anchors.margins * 2
-                radius: Tokens.rounding.extraSmall
-                anchors.fill: undefined
-
-                onClicked: {
-                    if (!modelData.active) {
-                        NetworkConnection.handleConnect(modelData);
-                        currentSelected = true;
-                        root.networkSelected(modelData);
-                    }
-                }
-
-                Behavior on textOpacity {
-                    Anim {
-                        type: Anim.DefaultEffects
-                    }
-                }
-
-                Connections {
-                    function onActiveChanged(): void {
-                        if (network.modelData.active)
-                            network.currentSelected = false;
-                    }
-
-                    target: network.modelData
-                }
-
-                Connections {
-                    function onNetworkSelected(ap: Nmcli.AccessPoint): void {
-                        if (ap !== network.modelData)
-                            network.currentSelected = false;
-                    }
-
-                    target: root
-                }
-
-                RowLayout {
-                    id: networkLayout
-
-                    anchors.fill: parent
-                    anchors.margins: Tokens.padding.large
-                    anchors.leftMargin: Tokens.padding.extraLarge
-                    anchors.rightMargin: Tokens.padding.extraLarge
-                    spacing: Tokens.spacing.medium
-
-                    MaterialIcon {
-                        text: Icons.getNetworkIcon(network.modelData.strength)
-                        color: network.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
-                        fontStyle: Tokens.font.icon.medium
-                        opacity: network.textOpacity
-                    }
-
-                    ColumnLayout {
-                        Layout.fillWidth: true
-                        spacing: 0
-                        opacity: network.textOpacity
-
-                        StyledText {
-                            Layout.fillWidth: true
-                            text: network.modelData.ssid
-                            font: Tokens.font.body.small
-                            elide: Text.ElideRight
-                        }
-
-                        StyledText {
-                            Layout.fillWidth: true
-                            text: qsTr("Security: %1%2").arg(network.modelData.security).arg(network.modelData.active ? qsTr(" • Connected") : Nmcli.hasSavedProfile(network.modelData.ssid) ? qsTr(" • Saved") : "")
-                            color: Colours.palette.m3outline
-                            font: Tokens.font.label.small
-                            elide: Text.ElideRight
-                        }
-                    }
-
-                    AnimLoader {
-                        sourceComp: Nmcli.connectingSsid() === network.modelData.ssid ? loadingComp : iconComp
-
-                        Component {
-                            id: iconComp
-
-                            MaterialIcon {
-                                text: network.modelData.active ? "settings" : "lock"
-                                color: network.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
-                                fontStyle: Tokens.font.icon.medium
-                                opacity: network.textOpacity
-                            }
-                        }
-
-                        Component {
-                            id: loadingComp
-
-                            LoadingIndicator {
-                                implicitSize: Math.round(Tokens.font.icon.medium.pointSize * 1.3)
-                            }
-                        }
-                    }
-                }
+            StateLayer {
+                onClicked: root.nState.openSubPage(5)
             }
 
-            StyledProgressBar {
-                id: scanningIndicator
+            RowLayout {
+                id: showAllLayout
 
                 anchors.left: parent.left
                 anchors.right: parent.right
-                anchors.margins: 1
-                implicitHeight: Nmcli.scanning ? Tokens.rounding.extraSmall : 0
-                indeterminate: true
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.margins: Tokens.padding.largeIncreased
+                spacing: Tokens.spacing.medium
 
-                Behavior on implicitHeight {
-                    Anim {
-                        type: Anim.DefaultEffects
-                    }
+                MaterialIcon {
+                    text: "expand_content"
+                    fontStyle: Tokens.font.icon.medium
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("Show all networks (%1)").arg(Nmcli.networks.length)
+                    font: Tokens.font.body.small
+                    elide: Text.ElideRight
+                }
+
+                MaterialIcon {
+                    text: "chevron_right"
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.medium
+                }
+            }
+        }
+
+        ConnectedRect {
+            Layout.fillWidth: true
+            implicitHeight: savedNetworksLayout.implicitHeight + savedNetworksLayout.anchors.margins * 2
+
+            StateLayer {
+                onClicked: root.nState.openSubPage(6)
+            }
+
+            RowLayout {
+                id: savedNetworksLayout
+
+                anchors.fill: parent
+                anchors.margins: Tokens.padding.medium
+                anchors.leftMargin: Tokens.padding.largeIncreased
+                anchors.rightMargin: Tokens.padding.largeIncreased
+                spacing: Tokens.spacing.medium
+
+                MaterialIcon {
+                    text: "bookmark"
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.medium
+                    fill: 1
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("Saved networks")
+                    font: Tokens.font.body.small
+                    elide: Text.ElideRight
+                }
+
+                MaterialIcon {
+                    text: "chevron_right"
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.medium
                 }
             }
         }
@@ -327,10 +280,50 @@ PageBase {
 
         ConnectedRect {
             Layout.fillWidth: true
+            implicitHeight: vpnProviderLayout.implicitHeight + vpnProviderLayout.anchors.margins * 2
+
+            StateLayer {
+                onClicked: root.nState.openSubPage(4)
+            }
+
+            RowLayout {
+                id: vpnProviderLayout
+
+                anchors.fill: parent
+                anchors.margins: Tokens.padding.medium
+                anchors.leftMargin: Tokens.padding.largeIncreased
+                anchors.rightMargin: Tokens.padding.largeIncreased
+                spacing: Tokens.spacing.medium
+
+                MaterialIcon {
+                    text: "vpn_key"
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.medium
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("VPN providers")
+                    font: Tokens.font.body.small
+                    elide: Text.ElideRight
+                }
+
+                MaterialIcon {
+                    text: "chevron_right"
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.medium
+                }
+            }
+        }
+
+        ConnectedRect {
+            Layout.fillWidth: true
             implicitHeight: addNetworkLayout.implicitHeight + addNetworkLayout.anchors.margins * 2
             last: true
 
-            StateLayer {}
+            StateLayer {
+                onClicked: root.nState.openSubPage(2)
+            }
 
             RowLayout {
                 id: addNetworkLayout

--- a/shell/modules/nexus/pages/network/AddNetworkPage.qml
+++ b/shell/modules/nexus/pages/network/AddNetworkPage.qml
@@ -2,6 +2,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Layouts
+import Caelestia.Components
 import Caelestia.Config
 import qs.components
 import qs.components.controls

--- a/shell/modules/nexus/pages/network/AddNetworkPage.qml
+++ b/shell/modules/nexus/pages/network/AddNetworkPage.qml
@@ -16,8 +16,6 @@ PageBase {
     title: qsTr("Add network")
     isSubPage: true
 
-    property bool hiddenNetwork: false
-
     ColumnLayout {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
@@ -51,12 +49,6 @@ PageBase {
                     Layout.fillWidth: true
                     placeholderText: qsTr("Password")
                     echoMode: TextInput.Password
-                }
-
-                ToggleRow {
-                    text: qsTr("Hidden network")
-                    checked: root.hiddenNetwork
-                    onToggled: root.hiddenNetwork = checked
                 }
             }
         }

--- a/shell/modules/nexus/pages/network/AddNetworkPage.qml
+++ b/shell/modules/nexus/pages/network/AddNetworkPage.qml
@@ -1,0 +1,91 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.utils
+import qs.modules.nexus.common
+
+PageBase {
+    id: root
+
+    title: qsTr("Add network")
+    isSubPage: true
+
+    property bool hiddenNetwork: false
+
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.extraSmall / 2
+
+        SectionHeader {
+            first: true
+            text: qsTr("Wi-Fi details")
+        }
+
+        ConnectedRect {
+            Layout.fillWidth: true
+            implicitHeight: formLayout.implicitHeight + Tokens.padding.medium * 2
+
+            ColumnLayout {
+                id: formLayout
+
+                anchors.fill: parent
+                anchors.margins: Tokens.padding.medium
+                spacing: Tokens.spacing.small
+
+                StyledTextField {
+                    id: ssidField
+                    Layout.fillWidth: true
+                    placeholderText: qsTr("Network name (SSID)")
+                }
+
+                StyledTextField {
+                    id: passwordField
+                    Layout.fillWidth: true
+                    placeholderText: qsTr("Password")
+                    echoMode: TextInput.Password
+                }
+
+                ToggleRow {
+                    text: qsTr("Hidden network")
+                    checked: root.hiddenNetwork
+                    onToggled: root.hiddenNetwork = checked
+                }
+            }
+        }
+
+        ButtonRow {
+            Layout.fillWidth: true
+            spacing: Tokens.spacing.small
+
+            ButtonBase {
+                fillWidth: true
+                text: qsTr("Connect")
+                onClicked: {
+                    const ssid = ssidField.text.trim();
+                    if (!ssid)
+                        return;
+
+                    NetworkConnection.connectWithPassword({ ssid: ssid, bssid: "" }, passwordField.text, result => {
+                        if (result?.success)
+                            root.nState.closeSubPage();
+                    });
+                }
+            }
+
+            ButtonBase {
+                fillWidth: true
+                text: qsTr("Cancel")
+                inactiveColour: Colours.palette.m3surfaceContainerHighest
+                inactiveOnColour: Colours.palette.m3onSurface
+                onClicked: root.nState.closeSubPage()
+            }
+        }
+    }
+}

--- a/shell/modules/nexus/pages/network/AddVpnPage.qml
+++ b/shell/modules/nexus/pages/network/AddVpnPage.qml
@@ -2,6 +2,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Layouts
+import Caelestia.Components
 import Caelestia.Config
 import qs.components
 import qs.components.controls

--- a/shell/modules/nexus/pages/network/AddVpnPage.qml
+++ b/shell/modules/nexus/pages/network/AddVpnPage.qml
@@ -1,0 +1,128 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.modules.nexus.common
+
+PageBase {
+    id: root
+
+    title: qsTr("VPN providers")
+    isSubPage: true
+
+    function setProvider(name: string): void {
+        GlobalConfig.utilities.vpn.provider = [{ enabled: true, name: name }];
+    }
+
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.extraSmall / 2
+
+        SectionHeader {
+            first: true
+            text: qsTr("Built-in providers")
+        }
+
+        ProviderRow {
+            providerName: "wireguard"
+            displayName: qsTr("WireGuard")
+            description: qsTr("Use a local WireGuard tunnel")
+        }
+
+        ProviderRow {
+            providerName: "warp"
+            displayName: qsTr("Cloudflare WARP")
+            description: qsTr("Cloudflare's privacy VPN")
+        }
+
+        ProviderRow {
+            providerName: "netbird"
+            displayName: qsTr("NetBird")
+            description: qsTr("Self-managed mesh VPN")
+        }
+
+        ProviderRow {
+            providerName: "tailscale"
+            displayName: qsTr("Tailscale")
+            description: qsTr("WireGuard-based mesh VPN")
+        }
+
+        ButtonRow {
+            Layout.fillWidth: true
+            spacing: Tokens.spacing.small
+
+            ButtonBase {
+                fillWidth: true
+                text: qsTr("Close")
+                inactiveColour: Colours.palette.m3surfaceContainerHighest
+                inactiveOnColour: Colours.palette.m3onSurface
+                onClicked: root.nState.closeSubPage()
+            }
+        }
+    }
+
+    component ProviderRow: ConnectedRect {
+        id: row
+
+        required property string providerName
+        required property string displayName
+        required property string description
+
+        readonly property bool selected: VPN.providerName === providerName
+
+        Layout.fillWidth: true
+        implicitHeight: providerLayout.implicitHeight + providerLayout.anchors.margins * 2
+
+        StateLayer {
+            onClicked: root.setProvider(row.providerName)
+        }
+
+        RowLayout {
+            id: providerLayout
+
+            anchors.fill: parent
+            anchors.margins: Tokens.padding.medium
+            anchors.leftMargin: Tokens.padding.largeIncreased
+            anchors.rightMargin: Tokens.padding.largeIncreased
+            spacing: Tokens.spacing.medium
+
+            MaterialIcon {
+                text: selected ? "radio_button_checked" : "radio_button_unchecked"
+                color: selected ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                fontStyle: Tokens.font.icon.medium
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: displayName
+                    font: Tokens.font.body.small
+                    elide: Text.ElideRight
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: description
+                    color: Colours.palette.m3outline
+                    font: Tokens.font.label.small
+                    elide: Text.ElideRight
+                }
+            }
+
+            MaterialIcon {
+                text: "chevron_right"
+                color: Colours.palette.m3onSurfaceVariant
+                fontStyle: Tokens.font.icon.medium
+            }
+        }
+    }
+}

--- a/shell/modules/nexus/pages/network/AllNetworksPage.qml
+++ b/shell/modules/nexus/pages/network/AllNetworksPage.qml
@@ -1,0 +1,139 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.modules.nexus.common
+
+PageBase {
+    id: root
+
+    title: qsTr("All networks")
+    isSubPage: true
+    flickable.bottomMargin: Tokens.padding.extraExtraLarge * 2
+
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.extraSmall / 2
+
+        Timer {
+            running: root.visible && Nmcli.wifiEnabled
+            repeat: true
+            triggeredOnStart: true
+            interval: GlobalConfig.nexus.networkRescanInterval
+            onTriggered: Nmcli.rescanWifi()
+        }
+
+        ConnectedRect {
+            Layout.fillWidth: true
+            implicitHeight: headerLayout.implicitHeight + Tokens.padding.medium * 2
+            first: true
+
+            RowLayout {
+                id: headerLayout
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.leftMargin: Tokens.padding.largeIncreased
+                anchors.rightMargin: Tokens.padding.large
+                anchors.verticalCenterOffset: 1
+                spacing: Tokens.spacing.extraSmall / 2
+
+                StyledText {
+                    text: qsTr("Filters")
+                    font: Tokens.font.title.small
+                }
+
+                Item { Layout.fillWidth: true }
+
+                FilterButton {
+                    id: savedFilter
+
+                    function internalFilter(ap: Nmcli.AccessPoint): bool {
+                        return Nmcli.hasSavedProfile(ap.ssid);
+                    }
+
+                    text: qsTr("Saved")
+                    topLeftRadius: pressed ? pressedRadius : implicitHeight / 2
+                    bottomLeftRadius: pressed ? pressedRadius : implicitHeight / 2
+                }
+
+                FilterButton {
+                    id: secureFilter
+
+                    function internalFilter(ap: Nmcli.AccessPoint): bool {
+                        return ap.security !== "none";
+                    }
+
+                    text: qsTr("Secured")
+                }
+
+                FilterButton {
+                    id: highFreqFilter
+
+                    function internalFilter(ap: Nmcli.AccessPoint): bool {
+                        return ap.frequency >= 4900 && ap.frequency <= 5900;
+                    }
+
+                    text: qsTr("5 GHz")
+                }
+
+                FilterButton {
+                    id: lowFreqFilter
+
+                    function internalFilter(ap: Nmcli.AccessPoint): bool {
+                        return ap.frequency >= 2400 && ap.frequency <= 2500;
+                    }
+
+                    text: qsTr("2.4 GHz")
+                    topRightRadius: pressed ? pressedRadius : implicitHeight / 2
+                    bottomRightRadius: pressed ? pressedRadius : implicitHeight / 2
+                }
+            }
+        }
+
+        NetworkList {
+            function networkFilter(ap: Nmcli.AccessPoint): bool {
+                return savedFilter.filter(ap) && secureFilter.filter(ap) && highFreqFilter.filter(ap) && lowFreqFilter.filter(ap);
+            }
+
+            nState: root.nState
+            enableFilter: true
+            last: true
+        }
+    }
+
+    component FilterButton: IconTextButton {
+        id: filter
+
+        property int filterState
+
+        function filter(ap: Nmcli.AccessPoint): bool {
+            if (filterState === 0)
+                return true;
+            if (filterState === 1)
+                return internalFilter(ap);
+            return !internalFilter(ap);
+        }
+
+        function internalFilter(ap: Nmcli.AccessPoint): bool {
+            return true;
+        }
+
+        onClicked: filterState = (filterState + 1) % 3
+
+        defaultRadius: Tokens.rounding.small
+        pressedRadius: Tokens.rounding.extraSmall
+        spacing: Tokens.spacing.extraSmall
+
+        icon: ["check_indeterminate_small", "check", "close"][filterState]
+        inactiveColour: [Colours.palette.m3secondaryContainer, Colours.palette.m3primary, Colours.palette.m3tertiary][filterState]
+        inactiveOnColour: [Colours.palette.m3onSecondaryContainer, Colours.palette.m3onPrimary, Colours.palette.m3onTertiary][filterState]
+    }
+}

--- a/shell/modules/nexus/pages/network/EthernetDetailPage.qml
+++ b/shell/modules/nexus/pages/network/EthernetDetailPage.qml
@@ -2,6 +2,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Layouts
+import Caelestia.Components
 import Caelestia.Config
 import qs.components
 import qs.components.controls

--- a/shell/modules/nexus/pages/network/EthernetDetailPage.qml
+++ b/shell/modules/nexus/pages/network/EthernetDetailPage.qml
@@ -1,0 +1,84 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.modules.nexus.common
+
+PageBase {
+    id: root
+
+    readonly property var device: Nmcli.activeEthernet
+
+    title: qsTr("Ethernet")
+    isSubPage: true
+
+    Component.onCompleted: Nmcli.getEthernetDeviceDetails("", () => {})
+
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.extraSmall / 2
+
+        SectionHeader {
+            first: true
+            text: qsTr("Connection")
+        }
+
+        InfoRow {
+            icon: "lan"
+            label: qsTr("Interface")
+            value: root.device?.interface || qsTr("Not connected")
+        }
+
+        InfoRow {
+            icon: "router"
+            label: qsTr("IP address")
+            value: root.device?.ipAddress || qsTr("—")
+        }
+
+        InfoRow {
+            icon: "dns"
+            label: qsTr("Gateway")
+            value: root.device?.gateway || qsTr("—")
+        }
+
+        InfoRow {
+            icon: "memory"
+            label: qsTr("MAC address")
+            value: root.device?.macAddress || qsTr("—")
+        }
+
+        InfoRow {
+            icon: "speed"
+            label: qsTr("Speed")
+            value: root.device?.speed || qsTr("—")
+        }
+
+        ButtonRow {
+            Layout.fillWidth: true
+            spacing: Tokens.spacing.small
+
+            ButtonBase {
+                fillWidth: true
+                text: qsTr("Disconnect")
+                onClicked: {
+                    if (root.device)
+                        Nmcli.disconnectEthernet(root.device.connection || root.device.interface, () => {});
+                }
+            }
+
+            ButtonBase {
+                fillWidth: true
+                text: qsTr("Close")
+                inactiveColour: Colours.palette.m3surfaceContainerHighest
+                inactiveOnColour: Colours.palette.m3onSurface
+                onClicked: root.nState.closeSubPage()
+            }
+        }
+    }
+}

--- a/shell/modules/nexus/pages/network/NetworkDetailPage.qml
+++ b/shell/modules/nexus/pages/network/NetworkDetailPage.qml
@@ -1,0 +1,150 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.modules.nexus.common
+
+PageBase {
+    id: root
+
+    readonly property string ssid: nState.selectedNetworkSsid
+    readonly property var ap: Nmcli.findNetwork(root.ssid)
+    readonly property var details: Nmcli.wirelessDeviceDetails
+    readonly property bool isActive: !!Nmcli.active && Nmcli.active.ssid === root.ssid
+
+    title: root.ssid || qsTr("Network details")
+    isSubPage: true
+
+    Component.onCompleted: {
+        Nmcli.getWirelessDeviceDetails("", () => {});
+    }
+
+    Connections {
+        function onActiveChanged(): void {
+            if (root.isActive)
+                Nmcli.getWirelessDeviceDetails("", () => {});
+        }
+
+        target: Nmcli
+    }
+
+    onApChanged: {
+        if (!nState.networkDetailsFromSaved && !root.ap)
+            nState.closeSubPage();
+    }
+
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.extraSmall / 2
+
+        ButtonRow {
+            Layout.bottomMargin: Tokens.spacing.large - parent.spacing
+            Layout.alignment: Qt.AlignHCenter
+            Layout.minimumWidth: Math.round(root.cappedWidth * (root.isActive ? 0.7 : 0.5))
+            spacing: Tokens.spacing.small
+
+            ButtonBase {
+                fillWidth: true
+                shapeMorph: root.isActive
+                isRound: true
+                inactiveColour: Colours.palette.m3errorContainer
+                inactiveOnColour: Colours.palette.m3onErrorContainer
+                text: qsTr("Forget")
+                onClicked: Nmcli.forgetNetwork(root.ssid, () => root.nState.closeSubPage())
+            }
+
+            ButtonBase {
+                visible: root.isActive
+                fillWidth: true
+                shapeMorph: true
+                isRound: true
+                inactiveColour: Colours.palette.m3primaryContainer
+                inactiveOnColour: Colours.palette.m3onPrimaryContainer
+                text: qsTr("Disconnect")
+                onClicked: {
+                    Nmcli.disconnectFromNetwork();
+                    root.nState.closeSubPage();
+                }
+            }
+
+            ButtonBase {
+                visible: !root.isActive
+                fillWidth: true
+                shapeMorph: true
+                isRound: true
+                inactiveColour: Colours.palette.m3primaryContainer
+                inactiveOnColour: Colours.palette.m3onPrimaryContainer
+                text: qsTr("Connect")
+                onClicked: {
+                    if (root.ap)
+                        NetworkConnection.handleConnect(root.ap);
+                }
+            }
+        }
+
+        SectionHeader {
+            first: true
+            text: qsTr("Connection")
+            visible: root.isActive
+        }
+
+        InfoRow {
+            icon: "signal_wifi_4_bar"
+            label: qsTr("Signal")
+            value: root.ap ? qsTr("%1%").arg(root.ap.strength) : qsTr("—")
+            visible: root.isActive
+        }
+
+        InfoRow {
+            icon: "lock"
+            label: qsTr("Security")
+            value: root.ap?.security || qsTr("Open")
+            visible: root.isActive
+        }
+
+        InfoRow {
+            icon: "graphic_eq"
+            label: qsTr("Frequency")
+            value: root.ap && root.ap.frequency > 0 ? qsTr("%1 MHz").arg(root.ap.frequency) : qsTr("—")
+            visible: root.isActive
+        }
+
+        InfoRow {
+            icon: "lan"
+            label: qsTr("IP address")
+            value: root.details?.ipAddress || qsTr("—")
+            visible: root.isActive
+        }
+
+        InfoRow {
+            icon: "router"
+            label: qsTr("Gateway")
+            value: root.details?.gateway || qsTr("—")
+            visible: root.isActive
+        }
+
+        InfoRow {
+            icon: "memory"
+            label: qsTr("MAC address")
+            value: root.details?.macAddress || qsTr("—")
+            visible: root.isActive
+        }
+
+        SectionHeader {
+            first: !root.isActive
+            text: qsTr("Behaviour")
+        }
+
+        InfoRow {
+            icon: "autorenew"
+            label: qsTr("Auto connect")
+            value: Nmcli.hasSavedProfile(root.ssid) ? qsTr("Saved") : qsTr("Not saved")
+        }
+    }
+}

--- a/shell/modules/nexus/pages/network/NetworkDetailPage.qml
+++ b/shell/modules/nexus/pages/network/NetworkDetailPage.qml
@@ -2,6 +2,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Layouts
+import Caelestia.Components
 import Caelestia.Config
 import qs.components
 import qs.components.controls
@@ -23,128 +24,138 @@ PageBase {
         Nmcli.getWirelessDeviceDetails("", () => {});
     }
 
-    Connections {
-        function onActiveChanged(): void {
-            if (root.isActive)
-                Nmcli.getWirelessDeviceDetails("", () => {});
-        }
+    Item {
+        anchors.fill: parent
 
-        target: Nmcli
-    }
-
-    onApChanged: {
-        if (!nState.networkDetailsFromSaved && !root.ap)
-            nState.closeSubPage();
-    }
-
-    ColumnLayout {
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.top: parent.top
-        width: root.cappedWidth
-        spacing: Tokens.spacing.extraSmall / 2
-
-        ButtonRow {
-            Layout.bottomMargin: Tokens.spacing.large - parent.spacing
-            Layout.alignment: Qt.AlignHCenter
-            Layout.minimumWidth: Math.round(root.cappedWidth * (root.isActive ? 0.7 : 0.5))
-            spacing: Tokens.spacing.small
-
-            ButtonBase {
-                fillWidth: true
-                shapeMorph: root.isActive
-                isRound: true
-                inactiveColour: Colours.palette.m3errorContainer
-                inactiveOnColour: Colours.palette.m3onErrorContainer
-                text: qsTr("Forget")
-                onClicked: Nmcli.forgetNetwork(root.ssid, () => root.nState.closeSubPage())
+        Connections {
+            function onActiveChanged(): void {
+                if (root.isActive)
+                    Nmcli.getWirelessDeviceDetails("", () => {});
             }
 
-            ButtonBase {
+            target: Nmcli
+        }
+
+        Connections {
+            function onApChanged(): void {
+                if (!nState.networkDetailsFromSaved && !root.ap)
+                    nState.closeSubPage();
+            }
+
+            target: root
+        }
+
+        ColumnLayout {
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.top: parent.top
+            width: root.cappedWidth
+            spacing: Tokens.spacing.extraSmall / 2
+
+            ButtonRow {
+                Layout.bottomMargin: Tokens.spacing.large - parent.spacing
+                Layout.alignment: Qt.AlignHCenter
+                Layout.minimumWidth: Math.round(root.cappedWidth * (root.isActive ? 0.7 : 0.5))
+                spacing: Tokens.spacing.small
+
+                ButtonBase {
+                    fillWidth: true
+                    shapeMorph: root.isActive
+                    isRound: true
+                    inactiveColour: Colours.palette.m3errorContainer
+                    inactiveOnColour: Colours.palette.m3onErrorContainer
+                    text: qsTr("Forget")
+                    onClicked: Nmcli.forgetNetwork(root.ssid, () => root.nState.closeSubPage())
+                }
+
+                ButtonBase {
+                    visible: root.isActive
+                    fillWidth: true
+                    shapeMorph: true
+                    isRound: true
+                    inactiveColour: Colours.palette.m3primaryContainer
+                    inactiveOnColour: Colours.palette.m3onPrimaryContainer
+                    text: qsTr("Disconnect")
+                    onClicked: {
+                        Nmcli.disconnectFromNetwork();
+                        root.nState.closeSubPage();
+                    }
+                }
+
+                ButtonBase {
+                    visible: !root.isActive
+                    fillWidth: true
+                    shapeMorph: true
+                    isRound: true
+                    inactiveColour: Colours.palette.m3primaryContainer
+                    inactiveOnColour: Colours.palette.m3onPrimaryContainer
+                    text: qsTr("Connect")
+                    onClicked: {
+                        if (root.ap)
+                            NetworkConnection.handleConnect(root.ap);
+                    }
+                }
+            }
+
+            SectionHeader {
+                first: true
+                text: qsTr("Connection")
                 visible: root.isActive
-                fillWidth: true
-                shapeMorph: true
-                isRound: true
-                inactiveColour: Colours.palette.m3primaryContainer
-                inactiveOnColour: Colours.palette.m3onPrimaryContainer
-                text: qsTr("Disconnect")
-                onClicked: {
-                    Nmcli.disconnectFromNetwork();
-                    root.nState.closeSubPage();
-                }
             }
 
-            ButtonBase {
+            InfoRow {
+                icon: "signal_wifi_4_bar"
+                label: qsTr("Signal")
+                value: root.ap ? qsTr("%1%").arg(root.ap.strength) : qsTr("—")
+                visible: root.isActive
+            }
+
+            InfoRow {
+                icon: "lock"
+                label: qsTr("Security")
+                value: root.ap?.security || qsTr("Open")
+                visible: root.isActive
+            }
+
+            InfoRow {
+                icon: "graphic_eq"
+                label: qsTr("Frequency")
+                value: root.ap && root.ap.frequency > 0 ? qsTr("%1 MHz").arg(root.ap.frequency) : qsTr("—")
+                visible: root.isActive
+            }
+
+            InfoRow {
+                icon: "lan"
+                label: qsTr("MAC address")
+                value: root.details?.macAddress || qsTr("—")
+                visible: root.isActive
+            }
+
+            InfoRow {
+                icon: "router"
+                label: qsTr("Gateway")
+                value: root.details?.gateway || qsTr("—")
+                visible: root.isActive
+            }
+
+            InfoRow {
+                icon: "memory"
+                label: qsTr("IP address")
+                value: root.details?.ipAddress || qsTr("—")
+                visible: root.isActive
+            }
+
+            SectionHeader {
+                first: true
+                text: qsTr("Actions")
                 visible: !root.isActive
-                fillWidth: true
-                shapeMorph: true
-                isRound: true
-                inactiveColour: Colours.palette.m3primaryContainer
-                inactiveOnColour: Colours.palette.m3onPrimaryContainer
-                text: qsTr("Connect")
-                onClicked: {
-                    if (root.ap)
-                        NetworkConnection.handleConnect(root.ap);
-                }
             }
-        }
 
-        SectionHeader {
-            first: true
-            text: qsTr("Connection")
-            visible: root.isActive
-        }
-
-        InfoRow {
-            icon: "signal_wifi_4_bar"
-            label: qsTr("Signal")
-            value: root.ap ? qsTr("%1%").arg(root.ap.strength) : qsTr("—")
-            visible: root.isActive
-        }
-
-        InfoRow {
-            icon: "lock"
-            label: qsTr("Security")
-            value: root.ap?.security || qsTr("Open")
-            visible: root.isActive
-        }
-
-        InfoRow {
-            icon: "graphic_eq"
-            label: qsTr("Frequency")
-            value: root.ap && root.ap.frequency > 0 ? qsTr("%1 MHz").arg(root.ap.frequency) : qsTr("—")
-            visible: root.isActive
-        }
-
-        InfoRow {
-            icon: "lan"
-            label: qsTr("IP address")
-            value: root.details?.ipAddress || qsTr("—")
-            visible: root.isActive
-        }
-
-        InfoRow {
-            icon: "router"
-            label: qsTr("Gateway")
-            value: root.details?.gateway || qsTr("—")
-            visible: root.isActive
-        }
-
-        InfoRow {
-            icon: "memory"
-            label: qsTr("MAC address")
-            value: root.details?.macAddress || qsTr("—")
-            visible: root.isActive
-        }
-
-        SectionHeader {
-            first: !root.isActive
-            text: qsTr("Behaviour")
-        }
-
-        InfoRow {
-            icon: "autorenew"
-            label: qsTr("Auto connect")
-            value: Nmcli.hasSavedProfile(root.ssid) ? qsTr("Saved") : qsTr("Not saved")
+            InfoRow {
+                icon: "info"
+                label: qsTr("State")
+                value: qsTr("Not connected")
+                visible: !root.isActive
+            }
         }
     }
 }

--- a/shell/modules/nexus/pages/network/SavedNetworksPage.qml
+++ b/shell/modules/nexus/pages/network/SavedNetworksPage.qml
@@ -1,0 +1,103 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.modules.nexus.common
+
+PageBase {
+    id: root
+
+    title: qsTr("Saved networks")
+    isSubPage: true
+
+    Component.onCompleted: Nmcli.loadSavedConnections(() => {})
+
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.extraSmall / 2
+
+        ItemList {
+            id: savedList
+
+            showList: true
+            first: true
+            last: true
+            placeholderIcon: "wifi_find"
+            placeholderText: qsTr("No saved networks")
+
+            model: ScriptModel {
+                values: [...Nmcli.savedConnectionSsids].sort((a, b) => a.localeCompare(b))
+            }
+
+            delegate: StateLayer {
+                id: saved
+
+                required property int index
+                required property var modelData
+                readonly property var ap: Nmcli.findNetwork(modelData)
+                readonly property bool isActive: !!Nmcli.active && Nmcli.active.ssid === modelData
+
+                anchors.left: savedList.list.contentItem.left
+                anchors.right: savedList.list.contentItem.right
+                implicitHeight: savedLayout.implicitHeight + savedLayout.anchors.margins * 2
+                radius: Tokens.rounding.extraSmall
+                bottomLeftRadius: root?.last && index === savedList.list.count - 1 ? Tokens.rounding.extraLarge : radius
+                bottomRightRadius: root?.last && index === savedList.list.count - 1 ? Tokens.rounding.extraLarge : radius
+
+                onClicked: {
+                    root.nState.selectedNetworkSsid = modelData;
+                    root.nState.networkDetailsFromSaved = true;
+                    root.nState.openSubPage(3);
+                }
+
+                RowLayout {
+                    id: savedLayout
+
+                    anchors.fill: parent
+                    anchors.margins: Tokens.padding.large
+                    anchors.leftMargin: Tokens.padding.extraLarge
+                    anchors.rightMargin: Tokens.padding.extraLarge
+                    spacing: Tokens.spacing.medium
+
+                    MaterialIcon {
+                        text: isActive ? "settings" : "bookmark"
+                        color: isActive ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.medium
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 0
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: modelData
+                            font: Tokens.font.body.small
+                            elide: Text.ElideRight
+                        }
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: isActive ? qsTr("Connected") : ap ? qsTr("Available") : qsTr("Saved")
+                            color: Colours.palette.m3outline
+                            font: Tokens.font.label.small
+                            elide: Text.ElideRight
+                        }
+                    }
+
+                    MaterialIcon {
+                        text: "chevron_right"
+                        color: Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.medium
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shell/modules/nexus/pages/network/SavedNetworksPage.qml
+++ b/shell/modules/nexus/pages/network/SavedNetworksPage.qml
@@ -2,10 +2,12 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Layouts
+import Quickshell
 import Caelestia.Config
 import qs.components
 import qs.components.controls
 import qs.services
+import qs.utils
 import qs.modules.nexus.common
 
 PageBase {

--- a/shell/modules/nexus/pages/network/SavedNetworksPage.qml
+++ b/shell/modules/nexus/pages/network/SavedNetworksPage.qml
@@ -47,8 +47,8 @@ PageBase {
                 anchors.right: savedList.list.contentItem.right
                 implicitHeight: savedLayout.implicitHeight + savedLayout.anchors.margins * 2
                 radius: Tokens.rounding.extraSmall
-                bottomLeftRadius: root?.last && index === savedList.list.count - 1 ? Tokens.rounding.extraLarge : radius
-                bottomRightRadius: root?.last && index === savedList.list.count - 1 ? Tokens.rounding.extraLarge : radius
+                bottomLeftRadius: savedList?.last && index === savedList.list.count - 1 ? Tokens.rounding.extraLarge : radius
+                bottomRightRadius: savedList?.last && index === savedList.list.count - 1 ? Tokens.rounding.extraLarge : radius
 
                 onClicked: {
                     root.nState.selectedNetworkSsid = modelData;

--- a/shell/modules/notifications/Content.qml
+++ b/shell/modules/notifications/Content.qml
@@ -9,6 +9,7 @@ import qs.components
 import qs.components.containers
 import qs.components.widgets
 import qs.services
+import qs.utils
 import qs.modules.utilities as Utilities
 
 Item {

--- a/shell/modules/sidebar/NotifDockList.qml
+++ b/shell/modules/sidebar/NotifDockList.qml
@@ -6,6 +6,7 @@ import Caelestia.Components
 import Caelestia.Config
 import qs.components
 import qs.services
+import qs.utils
 
 LazyListView {
     id: root

--- a/shell/modules/sidebar/NotifGroupList.qml
+++ b/shell/modules/sidebar/NotifGroupList.qml
@@ -6,6 +6,7 @@ import Caelestia.Components
 import Caelestia.Config
 import qs.components
 import qs.services
+import qs.utils
 
 LazyListView {
     id: root

--- a/shell/modules/utilities/toasts/Toasts.qml
+++ b/shell/modules/utilities/toasts/Toasts.qml
@@ -6,6 +6,7 @@ import Caelestia
 import Caelestia.Config
 import qs.components
 import qs.services
+import qs.utils
 
 Item {
     id: root

--- a/shell/plugin/src/Caelestia/Config/rootconfig.cpp
+++ b/shell/plugin/src/Caelestia/Config/rootconfig.cpp
@@ -54,6 +54,40 @@ QStringList RootConfig::collectUnknownKeys(const ConfigObject* obj, const QJsonO
     return unknown;
 }
 
+void RootConfig::mergeUnknownKeys(const ConfigObject* obj, const QJsonObject& source, QJsonObject& target) {
+    const auto* meta = obj->metaObject();
+
+    QSet<QString> known;
+    for (int i = ConfigObject::basePropertyOffset(); i < meta->propertyCount(); ++i)
+        known.insert(QString::fromUtf8(meta->property(i).name()));
+
+    for (auto it = source.begin(); it != source.end(); ++it) {
+        if (!known.contains(it.key())) {
+            if (!target.contains(it.key()))
+                target.insert(it.key(), it.value());
+            continue;
+        }
+
+        if (!it.value().isObject())
+            continue;
+
+        int idx = meta->indexOfProperty(it.key().toUtf8().constData());
+        if (idx < 0)
+            continue;
+
+        auto prop = meta->property(idx);
+        auto* subObj = prop.read(obj).value<ConfigObject*>();
+        if (!subObj)
+            continue;
+
+        auto childTarget = target.value(it.key()).toObject();
+        mergeUnknownKeys(subObj, it.value().toObject(), childTarget);
+
+        if (!childTarget.isEmpty())
+            target.insert(it.key(), childTarget);
+    }
+}
+
 void RootConfig::setupFileBackend(const QString& path, const QString& screen) {
     m_filePath = path;
     m_screen = screen;
@@ -81,6 +115,7 @@ void RootConfig::setupFileBackend(const QString& path, const QString& screen) {
         }
 
         auto json = toJsonObject();
+        mergeUnknownKeys(this, m_lastLoadedJson, json);
         file.write(QJsonDocument(json).toJson(QJsonDocument::Indented));
         file.close();
 
@@ -239,6 +274,7 @@ std::optional<QString> RootConfig::reloadFromFile() {
     clearLoadedKeys();
 
     auto jsonObj = doc.object();
+    m_lastLoadedJson = jsonObj;
     loadFromJson(jsonObj);
 
     m_loading = false;

--- a/shell/plugin/src/Caelestia/Config/rootconfig.cpp
+++ b/shell/plugin/src/Caelestia/Config/rootconfig.cpp
@@ -239,6 +239,8 @@ std::optional<QString> RootConfig::reloadFromFile() {
 
     if (!file.exists()) {
         qCDebug(lcConfig) << "File does not exist:" << m_filePath;
+        m_lastLoadedJson = QJsonObject{};
+        m_lastUnknownKeys.clear();
         return std::nullopt;
     }
 

--- a/shell/plugin/src/Caelestia/Config/rootconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/rootconfig.hpp
@@ -35,6 +35,7 @@ signals:
 
 private:
     static QStringList collectUnknownKeys(const ConfigObject* obj, const QJsonObject& json);
+    static void mergeUnknownKeys(const ConfigObject* obj, const QJsonObject& source, QJsonObject& target);
     void emitLoadSignals(const std::optional<QString>& result, bool emitLoaded = true);
     void updateWatch();
     void onWatcherEvent();
@@ -58,6 +59,7 @@ private:
     QTimer* m_reloadDebounce = nullptr;
     int m_parseRetries = 0;
     QStringList m_lastUnknownKeys;
+    QJsonObject m_lastLoadedJson;
 };
 
 } // namespace caelestia::config

--- a/shell/plugin/src/Caelestia/Models/filesystemmodel.cpp
+++ b/shell/plugin/src/Caelestia/Models/filesystemmodel.cpp
@@ -434,51 +434,27 @@ void FileSystemModel::applyChanges(const QSet<QString>& removedPaths, const QSet
         return compareEntries(a, b);
     });
 
-    // Pre-calculate insertion rows for all new entries before any mutations
-    QList<int> insertRows;
-    insertRows.reserve(newEntries.size());
-    for (const auto& entry : std::as_const(newEntries)) {
-        const auto it = std::lower_bound(
-            m_entries.begin(), m_entries.end(), entry, [this](const FileSystemEntry* a, const FileSystemEntry* b) {
-                return compareEntries(a, b);
-            });
-        insertRows << static_cast<int>(it - m_entries.begin());
-    }
+    // Batch insert new entries (each run lands contiguously before m_entries[row])
+    int i = 0;
+    while (i < newEntries.size()) {
+        const auto it = std::lower_bound(m_entries.begin(), m_entries.end(), newEntries[i], [this](const FileSystemEntry* a, const FileSystemEntry* b) {
+            return compareEntries(a, b);
+        });
+        const int row = static_cast<int>(it - m_entries.begin());
 
-    // Batch insert new entries
-    int offset = 0;
-    int currentOriginalRow = -1;
-    QList<FileSystemEntry*> batchItems;
-    for (int i = 0; i < newEntries.size(); ++i) {
-        const auto entry = newEntries[i];
-        const int originalRow = insertRows[i];
-
-        if (currentOriginalRow == -1) {
-            currentOriginalRow = originalRow;
-            batchItems << entry;
-        } else if (originalRow == currentOriginalRow) {
-            batchItems << entry;
-        } else {
-            int insertPos = currentOriginalRow + offset;
-            beginInsertRows(QModelIndex(), insertPos, insertPos + static_cast<int>(batchItems.size()) - 1);
-            for (int j = 0; j < batchItems.size(); ++j) {
-                m_entries.insert(insertPos + j, batchItems[j]);
-            }
-            endInsertRows();
-
-            offset += batchItems.size();
-            currentOriginalRow = originalRow;
-            batchItems.clear();
-            batchItems << entry;
+        // Extend the run while the next new entry still sorts before the existing element at row
+        int j = i + 1;
+        while (j < newEntries.size() && (row >= m_entries.size() || compareEntries(newEntries[j], m_entries[row]))) {
+            ++j;
         }
-    }
-    if (!batchItems.isEmpty()) {
-        int insertPos = currentOriginalRow + offset;
-        beginInsertRows(QModelIndex(), insertPos, insertPos + static_cast<int>(batchItems.size()) - 1);
-        for (int j = 0; j < batchItems.size(); ++j) {
-            m_entries.insert(insertPos + j, batchItems[j]);
+
+        beginInsertRows(QModelIndex(), row, row + (j - i) - 1);
+        for (int k = i; k < j; ++k) {
+            m_entries.insert(row + (k - i), newEntries[k]);
         }
         endInsertRows();
+
+        i = j;
     }
 
     emit entriesChanged();

--- a/shell/plugin/src/Caelestia/requests.cpp
+++ b/shell/plugin/src/Caelestia/requests.cpp
@@ -1,15 +1,33 @@
 #include "requests.hpp"
 
+#include <qjsvalue.h>
 #include <qjsvalueiterator.h>
 #include <qloggingcategory.h>
 #include <qnetworkaccessmanager.h>
 #include <qnetworkcookiejar.h>
 #include <qnetworkreply.h>
 #include <qnetworkrequest.h>
+#include <qqmlengine.h>
+#include <qvariant.h>
 
 Q_LOGGING_CATEGORY(lcRequests, "caelestia.requests", QtInfoMsg)
 
 namespace caelestia {
+
+namespace {
+
+QVariantMap responseMetadata(const QNetworkReply* reply) {
+    QVariantMap headers;
+
+    for (const auto& [name, value] : reply->rawHeaderPairs()) {
+        headers.insert(QString::fromLatin1(name).toLower(), QString::fromLatin1(value));
+    }
+
+    return { { "statusCode", reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() },
+        { "headers", headers } };
+}
+
+} // namespace
 
 Requests::Requests(QObject* parent)
     : QObject(parent)
@@ -38,11 +56,17 @@ void Requests::get(const QUrl& url, QJSValue onSuccess, QJSValue onError, QJSVal
 
     auto reply = m_manager->get(request);
 
-    QObject::connect(reply, &QNetworkReply::finished, [reply, onSuccess, onError]() {
+    QObject::connect(reply, &QNetworkReply::finished, this, [this, reply, onSuccess, onError]() {
+        const QString body = QString::fromUtf8(reply->readAll());
+
+        QJSValue metadata;
+        if (auto* engine = qmlEngine(this))
+            metadata = engine->toScriptValue(responseMetadata(reply));
+
         if (reply->error() == QNetworkReply::NoError) {
-            onSuccess.call({ QString(reply->readAll()) });
+            onSuccess.call({ body, metadata });
         } else if (onError.isCallable()) {
-            onError.call({ reply->errorString() });
+            onError.call({ reply->errorString(), metadata });
         } else {
             qCWarning(lcRequests) << "get: request failed with error" << reply->errorString();
         }

--- a/shell/scripts/qml-lint-conventions.py
+++ b/shell/scripts/qml-lint-conventions.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 """Checks QML files for Qt coding convention violations.
 
 https://doc.qt.io/qt-6/qml-codingconventions.html
@@ -52,6 +54,7 @@ SECTION_NAMES = {
 RULE_COLOURS = {
     "file-structure": RED,
     "import-order": GREEN,
+    "missing-scriptmodel-import": RED,
     "section-order": YELLOW,
     "missing-section-separator": CYAN,
     "blank-after-open-brace": MAGENTA,
@@ -59,6 +62,46 @@ RULE_COLOURS = {
 }
 
 IMPORT_RE = re.compile(r"^import\s+(\S+)")
+SCRIPT_MODEL_RE = re.compile(r"\bScriptModel\s*\{")
+
+
+def check_scriptmodel_import(lines: list[str], rel: str) -> list["Violation"]:
+    """Ensure files using ScriptModel import its required provider modules."""
+    violations: list["Violation"] = []
+
+    first_scriptmodel_line = None
+    for i, line in enumerate(lines):
+        if SCRIPT_MODEL_RE.search(line):
+            first_scriptmodel_line = i + 1
+            break
+
+    if first_scriptmodel_line is None:
+        return violations
+
+    has_qs_utils_import = any(line.strip().startswith("import qs.utils") for line in lines)
+    has_quickshell_import = any(re.match(r"^import\s+Quickshell(?:\.|\s|$)", line.strip()) for line in lines)
+
+    if not has_qs_utils_import:
+        violations.append(
+            Violation(
+                rel,
+                first_scriptmodel_line,
+                "missing-scriptmodel-import",
+                "ScriptModel is used but 'import qs.utils' is missing",
+            )
+        )
+
+    if not has_quickshell_import:
+        violations.append(
+            Violation(
+                rel,
+                first_scriptmodel_line,
+                "missing-scriptmodel-import",
+                "ScriptModel is used but no 'import Quickshell' provider import is present",
+            )
+        )
+
+    return violations
 
 
 def import_group(module: str) -> tuple[int, int] | None:
@@ -479,6 +522,7 @@ def check_file(filepath: Path) -> list[Violation]:
 
     violations.extend(check_file_structure(lines, rel))
     violations.extend(check_imports(filepath, lines, rel))
+    violations.extend(check_scriptmodel_import(lines, rel))
 
     scopes: dict[str, ScopeTracker] = {}  # indent -> tracker
     in_block_comment = False

--- a/shell/services/Weather.qml
+++ b/shell/services/Weather.qml
@@ -178,7 +178,7 @@ Singleton {
         } else if ((!loc || timer.elapsed() > 900) && !ipApiRequestPending && Date.now() >= ipApiBlockedUntil) {
             ipApiRequestPending = true;
 
-            Requests.get("http://ip-api.com/json?fields=status,message,city,lat,lon", (text, metadata) => {
+            Requests.get("https://ip-api.com/json?fields=status,message,city,lat,lon", (text, metadata) => {
                 ipApiRequestPending = false;
                 if (recordIpApiRateLimit(metadata))
                     return;

--- a/shell/services/Weather.qml
+++ b/shell/services/Weather.qml
@@ -20,6 +20,9 @@ Singleton {
     property list<var> locationSearchResults: []
     property int locationSearchToken: 0
 
+    property bool ipApiRequestPending: false
+    property double ipApiBlockedUntil: 0
+
     readonly property string icon: cc ? Icons.getWeatherIcon(cc.weatherCode) : "cloud_alert"
     readonly property string description: cc?.weatherDesc ?? qsTr("No weather")
     readonly property string temp: formatTemp(cc?.tempC)
@@ -172,19 +175,116 @@ Singleton {
             } else {
                 fetchCoordsFromCity(configLocation, true);
             }
-        } else if (!loc || timer.elapsed() > 900) {
-            Requests.get("https://ipinfo.io/json", text => {
-                const response = JSON.parse(text);
-                if (response.loc) {
-                    loc = response.loc;
-                    city = response.city ?? "";
-                    timer.restart();
+        } else if ((!loc || timer.elapsed() > 900) && !ipApiRequestPending && Date.now() >= ipApiBlockedUntil) {
+            ipApiRequestPending = true;
+
+            Requests.get("http://ip-api.com/json?fields=status,message,city,lat,lon", (text, metadata) => {
+                ipApiRequestPending = false;
+                recordIpApiRateLimit(metadata);
+
+                // Protect against stale responses overwriting the manually-set location,
+                // in case the config was updated while this request was in-flight.
+                if (GlobalConfig.services.weatherLocation)
+                    return;
+
+                let response;
+                try {
+                    response = JSON.parse(text);
+                } catch (error) {
+                    console.warn(lc, `Unable to parse response from ip-api: ${error}`);
+                    return;
                 }
+
+                const lat = Number(response.lat);
+                const lon = Number(response.lon);
+
+                if (response.status !== "success" || !Number.isFinite(lat) || !Number.isFinite(lon)) {
+                    console.warn(lc, `ip-api lookup failed: ${response.message ?? "invalid response"}`);
+                    return;
+                }
+
+                city = fixCityName(response.city ?? "");
+                timer.restart();
+                loc = `${lat},${lon}`;
+            }, (error, metadata) => {
+                ipApiRequestPending = false;
+
+                if (!recordIpApiRateLimit(metadata))
+                    console.warn(lc, `ip-api request failed: ${error}`);
             });
         }
     }
 
-    function fetchCityFromCoords(coords) {
+    function recordIpApiRateLimit(metadata: var): bool {
+        const remainingHeader = metadata?.headers?.["x-rl"];
+        const exhausted = remainingHeader !== undefined && Number(remainingHeader) === 0;
+
+        if (metadata?.statusCode !== 429 && !exhausted)
+            return false;
+
+        const ttlHeader = metadata?.headers?.["x-ttl"];
+        const ttl = Number(ttlHeader);
+
+        const delaySeconds = Number.isFinite(ttl) ? Math.max(1, Math.ceil(ttl) + 1) : 61;
+
+        const delayMs = delaySeconds * 1000;
+        ipApiBlockedUntil = Date.now() + delayMs;
+        ipApiRetryTimer.interval = delayMs;
+        ipApiRetryTimer.restart();
+
+        return true;
+    }
+
+    function fixCityName(cityName: string): string {
+        if (!cityName)
+            return "";
+        const mapping = {
+            // Polish
+            "Poznan": "Poznań",
+            "Wroclaw": "Wrocław",
+            "Krakow": "Kraków",
+            "Gdansk": "Gdańsk",
+            "Lodz": "Łódź",
+            "Rzeszow": "Rzeszów",
+            "Torun": "Toruń",
+            "Bialystok": "Białystok",
+            "Czestochowa": "Częstochowa",
+            "Plock": "Płock",
+            "Ruda Slaska": "Ruda Śląska",
+            "Dabrowa Gornicza": "Dąbrowa Górnicza",
+            "Elblag": "Elbląg",
+            "Gorzow Wielkopolski": "Gorzów Wielkopolski",
+            "Zielona Gora": "Zielona Góra",
+            "Slupsk": "Słupsk",
+
+            // German
+            "Munchen": "München",
+            "Koln": "Köln",
+            "Dusseldorf": "Düsseldorf",
+            "Nurnberg": "Nürnberg",
+
+            // French & Spanish & Portuguese
+            "Sao Paulo": "São Paulo",
+            "Montreal": "Montréal",
+            "Quebec": "Québec",
+            "Bogota": "Bogotá",
+            "Medellin": "Medellín",
+            "Cordoba": "Córdoba",
+
+            // Turkish
+            "Istanbul": "İstanbul",
+            "Izmir": "İzmir",
+
+            // Scandinavian & others
+            "Malmo": "Malmö",
+            "Goteborg": "Göteborg",
+            "Zurich": "Zürich",
+            "Geneve": "Genève"
+        };
+        return mapping[cityName] || cityName;
+    }
+
+    function fetchCityFromCoords(coords: string): void {
         if (cachedCities.has(coords)) {
             city = cachedCities.get(coords);
             return;
@@ -378,7 +478,31 @@ Singleton {
         onTriggered: fetchWeatherData()
     }
 
+    Timer {
+        id: ipApiRetryTimer
+
+        repeat: false
+
+        onTriggered: {
+            const remaining = root.ipApiBlockedUntil - Date.now();
+
+            if (remaining > 0) {
+                interval = Math.ceil(remaining);
+                restart();
+            } else {
+                root.reload();
+            }
+        }
+    }
+
     ElapsedTimer {
         id: timer
+    }
+
+    LoggingCategory {
+        id: lc
+
+        name: "caelestia.qml.services.weather"
+        defaultLogLevel: LoggingCategory.Info
     }
 }

--- a/shell/services/Weather.qml
+++ b/shell/services/Weather.qml
@@ -180,8 +180,8 @@ Singleton {
 
             Requests.get("http://ip-api.com/json?fields=status,message,city,lat,lon", (text, metadata) => {
                 ipApiRequestPending = false;
-                recordIpApiRateLimit(metadata);
-
+                if (recordIpApiRateLimit(metadata))
+                    return;
                 // Protect against stale responses overwriting the manually-set location,
                 // in case the config was updated while this request was in-flight.
                 if (GlobalConfig.services.weatherLocation)

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -26,6 +26,7 @@ ShellRoot {
     settings.watchFiles: false
 
     GSFLoader {}
+    ServiceLoader {}
 
     Background {}
     // BadAppleOverlay {}


### PR DESCRIPTION
NetworkList.qml now caps the main Wi-Fi list and opens the network-detail flow.
NetworkPage.qml now has the All networks, Saved networks, VPN providers, and Add network entry points.
AllNetworksPage.qml, SavedNetworksPage.qml, NetworkDetailPage.qml, AddNetworkPage.qml, EthernetDetailPage.qml, and AddVpnPage.qml were added to mirror the upstream structure
NexusState.qml now tracks whether a network detail page came from Saved networks.