### PR TITLE
fix(previews): request zkde_screencast so window thumbnails render

### DIFF
--- a/assets/org.quickshell.desktop
+++ b/assets/org.quickshell.desktop
@@ -1,0 +1,28 @@
+[Desktop Entry]
+Version=1.5
+Type=Application
+NoDisplay=true
+
+Name=Quickshell
+Icon=org.quickshell
+
+# Installed to ~/.local/share/applications, overriding the packaged
+# /usr/share/applications/org.quickshell.desktop.
+#
+# KWin only advertises its privileged Wayland interfaces to clients whose
+# desktop file asks for them: it takes the client's executable (/proc/<pid>/exe),
+# looks for an installed .desktop whose Exec resolves to that same binary, and
+# reads X-KDE-Wayland-Interfaces from it. Quickshell's packaged file has no Exec
+# line at all, so the shell matches nothing and zkde_screencast_unstable_v1 is
+# never offered — live window thumbnails stay empty and fall back to the app
+# icon in both the dock hover popup and the window switcher.
+#
+# zkde_screencast_unstable_v1 is what lets the shell ask KWin for a live
+# PipeWire feed of a single window, which is exactly how Plasma's own Task
+# Manager draws its taskbar thumbnails (org.kde.plasmashell.desktop requests
+# the same interface). org_kde_plasma_window_management goes with it for
+# window metadata.
+#
+# Delete this file to revoke that, then run: kbuildsycoca6
+Exec=/usr/bin/quickshell
+X-KDE-Wayland-Interfaces=zkde_screencast_unstable_v1,org_kde_plasma_window_management

--- a/scripts/08-build-shell.sh
+++ b/scripts/08-build-shell.sh
@@ -126,17 +126,6 @@ cmake --install build || {
     exit 1
 }
 
-# Live window thumbnails: KWin hands out zkde_screencast_unstable_v1 only to
-# clients whose desktop file requests it, and Quickshell's packaged entry has no
-# Exec line to match on. Override it per-user, then refresh the KService cache
-# KWin reads. Without this the dock hover popup and window switcher fall back to
-# showing the app icon instead of a live preview.
-if [ -f "$BUNDLE_DIR/assets/org.quickshell.desktop" ]; then
-    mkdir -p ~/.local/share/applications
-    cp --remove-destination "$BUNDLE_DIR/assets/org.quickshell.desktop" ~/.local/share/applications/org.quickshell.desktop 2>/dev/null || true
-    kbuildsycoca6 >/dev/null 2>&1 || true
-fi
-
 # Validate critical QML module presence before declaring success.
 CONFIG_MODULE_DIR="$HOME/.local/lib/qt6/qml/Caelestia/Config"
 if [[ ! -f "$CONFIG_MODULE_DIR/qmldir" ]]; then

--- a/scripts/08-build-shell.sh
+++ b/scripts/08-build-shell.sh
@@ -126,6 +126,17 @@ cmake --install build || {
     exit 1
 }
 
+# Live window thumbnails: KWin hands out zkde_screencast_unstable_v1 only to
+# clients whose desktop file requests it, and Quickshell's packaged entry has no
+# Exec line to match on. Override it per-user, then refresh the KService cache
+# KWin reads. Without this the dock hover popup and window switcher fall back to
+# showing the app icon instead of a live preview.
+if [ -f "$BUNDLE_DIR/assets/org.quickshell.desktop" ]; then
+    mkdir -p ~/.local/share/applications
+    cp --remove-destination "$BUNDLE_DIR/assets/org.quickshell.desktop" ~/.local/share/applications/org.quickshell.desktop 2>/dev/null || true
+    kbuildsycoca6 >/dev/null 2>&1 || true
+fi
+
 # Validate critical QML module presence before declaring success.
 CONFIG_MODULE_DIR="$HOME/.local/lib/qt6/qml/Caelestia/Config"
 if [[ ! -f "$CONFIG_MODULE_DIR/qmldir" ]]; then

--- a/scripts/10-autostart.sh
+++ b/scripts/10-autostart.sh
@@ -2,6 +2,10 @@
 # 06-autostart.sh  Set up autostart entries for Quickshell and kde-material-you-colors.
 # Idempotent: overwrites .desktop files with correct content each run.
 
+# Resolve the bundle root the same way the build script does, so this works
+# whether the installer exports it or the script is run directly.
+BUNDLE_DIR="${BUNDLE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
 AUTOSTART_DIR="$HOME/.config/autostart"
 mkdir -p "$AUTOSTART_DIR"
 mkdir -p "$HOME/.local/bin"
@@ -139,6 +143,29 @@ EOF
     echo "  [OK]  kde-material-you-colors systemd service enabled."
 else
     echo "  [SKIP] Skipping kde-material-you-colors systemd service."
+fi
+
+# Live window thumbnails.
+#
+# KWin only advertises its privileged Wayland interfaces to clients whose
+# desktop file requests them: it resolves the client's /proc/<pid>/exe, then
+# looks for an installed .desktop whose Exec resolves to that same binary and
+# reads X-KDE-Wayland-Interfaces from it. Quickshell's packaged entry has no
+# Exec line at all, so the shell matches nothing and zkde_screencast_unstable_v1
+# is never offered — the dock hover popup and window switcher then fall back to
+# drawing the app icon instead of a live preview.
+#
+# Note this cannot live on the autostart entry above: KWin matches on the
+# resolved executable, and that entry's Exec is the wrapper script rather than
+# the quickshell binary, so it never matches.
+if [[ -f "$BUNDLE_DIR/assets/org.quickshell.desktop" ]]; then
+    echo "  Requesting KWin screencast interface for window previews..."
+    mkdir -p "$HOME/.local/share/applications"
+    cp --remove-destination "$BUNDLE_DIR/assets/org.quickshell.desktop" \
+        "$HOME/.local/share/applications/org.quickshell.desktop" 2>/dev/null || true
+    # KWin reads this through KService, which needs its cache rebuilt.
+    kbuildsycoca6 >/dev/null 2>&1 || true
+    echo "  [OK]  Window preview interface requested."
 fi
 
 echo "[OK]  Autostart entries configured."


### PR DESCRIPTION
## What

Window thumbnails in the dock hover popup and the window switcher never render — both fall back to drawing the app icon.

## Why

The QML side is already correct: `WindowScreencastRequest` asks KWin for a per-window PipeWire feed over `zkde_screencast_unstable_v1`. The request just never becomes active on a stock install.

KWin gates its privileged Wayland interfaces on the **client's desktop file**. It resolves the client's `/proc/<pid>/exe`, searches installed `.desktop` files for one whose `Exec` resolves to that same binary, and reads `X-KDE-Wayland-Interfaces` from it.

Quickshell's packaged `/usr/share/applications/org.quickshell.desktop` has **no `Exec` line at all**, so the shell matches no service and the interface is never advertised to it. Nothing logs an error — the stream simply stays inactive, which is why this looks like "previews are broken" rather than "previews are not permitted".

## Fix

Ship a per-user override declaring the interface — the same one `org.kde.plasmashell.desktop` requests to draw its own taskbar thumbnails — and install it from the build script, running `kbuildsycoca6` so KWin sees it through ksycoca.

## Verified

On `kwin_wayland` 6.x, after install + shell restart:

```
WindowScreencastGlobal: zkde_screencast_unstable_v1 bound successfully.
WindowScreencastRequest: objectSerial arrived = 3415 for uuid "{630ebc08-...}"
nodeId = 235
```

Thumbnails render live in both the dock hover popup and the window switcher.

## Notes

- `NoDisplay=true` is kept, and does not break the lookup — plasmashell sets it too.
- `qs` is a symlink to `/usr/bin/quickshell`; KWin matches the resolved path, so `Exec` points at `quickshell`.
- The file documents itself, including how to revoke it (delete + `kbuildsycoca6`).
- Touches `scripts/08-build-shell.sh`, as does #(game icons PR) — whichever lands second needs a trivial rebase.
