### PR TITLE
feat(ai): Claude Code, ChatGPT, Gemini and OpenRouter providers

### DIFF
--- a/sdata/arch-dist/installDP.sh
+++ b/sdata/arch-dist/installDP.sh
@@ -31,7 +31,7 @@ PACKAGE_GROUP="${PACKAGE_GROUP:-all}"
 CORE_PACKAGES=(
     cmake ninja ccache
     wl-clipboard cliphist wl-clip-persist inotify-tools app2unit wireplumber trash-cli jq aubio lm_sensors
-    libpipewire glibc libcava qt6-declarative gcc-libs qt6-base qt6-declarative qt6-wayland libqalculate kpipewire kglobalaccel kglobalacceld
+    libpipewire glibc libcava qt6-declarative gcc-libs qt6-base qt6-declarative qt6-wayland libqalculate kpipewire kglobalaccel kglobalacceld libsecret
 )
 
 SHELL_PACKAGES=(

--- a/sdata/fedora-dist/installDP_fedora.sh
+++ b/sdata/fedora-dist/installDP_fedora.sh
@@ -18,7 +18,7 @@ PACKAGE_GROUP="${PACKAGE_GROUP:-all}"
 CORE_PACKAGES=(
     cmake ninja-build ccache
     wl-clipboard cliphist wl-clip-persist inotify-tools wireplumber trash-cli jq aubio lm_sensors lm_sensors-devel
-    pipewire-devel glibc qt6-qtdeclarative qt6-qtdeclarative-devel qt6-qtwayland qt6-qtwayland-devel kf6-kglobalaccel-devel qt6-qtbase-private-devel qt6-qtsvg qt6-qtsvg-devel qt6-qtshadertools-devel libgcc qt6-qtbase libqalculate libqalculate-devel aubio-devel kf6-kpipewire kf6-kpipewire-devel kf6-kwindowsystem-devel
+    pipewire-devel glibc qt6-qtdeclarative qt6-qtdeclarative-devel qt6-qtwayland qt6-qtwayland-devel kf6-kglobalaccel-devel qt6-qtbase-private-devel qt6-qtsvg qt6-qtsvg-devel qt6-qtshadertools-devel libgcc qt6-qtbase libqalculate libqalculate-devel aubio-devel kf6-kpipewire kf6-kpipewire-devel kf6-kwindowsystem-devel libsecret
 )
 
 SHELL_PACKAGES=(

--- a/shell/modules/nexus/PageCompRegistry.qml
+++ b/shell/modules/nexus/PageCompRegistry.qml
@@ -250,6 +250,13 @@ QtObject {
                     AboutPage {}
                 }
             }
+        },
+        Component {
+            StackPage {
+                Component {
+                    AiSettingsPage {}
+                }
+            }
         }
     ]
 

--- a/shell/modules/nexus/PageRegistry.qml
+++ b/shell/modules/nexus/PageRegistry.qml
@@ -186,5 +186,13 @@ QtObject {
             description: qsTr("System information, credits"),
             category: "system"
         },
+
+        // AI
+        {
+            label: qsTr("AI Assistant"),
+            icon: "smart_toy",
+            description: qsTr("Claude Code, accounts, providers"),
+            category: "controls"
+        },
     ]
 }

--- a/shell/modules/nexus/pages/AiSettingsPage.qml
+++ b/shell/modules/nexus/pages/AiSettingsPage.qml
@@ -16,10 +16,73 @@ PageBase {
 
     title: qsTr("AI Assistant")
 
+    // API key entry for one provider. The value is pushed back out through
+    // committed() so each instance keeps a plain static binding to its own
+    // config field rather than looking one up by name.
+    component ApiKeyField: ColumnLayout {
+        id: keyField
+
+        property string value
+        property string envName
+
+        signal committed(string v)
+
+        Layout.fillWidth: true
+        spacing: Tokens.spacing.small
+
+        ConnectedRect {
+            first: true
+            last: true
+            Layout.fillWidth: true
+            implicitHeight: keyRow.implicitHeight + Tokens.padding.medium * 2
+
+            RowLayout {
+                id: keyRow
+                anchors.fill: parent
+                anchors.margins: Tokens.padding.medium
+                anchors.leftMargin: Tokens.padding.largeIncreased
+                anchors.rightMargin: Tokens.padding.largeIncreased
+                spacing: Tokens.spacing.medium
+
+                StyledText {
+                    text: qsTr("API key")
+                    font: Tokens.font.body.small
+                    color: Colours.palette.m3onSurface
+                }
+                StyledInputField {
+                    Layout.fillWidth: true
+                    horizontalAlignment: TextInput.AlignLeft
+                    text: keyField.value
+                    onEditingFinished: keyField.committed(text)
+                }
+            }
+        }
+
+        StyledText {
+            Layout.fillWidth: true
+            Layout.leftMargin: Tokens.padding.largeIncreased
+            text: qsTr("The %1 environment variable overrides this value.").arg(keyField.envName)
+            color: Colours.palette.m3outline
+            font: Tokens.font.label.small
+            wrapMode: Text.Wrap
+        }
+    }
+
     property string claudeVersion: ""
     readonly property bool claudeInstalled: claudeVersion !== "" && claudeVersion !== "NOT_INSTALLED"
     property bool installing: false
     property string installStatus: ""
+
+    // `claude --version` prints "2.1.220 (Claude Code)"; the bare number is what
+    // reads well next to the published one.
+    readonly property string claudeVersionShort: {
+        const m = (claudeVersion || "").match(/[0-9]+\.[0-9]+\.[0-9]+/);
+        return m ? m[0] : claudeVersion;
+    }
+
+    // Ask what the newest published version is whenever this page is opened, so
+    // the button below is offering the right action rather than a stale one.
+    Component.onCompleted: UpdateChecker.checkClaudeCodeUpdate()
 
     function homeDir() {
         return Quickshell.env("HOME") || "";
@@ -176,6 +239,9 @@ PageBase {
                 root.installing = false;
                 root.installStatus = code === 0 ? qsTr("Installed.") : (qsTr("Failed") + " (" + code + ")");
                 root.refreshStatus();
+                // Re-read both versions so the button settles on "Check for
+                // updates" instead of still offering the update just applied.
+                UpdateChecker.checkClaudeCodeUpdate();
             }
         }
 
@@ -236,74 +302,109 @@ PageBase {
             onToggled: GlobalConfig.ai.enableClaudeCode = checked
         }
         ToggleRow {
-            last: true
             text: qsTr("Enable Claude API (API key)")
             subtext: qsTr("Pay-per-token HTTP API; needs ANTHROPIC_API_KEY")
             checked: GlobalConfig.ai.enableClaude
             onToggled: GlobalConfig.ai.enableClaude = checked
         }
+        ToggleRow {
+            text: qsTr("Enable ChatGPT (API key)")
+            subtext: qsTr("OpenAI pay-per-token API; needs OPENAI_API_KEY")
+            checked: GlobalConfig.ai.enableOpenai
+            onToggled: GlobalConfig.ai.enableOpenai = checked
+        }
+        ToggleRow {
+            text: qsTr("Enable Gemini (API key)")
+            subtext: qsTr("Google's OpenAI-compatible endpoint; needs GEMINI_API_KEY")
+            checked: GlobalConfig.ai.enableGemini
+            onToggled: GlobalConfig.ai.enableGemini = checked
+        }
+        ToggleRow {
+            last: true
+            text: qsTr("Enable OpenRouter (API key)")
+            subtext: qsTr("One key for many vendors' models; needs OPENROUTER_API_KEY")
+            checked: GlobalConfig.ai.enableOpenrouter
+            onToggled: GlobalConfig.ai.enableOpenrouter = checked
+        }
 
-        // API key input — only when Claude API is enabled.
-        ColumnLayout {
-            Layout.fillWidth: true
+        // Key entry, shown only for the providers that are actually enabled.
+        ApiKeyField {
             visible: GlobalConfig.ai.enableClaude
-            spacing: Tokens.spacing.small
-
-            ConnectedRect {
-                first: true
-                last: true
-                Layout.fillWidth: true
-                implicitHeight: apiKeyRow.implicitHeight + Tokens.padding.medium * 2
-
-                RowLayout {
-                    id: apiKeyRow
-                    anchors.fill: parent
-                    anchors.margins: Tokens.padding.medium
-                    anchors.leftMargin: Tokens.padding.largeIncreased
-                    anchors.rightMargin: Tokens.padding.largeIncreased
-                    spacing: Tokens.spacing.medium
-
-                    StyledText {
-                        text: qsTr("API key")
-                        font: Tokens.font.body.small
-                        color: Colours.palette.m3onSurface
-                    }
-                    StyledInputField {
-                        Layout.fillWidth: true
-                        horizontalAlignment: TextInput.AlignLeft
-                        text: GlobalConfig.ai.anthropicApiKey
-                        onEditingFinished: GlobalConfig.ai.anthropicApiKey = text
-                    }
-                }
-            }
-
-            StyledText {
-                Layout.fillWidth: true
-                Layout.leftMargin: Tokens.padding.largeIncreased
-                text: qsTr("The ANTHROPIC_API_KEY environment variable overrides this value.")
-                color: Colours.palette.m3outline
-                font: Tokens.font.label.small
-                wrapMode: Text.Wrap
-            }
+            value: GlobalConfig.ai.anthropicApiKey
+            envName: "ANTHROPIC_API_KEY"
+            onCommitted: v => GlobalConfig.ai.anthropicApiKey = v
+        }
+        ApiKeyField {
+            visible: GlobalConfig.ai.enableOpenai
+            value: GlobalConfig.ai.openaiApiKey
+            envName: "OPENAI_API_KEY"
+            onCommitted: v => GlobalConfig.ai.openaiApiKey = v
+        }
+        ApiKeyField {
+            visible: GlobalConfig.ai.enableGemini
+            value: GlobalConfig.ai.geminiApiKey
+            envName: "GEMINI_API_KEY"
+            onCommitted: v => GlobalConfig.ai.geminiApiKey = v
+        }
+        ApiKeyField {
+            visible: GlobalConfig.ai.enableOpenrouter
+            value: GlobalConfig.ai.openrouterApiKey
+            envName: "OPENROUTER_API_KEY"
+            onCommitted: v => GlobalConfig.ai.openrouterApiKey = v
         }
 
         // ── Claude Code ────────────────────────────────────────────
+        // Everything below is only meaningful while the provider is on, so it
+        // follows the toggle the same way the API key fields do.
         SectionHeader {
+            visible: GlobalConfig.ai.enableClaudeCode
             text: qsTr("Claude Code")
         }
         InfoRow {
+            visible: GlobalConfig.ai.enableClaudeCode
             first: true
             label: qsTr("Status")
-            value: root.claudeInstalled ? root.claudeVersion : qsTr("Not installed")
+            value: {
+                if (!root.claudeInstalled)
+                    return qsTr("Not installed");
+                if (UpdateChecker.claudeCodeHasUpdate)
+                    return root.claudeVersionShort + " → " + UpdateChecker.claudeCodeLatestVersion;
+                return root.claudeVersionShort;
+            }
         }
         NavRow {
+            visible: GlobalConfig.ai.enableClaudeCode
             last: true
-            icon: "download"
-            label: root.claudeInstalled ? qsTr("Update Claude Code") : qsTr("Install Claude Code")
-            status: root.installing ? (root.installStatus || qsTr("Installing…")) : root.installStatus
-            onClicked: {
+            // One button, three jobs: install it, update it, or — when it is
+            // already current — re-check whether that is still true.
+            icon: root.claudeInstalled && !UpdateChecker.claudeCodeHasUpdate ? "refresh" : "download"
+            label: {
+                if (!root.claudeInstalled)
+                    return qsTr("Download Claude Code");
+                if (UpdateChecker.claudeCodeHasUpdate)
+                    return qsTr("Update Claude Code");
+                return qsTr("Check for updates");
+            }
+            status: {
                 if (root.installing)
+                    return root.installStatus || qsTr("Installing…");
+                if (UpdateChecker.claudeCodeChecking)
+                    return qsTr("Checking…");
+                if (root.installStatus !== "")
+                    return root.installStatus;
+                if (root.claudeInstalled && !UpdateChecker.claudeCodeHasUpdate && UpdateChecker.claudeCodeLatestVersion !== "")
+                    return qsTr("Up to date");
+                return "";
+            }
+            onClicked: {
+                if (root.installing || UpdateChecker.claudeCodeChecking)
                     return;
+                // Up to date — the button is a re-check, not a reinstall.
+                if (root.claudeInstalled && !UpdateChecker.claudeCodeHasUpdate) {
+                    root.installStatus = "";
+                    UpdateChecker.checkClaudeCodeUpdate();
+                    return;
+                }
                 root.installing = true;
                 root.installStatus = qsTr("Installing…");
                 installProc.running = true;
@@ -312,6 +413,7 @@ PageBase {
 
         // ── Accounts ───────────────────────────────────────────────
         SectionHeader {
+            visible: GlobalConfig.ai.enableClaudeCode
             text: qsTr("Claude accounts")
         }
         Repeater {
@@ -325,6 +427,7 @@ PageBase {
                 readonly property bool isActive: (GlobalConfig.ai.activeClaudeAccount || "") === modelData.id
                 readonly property bool isDefault: modelData.id === ""
 
+                visible: GlobalConfig.ai.enableClaudeCode
                 Layout.fillWidth: true
                 first: index === 0
                 implicitHeight: accRow.implicitHeight + Tokens.padding.medium * 2
@@ -384,6 +487,7 @@ PageBase {
             }
         }
         NavRow {
+            visible: GlobalConfig.ai.enableClaudeCode
             icon: "login"
             label: qsTr("Log in to selected account")
             status: root.claudeInstalled ? "" : qsTr("Install Claude Code first")
@@ -393,6 +497,7 @@ PageBase {
             }
         }
         NavRow {
+            visible: GlobalConfig.ai.enableClaudeCode
             last: true
             icon: "person_add"
             label: qsTr("Add another account & log in")

--- a/shell/modules/nexus/pages/AiSettingsPage.qml
+++ b/shell/modules/nexus/pages/AiSettingsPage.qml
@@ -61,11 +61,31 @@ PageBase {
         StyledText {
             Layout.fillWidth: true
             Layout.leftMargin: Tokens.padding.largeIncreased
-            text: qsTr("The %1 environment variable overrides this value.").arg(keyField.envName)
+            text: qsTr("Stored in your session keyring, not in shell.json. The %1 environment variable overrides it.").arg(keyField.envName)
             color: Colours.palette.m3outline
             font: Tokens.font.label.small
             wrapMode: Text.Wrap
         }
+    }
+
+    // Keys are held in the session keyring, not shell.json — see AiAssistant.
+    property var keyringKeys: ({})
+
+    function apiKeyFor(p) {
+        return root.keyringKeys[p] || "";
+    }
+
+    function storeApiKey(p, key) {
+        const m = root.keyringKeys;
+        m[p] = key;
+        root.keyringKeys = Object.assign({}, m);
+        const attr = "caelestia-ai-" + p;
+        const script = key === ""
+            ? "secret-tool clear service caelestia key " + JSON.stringify(attr)
+            : "printf %s \"$1\" | secret-tool store --label=" + JSON.stringify("Caelestia " + p + " API key") +
+              " service caelestia key " + JSON.stringify(attr);
+        keyStoreProc.command = key === "" ? ["sh", "-c", script] : ["sh", "-c", script, "--", key];
+        keyStoreProc.running = true;
     }
 
     property string claudeVersion: ""
@@ -82,7 +102,16 @@ PageBase {
 
     // Ask what the newest published version is whenever this page is opened, so
     // the button below is offering the right action rather than a stale one.
-    Component.onCompleted: UpdateChecker.checkClaudeCodeUpdate()
+    Component.onCompleted: {
+        UpdateChecker.checkClaudeCodeUpdate();
+        loadStoredKeys();
+    }
+
+    function loadStoredKeys() {
+        const provs = ["claude", "openai", "gemini", "openrouter"];
+        for (let i = 0; i < provs.length; i++)
+            keyLoadComp.createObject(root, { provider: provs[i] });
+    }
 
     function homeDir() {
         return Quickshell.env("HOME") || "";
@@ -218,6 +247,32 @@ PageBase {
         // Non-visual helpers live inside the single Item child (PageBase's default
         // property is one Item; Process objects are kept as layout resources).
         Process {
+            id: keyStoreProc
+        }
+
+        Component {
+            id: keyLoadComp
+
+            Process {
+                id: kl
+                required property string provider
+                running: true
+                command: ["secret-tool", "lookup", "service", "caelestia", "key", "caelestia-ai-" + provider]
+                stdout: StdioCollector {
+                    onStreamFinished: {
+                        const k = (text || "").trim();
+                        if (k !== "") {
+                            const m = root.keyringKeys;
+                            m[kl.provider] = k;
+                            root.keyringKeys = Object.assign({}, m);
+                        }
+                        kl.destroy();
+                    }
+                }
+            }
+        }
+
+        Process {
             id: statusProc
             running: true
             command: ["sh", "-c", "test -x " + JSON.stringify(root.claudeBin()) + " && " + JSON.stringify(root.claudeBin()) + " --version 2>/dev/null || echo NOT_INSTALLED"]
@@ -330,27 +385,27 @@ PageBase {
         // Key entry, shown only for the providers that are actually enabled.
         ApiKeyField {
             visible: GlobalConfig.ai.enableClaude
-            value: GlobalConfig.ai.anthropicApiKey
+            value: root.apiKeyFor("claude")
             envName: "ANTHROPIC_API_KEY"
-            onCommitted: v => GlobalConfig.ai.anthropicApiKey = v
+            onCommitted: v => root.storeApiKey("claude", v)
         }
         ApiKeyField {
             visible: GlobalConfig.ai.enableOpenai
-            value: GlobalConfig.ai.openaiApiKey
+            value: root.apiKeyFor("openai")
             envName: "OPENAI_API_KEY"
-            onCommitted: v => GlobalConfig.ai.openaiApiKey = v
+            onCommitted: v => root.storeApiKey("openai", v)
         }
         ApiKeyField {
             visible: GlobalConfig.ai.enableGemini
-            value: GlobalConfig.ai.geminiApiKey
+            value: root.apiKeyFor("gemini")
             envName: "GEMINI_API_KEY"
-            onCommitted: v => GlobalConfig.ai.geminiApiKey = v
+            onCommitted: v => root.storeApiKey("gemini", v)
         }
         ApiKeyField {
             visible: GlobalConfig.ai.enableOpenrouter
-            value: GlobalConfig.ai.openrouterApiKey
+            value: root.apiKeyFor("openrouter")
             envName: "OPENROUTER_API_KEY"
-            onCommitted: v => GlobalConfig.ai.openrouterApiKey = v
+            onCommitted: v => root.storeApiKey("openrouter", v)
         }
 
         // ── Claude Code ────────────────────────────────────────────

--- a/shell/modules/nexus/pages/AiSettingsPage.qml
+++ b/shell/modules/nexus/pages/AiSettingsPage.qml
@@ -1,0 +1,406 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Io
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.utils
+import qs.modules.nexus.common
+
+PageBase {
+    id: root
+
+    title: qsTr("AI Assistant")
+
+    property string claudeVersion: ""
+    readonly property bool claudeInstalled: claudeVersion !== "" && claudeVersion !== "NOT_INSTALLED"
+    property bool installing: false
+    property string installStatus: ""
+
+    function homeDir() {
+        return Quickshell.env("HOME") || "";
+    }
+    function claudeBin() {
+        return homeDir() + "/.local/bin/claude";
+    }
+    function refreshStatus() {
+        statusProc.running = false;
+        statusProc.running = true;
+    }
+
+    // Real login names / emails resolved from each account's .claude.json.
+    property var resolvedNames: ({})
+    property var resolvedEmails: ({})
+    function accountJsonPath(id) {
+        if (!id || id === "")
+            return homeDir() + "/.claude.json";
+        return homeDir() + "/.config/caelestia/claude/" + id + "/.claude.json";
+    }
+    function accountIds() {
+        const a = accounts();
+        const ids = [];
+        for (let i = 0; i < a.length; i++)
+            ids.push(a[i].id);
+        return ids;
+    }
+    function displayName(id, fallback) {
+        return resolvedNames[id] || fallback;
+    }
+
+    // ---- Account helpers (mirror AiAssistant's model) ----
+    function accounts() {
+        const list = [{ id: "", name: qsTr("Default"), dir: "" }];
+        try {
+            const parsed = JSON.parse(GlobalConfig.ai.claudeAccountsJson || "[]");
+            if (Array.isArray(parsed))
+                for (let i = 0; i < parsed.length; i++) {
+                    const a = parsed[i];
+                    if (a && a.id)
+                        list.push({
+                            id: String(a.id),
+                            name: String(a.name || a.id),
+                            dir: root.homeDir() + "/.config/caelestia/claude/" + String(a.id)
+                        });
+                }
+        } catch (e) {}
+        return list;
+    }
+    function accountDir(id) {
+        const a = accounts();
+        for (let i = 0; i < a.length; i++)
+            if (a[i].id === id)
+                return a[i].dir;
+        return "";
+    }
+    function rawAccounts() {
+        try {
+            const p = JSON.parse(GlobalConfig.ai.claudeAccountsJson || "[]");
+            if (Array.isArray(p))
+                return p;
+        } catch (e) {}
+        return [];
+    }
+    function addAndLogin() {
+        const arr = rawAccounts();
+        const id = "acc_" + Date.now();
+        arr.push({ id: id, name: qsTr("Account") + " " + (arr.length + 1) });
+        GlobalConfig.ai.claudeAccountsJson = JSON.stringify(arr);
+        GlobalConfig.ai.activeClaudeAccount = id;
+        loginActive();
+    }
+    // Drop any added account whose login resolves to an email already used by an
+    // earlier account (default first) — e.g. logging a new slot into the same account.
+    function dedupAccounts() {
+        const arr = rawAccounts();
+        const seen = {};
+        const def = resolvedEmails[""];
+        if (def)
+            seen[def] = true;
+        const kept = [];
+        let removedActive = false;
+        for (let i = 0; i < arr.length; i++) {
+            const a = arr[i];
+            const em = resolvedEmails[a.id];
+            if (em && seen[em]) {
+                if ((GlobalConfig.ai.activeClaudeAccount || "") === a.id)
+                    removedActive = true;
+                continue;
+            }
+            if (em)
+                seen[em] = true;
+            kept.push(a);
+        }
+        if (kept.length !== arr.length) {
+            GlobalConfig.ai.claudeAccountsJson = JSON.stringify(kept);
+            if (removedActive)
+                GlobalConfig.ai.activeClaudeAccount = "";
+        }
+    }
+    function removeAccount(id) {
+        if (!id || id === "")
+            return; // the Default (~/.claude) account is the system login — not removable
+        const arr = rawAccounts().filter(a => a && a.id !== id);
+        GlobalConfig.ai.claudeAccountsJson = JSON.stringify(arr);
+        if ((GlobalConfig.ai.activeClaudeAccount || "") === id)
+            GlobalConfig.ai.activeClaudeAccount = "";
+    }
+    // Log out the Default (~/.claude) login so a different account can sign in.
+    // This clears the CLI's base credentials (WinTone01), not the Claude Desktop app.
+    function logoutDefault() {
+        logoutProc.command = ["sh", "-c", JSON.stringify(root.claudeBin()) + " auth logout"];
+        logoutProc.running = true;
+    }
+    function loginActive() {
+        const id = GlobalConfig.ai.activeClaudeAccount || "";
+        const dir = accountDir(id);
+        const term = GlobalConfig.ai.loginTerminal || "konsole";
+        let inner = "";
+        if (dir !== "")
+            inner = "mkdir -p " + JSON.stringify(dir) + "; export CLAUDE_CONFIG_DIR=" + JSON.stringify(dir) + "; ";
+        inner += JSON.stringify(root.claudeBin()) + " auth login; echo; echo " + JSON.stringify(qsTr("Login done? You can close this window.")) + "; read -n1";
+        loginProc.command = [term, "-e", "sh", "-lc", inner];
+        loginProc.running = true;
+    }
+
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.large
+
+        // Non-visual helpers live inside the single Item child (PageBase's default
+        // property is one Item; Process objects are kept as layout resources).
+        Process {
+            id: statusProc
+            running: true
+            command: ["sh", "-c", "test -x " + JSON.stringify(root.claudeBin()) + " && " + JSON.stringify(root.claudeBin()) + " --version 2>/dev/null || echo NOT_INSTALLED"]
+            stdout: StdioCollector {
+                onStreamFinished: root.claudeVersion = (text || "").trim()
+            }
+        }
+
+        Process {
+            id: installProc
+            command: ["sh", "-c", "curl -fsSL https://claude.ai/install.sh | bash"]
+            stdout: SplitParser {
+                onRead: line => root.installStatus = line
+            }
+            stderr: SplitParser {
+                onRead: line => root.installStatus = line
+            }
+            onExited: code => {
+                root.installing = false;
+                root.installStatus = code === 0 ? qsTr("Installed.") : (qsTr("Failed") + " (" + code + ")");
+                root.refreshStatus();
+            }
+        }
+
+        Process {
+            id: loginProc
+        }
+
+        Process {
+            id: logoutProc
+            onExited: root.refreshStatus()
+        }
+
+        // Resolve real login names from each account's .claude.json.
+        Instantiator {
+            model: root.accountIds()
+            delegate: FileView {
+                required property string modelData
+                path: root.accountJsonPath(modelData)
+                printErrors: false
+                watchChanges: false
+                onLoaded: {
+                    try {
+                        const d = JSON.parse(text());
+                        const oa = d.oauthAccount || {};
+                        const email = oa.emailAddress || "";
+                        const nm = oa.displayName || email || "";
+                        if (nm) {
+                            const map = root.resolvedNames;
+                            map[modelData] = nm;
+                            root.resolvedNames = Object.assign({}, map);
+                        }
+                        if (email) {
+                            const em = root.resolvedEmails;
+                            em[modelData] = email;
+                            root.resolvedEmails = Object.assign({}, em);
+                            root.dedupAccounts();
+                        }
+                    } catch (e) {}
+                }
+            }
+        }
+
+        // ── Providers ──────────────────────────────────────────────
+        SectionHeader {
+            first: true
+            text: qsTr("Providers")
+        }
+        ToggleRow {
+            first: true
+            text: qsTr("Enable Ollama")
+            checked: GlobalConfig.ai.enableOllama
+            onToggled: GlobalConfig.ai.enableOllama = checked
+        }
+        ToggleRow {
+            text: qsTr("Enable Claude Code")
+            subtext: qsTr("Uses the claude CLI + your Claude login — no API key")
+            checked: GlobalConfig.ai.enableClaudeCode
+            onToggled: GlobalConfig.ai.enableClaudeCode = checked
+        }
+        ToggleRow {
+            last: true
+            text: qsTr("Enable Claude API (API key)")
+            subtext: qsTr("Pay-per-token HTTP API; needs ANTHROPIC_API_KEY")
+            checked: GlobalConfig.ai.enableClaude
+            onToggled: GlobalConfig.ai.enableClaude = checked
+        }
+
+        // API key input — only when Claude API is enabled.
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: GlobalConfig.ai.enableClaude
+            spacing: Tokens.spacing.small
+
+            ConnectedRect {
+                first: true
+                last: true
+                Layout.fillWidth: true
+                implicitHeight: apiKeyRow.implicitHeight + Tokens.padding.medium * 2
+
+                RowLayout {
+                    id: apiKeyRow
+                    anchors.fill: parent
+                    anchors.margins: Tokens.padding.medium
+                    anchors.leftMargin: Tokens.padding.largeIncreased
+                    anchors.rightMargin: Tokens.padding.largeIncreased
+                    spacing: Tokens.spacing.medium
+
+                    StyledText {
+                        text: qsTr("API key")
+                        font: Tokens.font.body.small
+                        color: Colours.palette.m3onSurface
+                    }
+                    StyledInputField {
+                        Layout.fillWidth: true
+                        horizontalAlignment: TextInput.AlignLeft
+                        text: GlobalConfig.ai.anthropicApiKey
+                        onEditingFinished: GlobalConfig.ai.anthropicApiKey = text
+                    }
+                }
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                Layout.leftMargin: Tokens.padding.largeIncreased
+                text: qsTr("The ANTHROPIC_API_KEY environment variable overrides this value.")
+                color: Colours.palette.m3outline
+                font: Tokens.font.label.small
+                wrapMode: Text.Wrap
+            }
+        }
+
+        // ── Claude Code ────────────────────────────────────────────
+        SectionHeader {
+            text: qsTr("Claude Code")
+        }
+        InfoRow {
+            first: true
+            label: qsTr("Status")
+            value: root.claudeInstalled ? root.claudeVersion : qsTr("Not installed")
+        }
+        NavRow {
+            last: true
+            icon: "download"
+            label: root.claudeInstalled ? qsTr("Update Claude Code") : qsTr("Install Claude Code")
+            status: root.installing ? (root.installStatus || qsTr("Installing…")) : root.installStatus
+            onClicked: {
+                if (root.installing)
+                    return;
+                root.installing = true;
+                root.installStatus = qsTr("Installing…");
+                installProc.running = true;
+            }
+        }
+
+        // ── Accounts ───────────────────────────────────────────────
+        SectionHeader {
+            text: qsTr("Claude accounts")
+        }
+        Repeater {
+            model: root.accounts()
+
+            ConnectedRect {
+                id: accRect
+                required property var modelData
+                required property int index
+
+                readonly property bool isActive: (GlobalConfig.ai.activeClaudeAccount || "") === modelData.id
+                readonly property bool isDefault: modelData.id === ""
+
+                Layout.fillWidth: true
+                first: index === 0
+                implicitHeight: accRow.implicitHeight + Tokens.padding.medium * 2
+
+                StateLayer {
+                    onClicked: GlobalConfig.ai.activeClaudeAccount = accRect.modelData.id
+                }
+
+                RowLayout {
+                    id: accRow
+                    anchors.fill: parent
+                    anchors.margins: Tokens.padding.medium
+                    anchors.leftMargin: Tokens.padding.largeIncreased
+                    anchors.rightMargin: Tokens.padding.largeIncreased
+                    spacing: Tokens.spacing.medium
+
+                    MaterialIcon {
+                        text: accRect.isActive ? "check_circle" : "person"
+                        color: Colours.palette.m3onSurfaceVariant
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 0
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: root.displayName(accRect.modelData.id, accRect.modelData.name)
+                            font: Tokens.font.body.small
+                            elide: Text.ElideRight
+                        }
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: accRect.isActive ? qsTr("Active") : qsTr("Tap to select")
+                            color: Colours.palette.m3outline
+                            font: Tokens.font.label.small
+                            elide: Text.ElideRight
+                        }
+                    }
+
+                    // Named accounts get a delete button; the Default (system login)
+                    // gets a log-out button that clears its ~/.claude credentials.
+                    MaterialIcon {
+                        text: accRect.isDefault ? "logout" : "delete"
+                        color: delMouse.containsMouse ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
+
+                        MouseArea {
+                            id: delMouse
+                            anchors.fill: parent
+                            anchors.margins: -8
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: accRect.isDefault ? root.logoutDefault() : root.removeAccount(accRect.modelData.id)
+                        }
+                    }
+                }
+            }
+        }
+        NavRow {
+            icon: "login"
+            label: qsTr("Log in to selected account")
+            status: root.claudeInstalled ? "" : qsTr("Install Claude Code first")
+            onClicked: {
+                if (root.claudeInstalled)
+                    root.loginActive();
+            }
+        }
+        NavRow {
+            last: true
+            icon: "person_add"
+            label: qsTr("Add another account & log in")
+            status: root.claudeInstalled ? qsTr("Log into a different Claude account") : qsTr("Install Claude Code first")
+            onClicked: {
+                if (root.claudeInstalled)
+                    root.addAndLogin();
+            }
+        }
+    }
+}

--- a/shell/modules/nexus/pages/UtilitiesPage.qml
+++ b/shell/modules/nexus/pages/UtilitiesPage.qml
@@ -45,7 +45,7 @@ PageBase {
             StyledText {
                 width: parent.width
                 wrapMode: Text.Wrap
-                text: qsTr("The AI Assistant supports three providers:\n\n• Claude Code (recommended) — uses your Claude subscription through the 'claude' CLI. No API key needed.\n• Ollama — fully local models for maximum privacy (install Ollama, then e.g. 'ollama run llama3').\n• Claude API — pay-per-token; needs an API key (or the ANTHROPIC_API_KEY env var).\n\nInstall Claude Code, log in, add accounts and toggle providers in Settings → AI Assistant. Pick the active provider and model from the selectors at the top of the chat.\n\nThe assistant tab appears in the sidebar whenever at least one provider is enabled.")
+                text: qsTr("The AI Assistant supports several providers:\n\n• Claude Code (recommended) — uses your Claude subscription through the 'claude' CLI. No API key needed.\n• Ollama — fully local models for maximum privacy (install Ollama, then e.g. 'ollama run llama3').\n• Claude API, ChatGPT, Gemini, OpenRouter — pay-per-token; each needs its own API key (or the matching ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY / OPENROUTER_API_KEY env var, which takes precedence).\n\nInstall Claude Code, log in, add accounts, toggle providers and enter keys in Settings → AI Assistant. Pick the active provider and model from the selectors at the top of the chat.\n\nThe assistant tab appears in the sidebar whenever at least one provider is enabled.")
             }
         }
 

--- a/shell/modules/nexus/pages/UtilitiesPage.qml
+++ b/shell/modules/nexus/pages/UtilitiesPage.qml
@@ -45,21 +45,21 @@ PageBase {
             StyledText {
                 width: parent.width
                 wrapMode: Text.Wrap
-                text: qsTr("Caelestia's AI assistant runs entirely locally using Ollama for maximum privacy. No API keys are required!\n\nTo enable it:\n1. Install Ollama (e.g. 'sudo pacman -S ollama')\n2. Start the Ollama daemon\n3. Download a model (e.g., 'ollama run llama3')\n\nOnce Ollama is running on port 11434, the assistant connects automatically.")
+                text: qsTr("The AI Assistant supports three providers:\n\n• Claude Code (recommended) — uses your Claude subscription through the 'claude' CLI. No API key needed.\n• Ollama — fully local models for maximum privacy (install Ollama, then e.g. 'ollama run llama3').\n• Claude API — pay-per-token; needs an API key (or the ANTHROPIC_API_KEY env var).\n\nInstall Claude Code, log in, add accounts and toggle providers in Settings → AI Assistant. Pick the active provider and model from the selectors at the top of the chat.\n\nThe assistant tab appears in the sidebar whenever at least one provider is enabled.")
             }
         }
 
         ToggleRow {
-            text: qsTr("Enable Assistant")
-            subtext: qsTr("Show the AI Assistant in the sidebar")
-            checked: GlobalConfig.ai.enableOllama
-            onToggled: GlobalConfig.ai.enableOllama = checked
+            text: qsTr("Enable AI Assistant")
+            subtext: qsTr("Show the AI Assistant tab in the sidebar — manage providers in Settings → AI Assistant")
+            checked: GlobalConfig.ai.enableAiAssistant
+            onToggled: GlobalConfig.ai.enableAiAssistant = checked
         }
 
         ToggleRow {
             last: true
             text: qsTr("Enable Tool Usage")
-            subtext: qsTr("Allow the assistant to search the web, take screenshots, etc.")
+            subtext: qsTr("Lets Ollama / Claude API models use built-in tools (web search, screenshots…). Claude Code has its own agent tools and ignores this.")
             checked: GlobalConfig.ai.enableCelestialMode
             onToggled: GlobalConfig.ai.enableCelestialMode = checked
         }

--- a/shell/modules/sidebar/AiAssistant.qml
+++ b/shell/modules/sidebar/AiAssistant.qml
@@ -64,9 +64,18 @@ Item {
     
     property real savedContentY: -1
 
+    // Refresh the model list when switching to an OpenAI-compatible provider, so a
+    // key added after startup takes effect without a reload.
+    onProviderChanged: {
+        if (isOpenaiCompat)
+            fetchOpenaiCompatModels(provider);
+        else if (isClaude)
+            fetchClaudeModels();
+    }
+
     onVisibleChanged: {
         if (visible) {
-            fetchOllamaModels();
+            refreshAllModels();
             if (savedContentY >= 0) {
                 Qt.callLater(function() { listView.contentY = savedContentY; });
             }
@@ -85,27 +94,74 @@ Item {
         listView.positionViewAtEnd();
     }
 
-    Component.onCompleted: {
+    // Ask every enabled provider what it offers, rather than shipping lists that
+    // go stale each time a vendor releases a model.
+    function refreshAllModels() {
         fetchOllamaModels();
         fetchClaudeCodeModels();
+        fetchClaudeModels();
+        const compat = ["openai", "gemini", "openrouter"];
+        for (var i = 0; i < compat.length; i++) {
+            if (providerList.indexOf(compat[i]) !== -1)
+                fetchOpenaiCompatModels(compat[i]);
+        }
+    }
+
+    Component.onCompleted: {
+        refreshAllModels();
         loadHistory();
     }
 
     property var ollamaModelsList: []
 
-    // Static curated list of Claude models (Anthropic has no public "list models"
-    // discovery that the free-form chat needs; these are the current chat-capable IDs).
-    readonly property var claudeModelsList: [
-        "claude-sonnet-5",
-        "claude-opus-4-8",
-        "claude-opus-4-7",
-        "claude-haiku-4-5"
-    ]
+    // Every provider's model list is discovered from that provider, so none of
+    // them need editing here when a vendor ships a new model. Anthropic's list
+    // comes from GET /v1/models (needs the API key the provider requires anyway).
+    property var claudeModelsList: []
 
-    // "Model" choices for the Claude Code (subscription CLI) provider. "default"
-    // means: don't pass --model, let the CLI use the subscription's default.
-    // Populated at startup by fetchClaudeCodeModels() from the installed CLI binary.
-    property var claudeCodeModelsList: ["default", "opus", "sonnet", "haiku"]
+    function fetchClaudeModels() {
+        const key = root.getApiKeyFor("claude");
+        if (key === "")
+            return;
+        const base = GlobalConfig.ai.anthropicUrl || "https://api.anthropic.com";
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", base + "/v1/models?limit=100", true);
+        xhr.setRequestHeader("x-api-key", key);
+        xhr.setRequestHeader("anthropic-version", "2023-06-01");
+        xhr.setRequestHeader("anthropic-dangerous-direct-browser-access", "true");
+        xhr.onreadystatechange = () => {
+            if (xhr.readyState !== XMLHttpRequest.DONE)
+                return;
+            if (xhr.status !== 200) {
+                Logger.log("[AI] Claude model list failed (status " + xhr.status + ")");
+                return;
+            }
+            try {
+                const parsed = JSON.parse(xhr.responseText);
+                var list = [];
+                for (var i = 0; i < (parsed.data || []).length; i++) {
+                    if (parsed.data[i].id)
+                        list.push(parsed.data[i].id);
+                }
+                if (list.length === 0)
+                    return;
+                // Newest first — the API returns them in creation order.
+                list.reverse();
+                root.claudeModelsList = list;
+                if (list.indexOf(GlobalConfig.ai.defaultClaudeModel) === -1)
+                    GlobalConfig.ai.defaultClaudeModel = list[0];
+            } catch (e) {
+                Logger.log("[AI] Error parsing Claude models: " + e.message);
+            }
+        };
+        xhr.send();
+    }
+
+    // Model choices for the Claude Code (subscription CLI) provider. "default"
+    // means: don't pass --model at all and let the CLI use whatever the
+    // subscription defaults to. The concrete ids are read out of the installed
+    // binary by fetchClaudeCodeModels(), so they track the CLI as it updates.
+    property var claudeCodeModelsList: ["default"]
 
     // Effort/thinking levels vary per model: recent models add xhigh/max, some support
     // fewer, and several (haiku, older sonnet, opus ≤4.1) support none at all. Returns
@@ -180,25 +236,39 @@ Item {
     }
 
     function applyClaudeCodeModels(text) {
-        var out = ["default", "opus", "sonnet", "haiku"];
+        // The binary also embeds unrelated strings that merely start with "claude-"
+        // and long-dead models, so only ids shaped like <family>-<version> survive,
+        // minus dated snapshots (…-20250514) and the ".0" aliases of a base version.
+        var ids = [];
         var seen = {};
-        for (var k = 0; k < out.length; k++)
-            seen[out[k]] = true;
-        var lines = (text || "").split("\n");
+        const lines = (text || "").split("\n");
         for (var i = 0; i < lines.length; i++) {
-            var id = lines[i].trim();
-            if (id === "")
+            const id = lines[i].trim();
+            if (id === "" || seen[id])
                 continue;
-            // Drop dated snapshots (…-20250514) and the deprecated .0 base versions
-            // (claude-opus-4-0, claude-sonnet-4-0) — these aren't selectable models.
             if (/-\d{5,}$/.test(id) || /-0$/.test(id))
                 continue;
-            if (!seen[id]) {
-                out.push(id);
-                seen[id] = true;
-            }
+            seen[id] = true;
+            ids.push(id);
         }
-        claudeCodeModelsList = out;
+
+        // A family's bare major ("claude-opus-4") is just a stub for its newest
+        // minor, so drop it when a more specific id for the same major exists.
+        ids = ids.filter(id => !ids.some(other => other !== id && other.indexOf(id + "-") === 0));
+
+        // Newest first: sort by family version, descending.
+        ids.sort((a, b) => {
+            const va = (a.match(/\d+/g) || []).map(Number);
+            const vb = (b.match(/\d+/g) || []).map(Number);
+            for (var k = 0; k < Math.max(va.length, vb.length); k++) {
+                const d = (vb[k] || 0) - (va[k] || 0);
+                if (d !== 0)
+                    return d;
+            }
+            return a.localeCompare(b);
+        });
+
+        claudeCodeModelsList = ["default"].concat(ids);
     }
 
     // Currently selected provider ("ollama" | "claude-code" | "claude"), persisted in config.
@@ -352,20 +422,64 @@ Item {
     }
 
     // Resolve the Anthropic API key: ANTHROPIC_API_KEY env var wins, config field is the fallback.
-    function getApiKey() {
-        var envKey = Quickshell.env("ANTHROPIC_API_KEY");
-        if (envKey && envKey.trim() !== "")
-            return envKey.trim();
-        return (GlobalConfig.ai.anthropicApiKey || "").trim();
+    // OpenAI, Gemini and OpenRouter all expose the same /chat/completions and
+    // /models API, so they share one request/parse path and differ only in the
+    // three values below.
+    readonly property bool isOpenaiCompat: provider === "openai" || provider === "gemini" || provider === "openrouter"
+
+    function openaiCompatBase(p) {
+        const which = p || provider;
+        if (which === "gemini")
+            return GlobalConfig.ai.geminiUrl || "https://generativelanguage.googleapis.com/v1beta/openai";
+        if (which === "openrouter")
+            return GlobalConfig.ai.openrouterUrl || "https://openrouter.ai/api/v1";
+        return GlobalConfig.ai.openaiUrl || "https://api.openai.com/v1";
     }
 
-    // The model to send for the active provider.
+    // The API key for a provider. The environment variable wins over the config
+    // field, so a key exported in the session is never overridden by a stale one
+    // saved in settings.
+    function getApiKeyFor(p) {
+        const which = p || provider;
+        var envName = "ANTHROPIC_API_KEY";
+        var configured = GlobalConfig.ai.anthropicApiKey;
+        if (which === "openai") {
+            envName = "OPENAI_API_KEY";
+            configured = GlobalConfig.ai.openaiApiKey;
+        } else if (which === "gemini") {
+            envName = "GEMINI_API_KEY";
+            configured = GlobalConfig.ai.geminiApiKey;
+        } else if (which === "openrouter") {
+            envName = "OPENROUTER_API_KEY";
+            configured = GlobalConfig.ai.openrouterApiKey;
+        }
+        const envKey = Quickshell.env(envName);
+        if (envKey && envKey.trim() !== "")
+            return envKey.trim();
+        return (configured || "").trim();
+    }
+
+    function getApiKey() {
+        return root.getApiKeyFor(root.provider);
+    }
+
+    // Providers that need a key before they can send anything.
+    readonly property bool needsApiKey: isClaude || isOpenaiCompat
+
+    // The model to send for the active provider. Nothing is hardcoded: until a
+    // provider's list has been fetched the saved choice is used as-is, and when
+    // there is no saved choice the first model the provider offered wins.
     function activeModel() {
         if (isClaudeCode)
             return GlobalConfig.ai.defaultClaudeCodeModel || "default";
         if (isClaude)
-            return GlobalConfig.ai.defaultClaudeModel || "claude-sonnet-5";
-        return GlobalConfig.ai.defaultOllamaModel || "llama3";
+            return GlobalConfig.ai.defaultClaudeModel || root.claudeModelsList[0] || "";
+        if (isOpenaiCompat) {
+            const cfgKey = provider === "openai" ? "defaultOpenaiModel"
+                         : provider === "gemini" ? "defaultGeminiModel" : "defaultOpenrouterModel";
+            return GlobalConfig.ai[cfgKey] || root.openaiCompatModelList()[0] || "";
+        }
+        return GlobalConfig.ai.defaultOllamaModel || root.ollamaModelsList[0] || "";
     }
 
     // Providers exposed in the provider selector (respecting the enable toggles).
@@ -377,6 +491,12 @@ Item {
             l.push("claude-code");
         if (GlobalConfig.ai.enableClaude)
             l.push("claude");
+        if (GlobalConfig.ai.enableOpenai)
+            l.push("openai");
+        if (GlobalConfig.ai.enableGemini)
+            l.push("gemini");
+        if (GlobalConfig.ai.enableOpenrouter)
+            l.push("openrouter");
         if (l.length === 0)
             l.push("ollama");
         return l;
@@ -387,6 +507,12 @@ Item {
             return "Claude Code";
         if (p === "claude")
             return "Claude API";
+        if (p === "openai")
+            return "ChatGPT";
+        if (p === "gemini")
+            return "Gemini";
+        if (p === "openrouter")
+            return "OpenRouter";
         return "Ollama";
     }
 
@@ -912,22 +1038,77 @@ Item {
                                 list.push(response.models[i].name);
                             }
                         }
-                        if (list.length > 0) {
-                            ollamaModelsList = list;
-                            if (list.indexOf(GlobalConfig.ai.defaultOllamaModel) === -1) {
-                                GlobalConfig.ai.defaultOllamaModel = list[0];
-                            }
-                        } else {
-                            ollamaModelsList = ["llama3", "mistral", "phi3", "gemma"];
-                        }
+                        // Only what this Ollama instance actually has pulled — a
+                        // guessed list would just offer models that aren't installed.
+                        ollamaModelsList = list;
+                        if (list.length > 0 && list.indexOf(GlobalConfig.ai.defaultOllamaModel) === -1)
+                            GlobalConfig.ai.defaultOllamaModel = list[0];
                     } catch (e) {
                         Logger.log("Error parsing Ollama models: " + e.message);
-                        ollamaModelsList = ["llama3", "mistral", "phi3", "gemma"];
                     }
                 } else {
                     Logger.log("Ollama tags request failed (status " + xhr.status + ")");
-                    ollamaModelsList = ["llama3", "mistral", "phi3", "gemma"];
                 }
+            }
+        };
+        xhr.send();
+    }
+
+    // Models offered by the OpenAI-compatible providers, keyed by provider id.
+    // Fetched from /models on demand; the fallbacks below are used until a fetch
+    // succeeds (and when it can't, e.g. no key yet).
+    property var openaiCompatModels: ({})
+
+    function openaiCompatModelList(p) {
+        return root.openaiCompatModels[p || provider] || [];
+    }
+
+    function fetchOpenaiCompatModels(p) {
+        const which = p || provider;
+        const key = root.getApiKeyFor(which);
+        // OpenRouter publishes its catalogue without auth; the other two need the key.
+        if (key === "" && which !== "openrouter")
+            return;
+
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", root.openaiCompatBase(which) + "/models", true);
+        if (key !== "")
+            xhr.setRequestHeader("Authorization", "Bearer " + key);
+        xhr.onreadystatechange = () => {
+            if (xhr.readyState !== XMLHttpRequest.DONE)
+                return;
+            if (xhr.status !== 200) {
+                Logger.log("[AI] " + root.providerLabel(which) + " model list failed (status " + xhr.status + ")");
+                return;
+            }
+            try {
+                const parsed = JSON.parse(xhr.responseText);
+                var list = [];
+                for (var i = 0; i < (parsed.data || []).length; i++) {
+                    const id = parsed.data[i].id;
+                    if (!id)
+                        continue;
+                    // Gemini prefixes ids with "models/"; the chat endpoint accepts either,
+                    // but the bare id is what users recognise.
+                    list.push(id.indexOf("models/") === 0 ? id.substring(7) : id);
+                }
+                // Only chat-capable models are useful here — drop embedding/audio/image ones.
+                list = list.filter(m => !/embed|whisper|tts|audio|image|vision-preview|moderation|rerank|dall-e/i.test(m));
+                list.sort();
+                if (list.length === 0)
+                    return;
+                var next = {};
+                for (var k in root.openaiCompatModels)
+                    next[k] = root.openaiCompatModels[k];
+                next[which] = list;
+                root.openaiCompatModels = next;
+
+                // Keep the saved default honest: if it isn't offered, fall back to the first.
+                const cfgKey = which === "openai" ? "defaultOpenaiModel" : (which === "gemini" ? "defaultGeminiModel" : "defaultOpenrouterModel");
+                if (list.indexOf(GlobalConfig.ai[cfgKey]) === -1)
+                    GlobalConfig.ai[cfgKey] = list[0];
+            } catch (e) {
+                Logger.log("[AI] Error parsing " + root.providerLabel(which) + " models: " + e.message);
             }
         };
         xhr.send();
@@ -1152,6 +1333,32 @@ Item {
             return;
         }
 
+        if (root.isOpenaiCompat) {
+            if (root.getApiKey() === "")
+                return;
+            xhr.open("POST", root.openaiCompatBase() + "/chat/completions", true);
+            xhr.setRequestHeader("Content-Type", "application/json");
+            xhr.setRequestHeader("Authorization", "Bearer " + root.getApiKey());
+            xhr.onreadystatechange = () => {
+                if (xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {
+                    try {
+                        var oaiParsed = JSON.parse(xhr.responseText);
+                        if (oaiParsed.choices && oaiParsed.choices.length > 0 && oaiParsed.choices[0].message)
+                            root.applyGeneratedTitle(chatId, oaiParsed.choices[0].message.content || "");
+                    } catch (e) {}
+                }
+            };
+            xhr.send(JSON.stringify({
+                model: root.activeModel(),
+                messages: [
+                    { role: "system", content: titleSystem },
+                    { role: "user", content: "Message: " + safeMsg + "\nTitle:" }
+                ],
+                stream: false
+            }));
+            return;
+        }
+
         var url = (GlobalConfig.ai.ollamaUrl || "http://localhost:11434") + "/api/generate";
         xhr.open("POST", url, true);
         xhr.setRequestHeader("Content-Type", "application/json");
@@ -1229,8 +1436,15 @@ Item {
             saveHistory();
         }
 
-        if (root.isClaude && root.getApiKey() === "") {
-            addAiMessage("⚠️ No Claude API key configured. Set the ANTHROPIC_API_KEY environment variable, or add a key in the AI settings.");
+        if (root.needsApiKey && root.getApiKey() === "") {
+            const envNames = {
+                "claude": "ANTHROPIC_API_KEY",
+                "openai": "OPENAI_API_KEY",
+                "gemini": "GEMINI_API_KEY",
+                "openrouter": "OPENROUTER_API_KEY"
+            };
+            addAiMessage("⚠️ No " + root.providerLabel(root.provider) + " API key configured. Set the "
+                + (envNames[root.provider] || "API") + " environment variable, or add a key in the AI settings.");
             return;
         }
 
@@ -1272,6 +1486,15 @@ Item {
             xhr.setRequestHeader("anthropic-version", "2023-06-01");
             // QML's XMLHttpRequest presents a browser-like origin; this header opts into direct access.
             xhr.setRequestHeader("anthropic-dangerous-direct-browser-access", "true");
+        } else if (root.isOpenaiCompat) {
+            xhr.open("POST", root.openaiCompatBase() + "/chat/completions", true);
+            xhr.setRequestHeader("Content-Type", "application/json");
+            xhr.setRequestHeader("Authorization", "Bearer " + root.getApiKey());
+            if (root.provider === "openrouter") {
+                // OpenRouter attributes requests to an app via these; harmless elsewhere.
+                xhr.setRequestHeader("HTTP-Referer", "https://github.com/ladybug-me/caelestia-dots-kde");
+                xhr.setRequestHeader("X-Title", "Caelestia Shell");
+            }
         } else {
             var ollamaUrl = GlobalConfig.ai.ollamaUrl || "http://localhost:11434";
             xhr.open("POST", ollamaUrl + "/api/chat", true);
@@ -1345,6 +1568,33 @@ Item {
                                         chunkReasoning = evt.delta.thinking || "";
                                 } else if (evt.type === "error") {
                                     Logger.log("[AI] Claude stream error: " + JSON.stringify(evt.error || {}));
+                                }
+                            } catch (e) {
+                                break;
+                            }
+                        } else if (root.isOpenaiCompat) {
+                            // OpenAI-compatible streaming: SSE where each "data:" line is a
+                            // chunk holding choices[0].delta. "[DONE]" ends the stream.
+                            if (line.indexOf("data:") !== 0) {
+                                processedTextLength += rawLine.length + 1;
+                                continue;
+                            }
+                            var oaiJson = line.substring(5).trim();
+                            if (oaiJson === "" || oaiJson === "[DONE]") {
+                                processedTextLength += rawLine.length + 1;
+                                continue;
+                            }
+                            try {
+                                var oaiEvt = JSON.parse(oaiJson);
+                                processedTextLength += rawLine.length + 1;
+                                if (oaiEvt.error) {
+                                    Logger.log("[AI] " + root.providerLabel(root.provider) + " stream error: " + JSON.stringify(oaiEvt.error));
+                                } else if (oaiEvt.choices && oaiEvt.choices.length > 0) {
+                                    var delta = oaiEvt.choices[0].delta || {};
+                                    chunkContent = delta.content || "";
+                                    // Reasoning models expose their thinking under different
+                                    // keys depending on the provider.
+                                    chunkReasoning = delta.reasoning_content || delta.reasoning || "";
                                 }
                             } catch (e) {
                                 break;
@@ -1499,8 +1749,8 @@ Item {
                             inAgentLoop = false;
                         }
                     } else {
-                        var providerName = root.isClaude ? "Claude" : "Ollama";
-                        var errMsg = (xhr.status === 0) ? "Generation cancelled" : (providerName + " request failed (status " + xhr.status + ")." + ((root.isClaude && xhr.status === 401) ? " Check your API key." : ""));
+                        var providerName = root.providerLabel(root.provider);
+                        var errMsg = (xhr.status === 0) ? "Generation cancelled" : (providerName + " request failed (status " + xhr.status + ")." + ((root.needsApiKey && (xhr.status === 401 || xhr.status === 403)) ? " Check your API key." : ""));
                         var currentText = chatHistory.get(chatHistory.count - 1).text;
                         if (currentText.trim() === "") {
                             chatHistory.setProperty(chatHistory.count - 1, "text", errMsg);
@@ -1581,7 +1831,16 @@ Item {
                     "content": promptText
                 };
                 if (base64Image) {
-                    toolMsg["images"] = [base64Image];
+                    if (root.isOpenaiCompat) {
+                        // OpenAI carries images inline in the content array as data URLs;
+                        // Ollama takes a separate base64 "images" field.
+                        toolMsg["content"] = [
+                            { "type": "text", "text": promptText },
+                            { "type": "image_url", "image_url": { "url": "data:image/jpeg;base64," + base64Image } }
+                        ];
+                    } else {
+                        toolMsg["images"] = [base64Image];
+                    }
                 }
                 messages.push(toolMsg);
             }
@@ -1781,6 +2040,12 @@ Item {
                          GlobalConfig.ai.claudeCodeEffort = "default";
                      } else if (root.isClaude)
                          GlobalConfig.ai.defaultClaudeModel = item.modelData;
+                     else if (root.provider === "openai")
+                         GlobalConfig.ai.defaultOpenaiModel = item.modelData;
+                     else if (root.provider === "gemini")
+                         GlobalConfig.ai.defaultGeminiModel = item.modelData;
+                     else if (root.provider === "openrouter")
+                         GlobalConfig.ai.defaultOpenrouterModel = item.modelData;
                      else
                          GlobalConfig.ai.defaultOllamaModel = item.modelData;
                  }
@@ -1798,7 +2063,9 @@ Item {
                              return root.claudeCodeModelsList;
                          if (root.isClaude)
                              return root.claudeModelsList;
-                         return root.ollamaModelsList && root.ollamaModelsList.length > 0 ? root.ollamaModelsList : ["llama3", "mistral", "phi3", "gemma"];
+                         if (root.isOpenaiCompat)
+                             return root.openaiCompatModelList();
+                         return root.ollamaModelsList;
                      }
 
                      delegate: MenuItem {

--- a/shell/modules/sidebar/AiAssistant.qml
+++ b/shell/modules/sidebar/AiAssistant.qml
@@ -109,6 +109,7 @@ Item {
     }
 
     Component.onCompleted: {
+        loadAllKeys();
         refreshAllModels();
         loadHistory();
     }
@@ -440,6 +441,72 @@ Item {
     // The API key for a provider. The environment variable wins over the config
     // field, so a key exported in the session is never overridden by a stale one
     // saved in settings.
+    // API keys live in the session keyring (Secret Service — KWallet on KDE,
+    // gnome-keyring elsewhere), not in shell.json. A config file is world-readable
+    // by anything running as the user and ends up in dotfile backups and git
+    // repos; a key is not the kind of thing to leave sitting there.
+    //
+    // The config fields are kept only so an existing plaintext key can be moved
+    // across once and then cleared.
+    property var keyringKeys: ({})
+
+    function keyringAttr(p) {
+        return "caelestia-ai-" + (p || provider);
+    }
+
+    function loadKeyring(p) {
+        const which = p || provider;
+        const cmd = ["secret-tool", "lookup", "service", "caelestia", "key", root.keyringAttr(which)];
+        const qml = 'import QtQuick\nimport Quickshell.Io\n' +
+            'Process {\n    id: kp\n    command: ' + JSON.stringify(cmd) + '\n' +
+            '    stdout: StdioCollector { onStreamFinished: root.onKeyringKey(' + JSON.stringify(which) + ', (text || "").trim(), kp); }\n' +
+            '    onExited: code => { if (code !== 0) kp.destroy(); }\n}';
+        try {
+            const o = Qt.createQmlObject(qml, root, "keyringProc");
+            o.running = true;
+        } catch (e) {}
+    }
+
+    function onKeyringKey(p, key, proc) {
+        if (key !== "") {
+            const m = root.keyringKeys;
+            m[p] = key;
+            root.keyringKeys = Object.assign({}, m);
+        }
+        if (proc)
+            proc.destroy();
+    }
+
+    function storeKeyring(p, key) {
+        const which = p || provider;
+        const m = root.keyringKeys;
+        m[which] = key;
+        root.keyringKeys = Object.assign({}, m);
+
+        const attr = root.keyringAttr(which);
+        // The key goes in on stdin so it never appears in the process list.
+        const script = key === ""
+            ? "secret-tool clear service caelestia key " + JSON.stringify(attr)
+            : "printf %s \"$1\" | secret-tool store --label=" + JSON.stringify("Caelestia " + which + " API key") +
+              " service caelestia key " + JSON.stringify(attr);
+        const cmd = key === "" ? ["sh", "-c", script] : ["sh", "-c", script, "--", key];
+        try {
+            const o = Qt.createQmlObject('import QtQuick\nimport Quickshell.Io\nProcess { id: sp; command: ' +
+                JSON.stringify(cmd) + '\n onExited: code => sp.destroy() }', root, "keyringStore");
+            o.running = true;
+        } catch (e) {}
+    }
+
+    // Move a key that predates keyring storage out of the config, once.
+    function migratePlaintextKey(p, configKey) {
+        const existing = (GlobalConfig.ai[configKey] || "").trim();
+        if (existing === "")
+            return;
+        root.storeKeyring(p, existing);
+        GlobalConfig.ai[configKey] = "";
+        Logger.log("[AI] moved " + p + " API key from shell.json into the keyring");
+    }
+
     function getApiKeyFor(p) {
         const which = p || provider;
         var envName = "ANTHROPIC_API_KEY";
@@ -457,7 +524,28 @@ Item {
         const envKey = Quickshell.env(envName);
         if (envKey && envKey.trim() !== "")
             return envKey.trim();
+
+        // Keyring next. A value still sitting in the config is a leftover from
+        // before keyring storage — hand it back this once, migrateKeys() moves it.
+        const stored = root.keyringKeys[which];
+        if (stored && stored !== "")
+            return stored;
         return (configured || "").trim();
+    }
+
+    // Config field backing each provider, used only for the one-time migration.
+    readonly property var legacyKeyFields: ({
+        "claude": "anthropicApiKey",
+        "openai": "openaiApiKey",
+        "gemini": "geminiApiKey",
+        "openrouter": "openrouterApiKey"
+    })
+
+    function loadAllKeys() {
+        for (const p in root.legacyKeyFields) {
+            root.loadKeyring(p);
+            root.migratePlaintextKey(p, root.legacyKeyFields[p]);
+        }
     }
 
     function getApiKey() {

--- a/shell/modules/sidebar/AiAssistant.qml
+++ b/shell/modules/sidebar/AiAssistant.qml
@@ -12,6 +12,7 @@ import qs.components.effects
 import qs.services
 import qs.utils
 import Quickshell
+import Quickshell.Io
 import M3Shapes
 import Caelestia.Blobs
 
@@ -86,10 +87,309 @@ Item {
 
     Component.onCompleted: {
         fetchOllamaModels();
+        fetchClaudeCodeModels();
         loadHistory();
     }
 
     property var ollamaModelsList: []
+
+    // Static curated list of Claude models (Anthropic has no public "list models"
+    // discovery that the free-form chat needs; these are the current chat-capable IDs).
+    readonly property var claudeModelsList: [
+        "claude-sonnet-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-haiku-4-5"
+    ]
+
+    // "Model" choices for the Claude Code (subscription CLI) provider. "default"
+    // means: don't pass --model, let the CLI use the subscription's default.
+    // Populated at startup by fetchClaudeCodeModels() from the installed CLI binary.
+    property var claudeCodeModelsList: ["default", "opus", "sonnet", "haiku"]
+
+    // Effort/thinking levels vary per model: recent models add xhigh/max, some support
+    // fewer, and several (haiku, older sonnet, opus ≤4.1) support none at all. Returns
+    // the valid levels for a given model ("" when the model has no effort control).
+    function effortLevelsFor(model) {
+        var m = String(model || "default").toLowerCase();
+        if (m === "haiku")
+            return [];
+        if (m === "default" || m === "opus" || m === "sonnet" || m === "fable")
+            return ["low", "medium", "high", "xhigh", "max"];
+
+        var fam = m.indexOf("opus") !== -1 ? "opus"
+                : m.indexOf("sonnet") !== -1 ? "sonnet"
+                : m.indexOf("haiku") !== -1 ? "haiku"
+                : m.indexOf("fable") !== -1 ? "fable" : "";
+        var nums = (m.match(/\d+/g) || []).map(Number);
+        var major = nums.length >= 1 ? nums[0] : 0;
+        var minor = nums.length >= 2 ? nums[1] : 0;
+
+        if (fam === "haiku")
+            return [];
+        if (fam === "fable")
+            return ["low", "medium", "high", "xhigh", "max"];
+        if (fam === "opus") {
+            if (major > 4 || (major === 4 && minor >= 7))
+                return ["low", "medium", "high", "xhigh", "max"];
+            if (major === 4 && minor === 6)
+                return ["low", "medium", "high", "max"];
+            if (major === 4 && minor === 5)
+                return ["low", "medium", "high"];
+            return [];
+        }
+        if (fam === "sonnet") {
+            if (major >= 5)
+                return ["low", "medium", "high", "xhigh", "max"];
+            if (major === 4 && minor === 6)
+                return ["low", "medium", "high", "max"];
+            return [];
+        }
+        return [];
+    }
+
+    // Effort choices for the currently-selected Claude Code model (empty = unsupported).
+    readonly property var claudeCodeEffortOptions: {
+        var lv = effortLevelsFor(activeModel());
+        return lv.length > 0 ? ["default"].concat(lv) : [];
+    }
+
+    // Extract the model IDs the installed `claude` binary knows about (a real
+    // "fetch" of what this CLI version supports), merged with the handy aliases.
+    function fetchClaudeCodeModels() {
+        var bin = claudeCodeBinPath();
+        var script =
+            "t=\"$(readlink -f " + JSON.stringify(bin) + " 2>/dev/null)\"; [ -z \"$t\" ] && t=" + JSON.stringify(bin) + "; " +
+            "strings \"$t\" 2>/dev/null | grep -oE 'claude-(opus|sonnet|haiku|fable)-[0-9]+(-[0-9]+)?' | sort -u";
+        var commandStr = JSON.stringify(["sh", "-c", script]);
+        var qml =
+            "import QtQuick\n" +
+            "import Quickshell.Io\n" +
+            "Process {\n" +
+            "    id: mp\n" +
+            "    command: " + commandStr + "\n" +
+            "    stdout: StdioCollector { onStreamFinished: root.applyClaudeCodeModels(text || \"\"); }\n" +
+            "    onExited: code => mp.destroy()\n" +
+            "}";
+        try {
+            var o = Qt.createQmlObject(qml, root, "ccModelsProc");
+            o.running = true;
+        } catch (e) {
+            Logger.log("[AI] claude-code model fetch error: " + e.message);
+        }
+    }
+
+    function applyClaudeCodeModels(text) {
+        var out = ["default", "opus", "sonnet", "haiku"];
+        var seen = {};
+        for (var k = 0; k < out.length; k++)
+            seen[out[k]] = true;
+        var lines = (text || "").split("\n");
+        for (var i = 0; i < lines.length; i++) {
+            var id = lines[i].trim();
+            if (id === "")
+                continue;
+            // Drop dated snapshots (…-20250514) and the deprecated .0 base versions
+            // (claude-opus-4-0, claude-sonnet-4-0) — these aren't selectable models.
+            if (/-\d{5,}$/.test(id) || /-0$/.test(id))
+                continue;
+            if (!seen[id]) {
+                out.push(id);
+                seen[id] = true;
+            }
+        }
+        claudeCodeModelsList = out;
+    }
+
+    // Currently selected provider ("ollama" | "claude-code" | "claude"), persisted in config.
+    readonly property string provider: GlobalConfig.ai.defaultProvider || "ollama"
+    readonly property bool isClaude: provider === "claude"       // Anthropic HTTP API (API key)
+    readonly property bool isClaudeCode: provider === "claude-code" // `claude` CLI (subscription)
+
+    // Runtime cache of Claude Code CLI session ids, keyed by chat id (also persisted
+    // into allChatSessions so --resume works across shell restarts).
+    property var claudeCodeSessions: ({})
+    property var currentClaudeCodeProc: null
+
+    // Prompt suggestions (Claude Code): starter prompts generated on demand.
+    property var promptSuggestions: []
+    property bool loadingSuggestions: false
+
+    function fetchPromptSuggestions() {
+        if (!isClaudeCode || loadingSuggestions)
+            return;
+        loadingSuggestions = true;
+        promptSuggestions = [];
+
+        // Gather recent conversation context + the current input draft so suggestions
+        // are relevant to what the user is doing (not generic starters).
+        var lines = [];
+        for (var li = 0; li < chatHistory.count; li++) {
+            var lm = chatHistory.get(li);
+            if (!lm.isUser && !lm.isFinished)
+                continue;
+            var lt = (lm.text || "").trim();
+            if (lt === "")
+                continue;
+            lines.push((lm.isUser ? "User" : "Assistant") + ": " + lt);
+        }
+        if (lines.length > 6)
+            lines = lines.slice(lines.length - 6);
+        var context = lines.join("\n");
+        var draft = "";
+        try {
+            draft = (inputArea.text || "").trim();
+        } catch (e) {}
+
+        var prompt;
+        if (context === "" && draft === "") {
+            prompt = "Suggest exactly 4 short, varied example prompts a user might ask a helpful AI desktop assistant. Reply with ONLY a JSON array of 4 short strings, nothing else.";
+        } else {
+            prompt = "You are suggesting what the user might type NEXT in this chat. Based only on the context below, propose exactly 4 short, specific follow-up prompts they are likely to want to send next. Reply with ONLY a JSON array of 4 short strings, nothing else.\n\n";
+            if (context !== "")
+                prompt += "Conversation so far:\n" + context + "\n\n";
+            if (draft !== "")
+                prompt += "The user has started typing: \"" + draft + "\"\n\n";
+        }
+
+        var cmd = [claudeCodeBinPath(), "-p", prompt, "--output-format", "json", "--dangerously-skip-permissions"];
+        var qml =
+            "import QtQuick\n" +
+            "import Quickshell.Io\n" +
+            "Process {\n" +
+            "    id: sp\n" +
+            "    command: " + JSON.stringify(cmd) + "\n" +
+            "    workingDirectory: " + JSON.stringify(claudeCodeCwd()) + "\n" +
+            claudeCodeEnvSnippet() +
+            "    stdout: StdioCollector { onStreamFinished: root.applyPromptSuggestions(text || \"\"); }\n" +
+            "    onExited: code => { root.loadingSuggestions = false; sp.destroy(); }\n" +
+            "}";
+        try {
+            var o = Qt.createQmlObject(qml, root, "promptSugProc");
+            o.running = true;
+        } catch (e) {
+            loadingSuggestions = false;
+            Logger.log("[AI] suggestion process error: " + e.message);
+        }
+    }
+
+    function applyPromptSuggestions(text) {
+        loadingSuggestions = false;
+        var resultStr = "";
+        try {
+            resultStr = JSON.parse(text).result || "";
+        } catch (e) {
+            return;
+        }
+        var arr = null;
+        try {
+            arr = JSON.parse(resultStr);
+        } catch (e) {
+            var m = resultStr.match(/\[[\s\S]*\]/);
+            if (m)
+                try { arr = JSON.parse(m[0]); } catch (e2) {}
+        }
+        if (Array.isArray(arr)) {
+            var list = [];
+            for (var i = 0; i < arr.length && i < 6; i++)
+                list.push(String(arr[i]));
+            promptSuggestions = list;
+        }
+    }
+
+    // A stored CLI session id only applies to the account that created it (session
+    // ids live under that account's CLAUDE_CONFIG_DIR). If the active account differs,
+    // return "" so we start a fresh session under the new account instead of a
+    // --resume that would fail with "no conversation found".
+    function claudeCodeSessionFor(chatId) {
+        var active = GlobalConfig.ai.activeClaudeAccount || "";
+        var c = claudeCodeSessions[chatId];
+        if (c && c.acc === active)
+            return c.sid;
+        for (var i = 0; i < allChatSessions.length; i++)
+            if (allChatSessions[i].id === chatId) {
+                if ((allChatSessions[i].claudeCodeSessionAccount || "") === active)
+                    return allChatSessions[i].claudeCodeSessionId || "";
+                return "";
+            }
+        return "";
+    }
+
+    function setClaudeCodeSession(chatId, sid) {
+        if (!sid)
+            return;
+        var active = GlobalConfig.ai.activeClaudeAccount || "";
+        claudeCodeSessions[chatId] = { sid: sid, acc: active };
+        for (var i = 0; i < allChatSessions.length; i++) {
+            if (allChatSessions[i].id === chatId) {
+                allChatSessions[i].claudeCodeSessionId = sid;
+                allChatSessions[i].claudeCodeSessionAccount = active;
+                break;
+            }
+        }
+    }
+
+    // Plain-text transcript of the conversation so far, used to seed a *fresh* CLI
+    // session (new chat, or after switching account) with prior context. Includes the
+    // latest user message and skips the streaming placeholder. Returns "" when there
+    // is only the single latest message (nothing to carry over).
+    function claudeCodeTranscript() {
+        var lines = [];
+        var count = 0;
+        for (var i = 0; i < chatHistory.count; i++) {
+            var m = chatHistory.get(i);
+            if (!m.isUser && !m.isFinished)
+                continue;
+            var t = (m.text || "").trim();
+            if (t === "")
+                continue;
+            lines.push((m.isUser ? "User: " : "Assistant: ") + t);
+            count++;
+        }
+        if (count <= 1)
+            return "";
+        return "Continue this conversation. Conversation so far:\n\n" + lines.join("\n\n") + "\n\nReply to the last user message.";
+    }
+
+    // Resolve the Anthropic API key: ANTHROPIC_API_KEY env var wins, config field is the fallback.
+    function getApiKey() {
+        var envKey = Quickshell.env("ANTHROPIC_API_KEY");
+        if (envKey && envKey.trim() !== "")
+            return envKey.trim();
+        return (GlobalConfig.ai.anthropicApiKey || "").trim();
+    }
+
+    // The model to send for the active provider.
+    function activeModel() {
+        if (isClaudeCode)
+            return GlobalConfig.ai.defaultClaudeCodeModel || "default";
+        if (isClaude)
+            return GlobalConfig.ai.defaultClaudeModel || "claude-sonnet-5";
+        return GlobalConfig.ai.defaultOllamaModel || "llama3";
+    }
+
+    // Providers exposed in the provider selector (respecting the enable toggles).
+    readonly property var providerList: {
+        var l = [];
+        if (GlobalConfig.ai.enableOllama)
+            l.push("ollama");
+        if (GlobalConfig.ai.enableClaudeCode)
+            l.push("claude-code");
+        if (GlobalConfig.ai.enableClaude)
+            l.push("claude");
+        if (l.length === 0)
+            l.push("ollama");
+        return l;
+    }
+
+    function providerLabel(p) {
+        if (p === "claude-code")
+            return "Claude Code";
+        if (p === "claude")
+            return "Claude API";
+        return "Ollama";
+    }
+
     property bool isTyping: false
     property bool isThinking: false
     property string currentThoughtText: ""
@@ -211,6 +511,390 @@ Item {
         }
     }
 
+    // ---- Claude Code provider (subscription `claude` CLI, no API key) ----
+
+    function claudeCodeCwd() {
+        return Quickshell.env("HOME") || ".";
+    }
+
+    // Resolve the `claude` binary without depending on the shell PATH (Quickshell may
+    // not inherit ~/.local/bin). If the config value is left at the default "claude",
+    // point at the official installer location; a custom value is used verbatim.
+    function claudeCodeBinPath() {
+        var b = (GlobalConfig.ai.claudeCodeBin || "claude").trim();
+        if (b === "" || b === "claude") {
+            var home = Quickshell.env("HOME") || "";
+            if (home !== "")
+                return home + "/.local/bin/claude";
+            return "claude";
+        }
+        return b;
+    }
+
+    // ---- Claude accounts (multi-login via CLAUDE_CONFIG_DIR) ----
+    // The default ~/.claude login is always present as an implicit "Default" (id "").
+    // Additional accounts each get their own config dir under ~/.config/caelestia/claude/<id>.
+    function claudeAccounts() {
+        var list = [{ "id": "", "name": "Default", "dir": "" }];
+        try {
+            var parsed = JSON.parse(GlobalConfig.ai.claudeAccountsJson || "[]");
+            if (Array.isArray(parsed)) {
+                var home = Quickshell.env("HOME") || "";
+                for (var i = 0; i < parsed.length; i++) {
+                    var a = parsed[i];
+                    if (a && a.id)
+                        list.push({
+                            "id": String(a.id),
+                            "name": String(a.name || a.id),
+                            "dir": home + "/.config/caelestia/claude/" + String(a.id)
+                        });
+                }
+            }
+        } catch (e) {}
+        return list;
+    }
+
+    function activeClaudeAccountObj() {
+        var id = GlobalConfig.ai.activeClaudeAccount || "";
+        var list = claudeAccounts();
+        for (var i = 0; i < list.length; i++)
+            if (list[i].id === id)
+                return list[i];
+        return list[0];
+    }
+
+    function activeClaudeConfigDir() {
+        return activeClaudeAccountObj().dir || "";
+    }
+
+    // Real display names (login email / name) read from each account's .claude.json.
+    property var resolvedAccountNames: ({})
+
+    function accountJsonPath(id) {
+        var home = Quickshell.env("HOME") || "";
+        if (!id || id === "")
+            return home + "/.claude.json";
+        return home + "/.config/caelestia/claude/" + id + "/.claude.json";
+    }
+
+    function accountLabel(id) {
+        if (resolvedAccountNames[id])
+            return resolvedAccountNames[id];
+        var list = claudeAccounts();
+        for (var i = 0; i < list.length; i++)
+            if (list[i].id === id)
+                return list[i].name;
+        return "Default";
+    }
+
+    // One FileView per account resolves its login name from .claude.json.
+    Instantiator {
+        model: root.claudeAccountIds
+        delegate: FileView {
+            required property string modelData
+            path: root.accountJsonPath(modelData)
+            printErrors: false
+            watchChanges: false
+            onLoaded: {
+                try {
+                    var d = JSON.parse(text());
+                    var oa = d.oauthAccount || {};
+                    var nm = oa.displayName || oa.emailAddress || "";
+                    if (nm) {
+                        var map = root.resolvedAccountNames;
+                        map[modelData] = nm;
+                        root.resolvedAccountNames = Object.assign({}, map);
+                    }
+                } catch (e) {}
+            }
+        }
+    }
+
+    readonly property var claudeAccountIds: {
+        var l = [];
+        var a = claudeAccounts();
+        for (var i = 0; i < a.length; i++)
+            l.push(a[i].id);
+        return l;
+    }
+
+    // Env-var line injected into the dynamically-built Process (empty for Default).
+    function claudeCodeEnvSnippet() {
+        var dir = activeClaudeConfigDir();
+        if (dir && dir !== "")
+            return "    environment: ({ \"CLAUDE_CONFIG_DIR\": " + JSON.stringify(dir) + " })\n";
+        return "";
+    }
+
+    function logClaudeCodeStderr(proc, line) {
+        if (!line)
+            return;
+        var t = line.trim();
+        if (t === "")
+            return;
+        proc.errAcc = (proc.errAcc || "") + t + "\n";
+        Logger.log("[ClaudeCode] " + t);
+    }
+
+    // Heuristic: does this CLI output indicate the Claude account isn't logged in?
+    function isClaudeCodeAuthError(text) {
+        if (!text)
+            return false;
+        var t = String(text).toLowerCase();
+        return t.indexOf("login") !== -1
+            || t.indexOf("log in") !== -1
+            || t.indexOf("logged in") !== -1
+            || t.indexOf("not authenticated") !== -1
+            || t.indexOf("unauthorized") !== -1
+            || t.indexOf("authentication") !== -1
+            || t.indexOf("oauth") !== -1
+            || t.indexOf("invalid api key") !== -1
+            || t.indexOf("api key") !== -1
+            || t.indexOf("expired") !== -1
+            || t.indexOf("sign in") !== -1
+            || t.indexOf("credentials") !== -1;
+    }
+
+    function claudeCodeAuthHint() {
+        return "⚠️ Claude hesabınıza giriş yapılmamış görünüyor.\n\nBir terminal açıp `claude` komutunu çalıştırın ve aboneliğinizle giriş yapın (login), ardından burada tekrar deneyin.";
+    }
+
+    // Generate a short chat title via a one-shot `claude -p ... --output-format json`.
+    function generateClaudeCodeTitleAsync(chatId, firstMessage) {
+        if (!firstMessage)
+            return;
+        var safeMsg = firstMessage.substring(0, 200);
+        var prompt = "Output ONLY a concise 2-4 word title for the following message. No quotes, no trailing punctuation, no explanation.\n\nMessage: " + safeMsg;
+
+        var cmd = [claudeCodeBinPath(), "-p", prompt, "--output-format", "json", "--dangerously-skip-permissions"];
+        var commandStr = JSON.stringify(cmd);
+        var cwdStr = JSON.stringify(claudeCodeCwd());
+        var chatIdStr = JSON.stringify(chatId);
+        var qml =
+            "import QtQuick\n" +
+            "import Quickshell.Io\n" +
+            "Process {\n" +
+            "    id: tproc\n" +
+            "    command: " + commandStr + "\n" +
+            "    workingDirectory: " + cwdStr + "\n" +
+            claudeCodeEnvSnippet() +
+            "    stdout: StdioCollector { onStreamFinished: root.handleClaudeCodeTitle(" + chatIdStr + ", text || \"\", tproc); }\n" +
+            "    onExited: code => { if (code !== 0) tproc.destroy(); }\n" +
+            "}";
+        try {
+            var obj = Qt.createQmlObject(qml, root, "claudeCodeTitleProc");
+            obj.running = true;
+        } catch (e) {
+            Logger.log("[AI] claude-code title process error: " + e.message);
+        }
+    }
+
+    function handleClaudeCodeTitle(chatId, text, proc) {
+        try {
+            var parsed = JSON.parse(text);
+            if (parsed && parsed.result && !parsed.is_error)
+                applyGeneratedTitle(chatId, String(parsed.result));
+        } catch (e) {}
+        if (proc)
+            proc.destroy();
+    }
+
+    function stopClaudeCode() {
+        if (root.currentClaudeCodeProc) {
+            try {
+                root.currentClaudeCodeProc.running = false;
+            } catch (e) {}
+            root.currentClaudeCodeProc = null;
+        }
+    }
+
+    function sendClaudeCode(promptText) {
+        // Drop any stale empty assistant placeholder, then add a fresh bubble to stream into.
+        for (var i = chatHistory.count - 1; i >= 0; i--) {
+            var m = chatHistory.get(i);
+            if (!m.isUser && !m.isFinished && m.text === "")
+                chatHistory.remove(i);
+        }
+        chatHistory.append({
+            "isUser": false,
+            "text": "",
+            "isFinished": false,
+            "thoughtText": ""
+        });
+        listView.positionViewAtEnd();
+
+        var bin = claudeCodeBinPath();
+        var sid = claudeCodeSessionFor(currentChatId);
+
+        // Fresh session (new chat, or the active account changed) → seed it with the
+        // prior transcript so the new account continues the same conversation.
+        var promptToSend = promptText;
+        if (sid === "") {
+            var transcript = claudeCodeTranscript();
+            if (transcript !== "")
+                promptToSend = transcript;
+        }
+
+        var cmd = [bin, "-p", promptToSend, "--output-format", "stream-json", "--verbose", "--include-partial-messages", "--dangerously-skip-permissions"];
+
+        var mdl = GlobalConfig.ai.defaultClaudeCodeModel || "default";
+        if (mdl && mdl !== "default") {
+            cmd.push("--model");
+            cmd.push(mdl);
+        }
+
+        var eff = GlobalConfig.ai.claudeCodeEffort || "default";
+        if (eff && eff !== "default" && effortLevelsFor(mdl).indexOf(eff) !== -1) {
+            cmd.push("--effort");
+            cmd.push(eff);
+        }
+
+        if (sid !== "") {
+            cmd.push("--resume");
+            cmd.push(sid);
+        }
+
+        var commandStr = JSON.stringify(cmd);
+        var cwdStr = JSON.stringify(claudeCodeCwd());
+        var processQml =
+            "import QtQuick\n" +
+            "import Quickshell.Io\n" +
+            "Process {\n" +
+            "    id: proc\n" +
+            "    command: " + commandStr + "\n" +
+            "    workingDirectory: " + cwdStr + "\n" +
+            claudeCodeEnvSnippet() +
+            "    property string acc: \"\"\n" +
+            "    property string thought: \"\"\n" +
+            "    property string sess: \"\"\n" +
+            "    property string errAcc: \"\"\n" +
+            "    property bool done: false\n" +
+            "    stdout: SplitParser { onRead: line => root.onClaudeCodeLine(proc, line) }\n" +
+            "    stderr: SplitParser { onRead: line => root.logClaudeCodeStderr(proc, line) }\n" +
+            "    onExited: code => root.onClaudeCodeExit(proc, code)\n" +
+            "}";
+        try {
+            var obj = Qt.createQmlObject(processQml, root, "claudeCodeProc");
+            root.currentClaudeCodeProc = obj;
+            obj.running = true;
+        } catch (e) {
+            console.error("CLAUDE CODE PROCESS ERROR: " + e.message);
+            chatHistory.setProperty(chatHistory.count - 1, "text", "⚠️ Failed to launch Claude Code: " + e.message);
+            chatHistory.setProperty(chatHistory.count - 1, "isFinished", true);
+            isTyping = false;
+            isThinking = false;
+            inAgentLoop = false;
+            saveHistory();
+        }
+    }
+
+    function onClaudeCodeLine(proc, line) {
+        line = (line || "").trim();
+        if (line === "")
+            return;
+
+        var evt;
+        try {
+            evt = JSON.parse(line);
+        } catch (e) {
+            return; // non-JSON diagnostic output
+        }
+
+        if (evt.session_id)
+            proc.sess = evt.session_id;
+
+        if (evt.type === "system")
+            return;
+
+        // Token-level streaming (when the CLI emits partial messages).
+        if (evt.type === "stream_event" && evt.event) {
+            var ev = evt.event;
+            if (ev.type === "content_block_delta" && ev.delta) {
+                if (ev.delta.type === "text_delta") {
+                    proc.acc += ev.delta.text || "";
+                    if (isThinking) isThinking = false;
+                } else if (ev.delta.type === "thinking_delta") {
+                    proc.thought += ev.delta.thinking || "";
+                }
+                root.currentThoughtText = proc.thought.trim();
+                chatHistory.setProperty(chatHistory.count - 1, "thoughtText", proc.thought.trim());
+                chatHistory.setProperty(chatHistory.count - 1, "text", proc.acc.trim());
+                listView.positionViewAtEnd();
+            }
+            return;
+        }
+
+        // Whole assistant messages (also carry tool_use blocks). Used as the fallback
+        // when token-level partials aren't emitted, and to surface tool activity.
+        if (evt.type === "assistant" && evt.message && evt.message.content) {
+            var hasTool = false;
+            var textPart = "";
+            for (var i = 0; i < evt.message.content.length; i++) {
+                var b = evt.message.content[i];
+                if (b.type === "tool_use") {
+                    hasTool = true;
+                    if (b.name)
+                        currentActionText = "Running " + b.name + "...";
+                } else if (b.type === "text") {
+                    textPart += b.text || "";
+                }
+            }
+            if (textPart.trim() !== "" && proc.acc.indexOf(textPart) === -1) {
+                proc.acc = (proc.acc ? proc.acc + "\n\n" : "") + textPart;
+                if (isThinking) isThinking = false;
+                chatHistory.setProperty(chatHistory.count - 1, "text", proc.acc.trim());
+                listView.positionViewAtEnd();
+            }
+            if (hasTool && textPart.trim() === "")
+                isThinking = true;
+            return;
+        }
+
+        if (evt.type === "result") {
+            var resText = (evt.result !== undefined && evt.result !== null) ? String(evt.result) : "";
+            var errored = (evt.is_error === true) || (evt.subtype && String(evt.subtype).indexOf("error") !== -1);
+            if (errored && (isClaudeCodeAuthError(resText) || isClaudeCodeAuthError(proc.errAcc))) {
+                proc.acc = claudeCodeAuthHint();
+            } else if (proc.acc.trim() === "" && resText !== "") {
+                proc.acc = resText;
+            }
+            finalizeClaudeCode(proc);
+            return;
+        }
+    }
+
+    function finalizeClaudeCode(proc) {
+        if (proc.done)
+            return;
+        proc.done = true;
+        var finalText = (proc.acc || "").trim();
+        chatHistory.setProperty(chatHistory.count - 1, "text", finalText !== "" ? finalText : "(no output)");
+        chatHistory.setProperty(chatHistory.count - 1, "isFinished", true);
+        setClaudeCodeSession(currentChatId, proc.sess);
+        isTyping = false;
+        isThinking = false;
+        inAgentLoop = false;
+        currentActionText = "Thinking...";
+        saveHistory();
+        listView.positionViewAtEnd();
+    }
+
+    function onClaudeCodeExit(proc, code) {
+        if (!proc.done) {
+            if ((proc.acc || "").trim() === "") {
+                if (isClaudeCodeAuthError(proc.errAcc))
+                    chatHistory.setProperty(chatHistory.count - 1, "text", claudeCodeAuthHint());
+                else if (code !== 0)
+                    chatHistory.setProperty(chatHistory.count - 1, "text",
+                        "⚠️ Claude Code çalıştırılamadı (çıkış kodu " + code + "). `claude` CLI kurulu ve giriş yapılmış mı? Bir terminalde `claude` çalıştırıp giriş yapmayı deneyin.");
+            }
+            finalizeClaudeCode(proc);
+        }
+        if (root.currentClaudeCodeProc === proc)
+            root.currentClaudeCodeProc = null;
+        proc.destroy();
+    }
+
     property string currentActionText: "Thinking..."
 
     function fetchOllamaModels() {
@@ -253,6 +937,7 @@ Item {
 
     function createNewChat() {
         typingTimer.stop();
+        stopClaudeCode();
         isTyping = false;
         isThinking = false;
         inAgentLoop = false;
@@ -263,6 +948,7 @@ Item {
 
     function loadChat(id) {
         typingTimer.stop();
+        stopClaudeCode();
         isTyping = false;
         isThinking = false;
         inAgentLoop = false;
@@ -417,10 +1103,55 @@ Item {
         createNewChat();
     }
 
+    function applyGeneratedTitle(chatId, raw) {
+        if (!raw)
+            return;
+        var title = raw.trim().replace(/^"|"$/g, '').replace(/\n/g, ' ');
+        if (title.length > 40)
+            title = title.substring(0, 40) + "...";
+        if (title.length > 0)
+            updateChatTitle(chatId, title);
+    }
+
     function generateChatTitleAsync(chatId, firstMessage) {
         if (!firstMessage) return;
-        
+
+        if (root.isClaudeCode) {
+            root.generateClaudeCodeTitleAsync(chatId, firstMessage);
+            return;
+        }
+
+        var safeMsg = firstMessage.substring(0, 200);
+        var titleSystem = "You are a title generator. Output ONLY a 2-4 word title representing the user's message. NO quotes, NO explanation.";
         var xhr = new XMLHttpRequest();
+
+        if (root.isClaude) {
+            if (root.getApiKey() === "")
+                return;
+            var claudeBase = GlobalConfig.ai.anthropicUrl || "https://api.anthropic.com";
+            xhr.open("POST", claudeBase + "/v1/messages", true);
+            xhr.setRequestHeader("Content-Type", "application/json");
+            xhr.setRequestHeader("x-api-key", root.getApiKey());
+            xhr.setRequestHeader("anthropic-version", "2023-06-01");
+            xhr.setRequestHeader("anthropic-dangerous-direct-browser-access", "true");
+            xhr.onreadystatechange = () => {
+                if (xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {
+                    try {
+                        var parsed = JSON.parse(xhr.responseText);
+                        if (parsed.content && parsed.content.length > 0 && parsed.content[0].text)
+                            root.applyGeneratedTitle(chatId, parsed.content[0].text);
+                    } catch (e) {}
+                }
+            };
+            xhr.send(JSON.stringify({
+                model: root.activeModel(),
+                max_tokens: 32,
+                system: titleSystem,
+                messages: [{ role: "user", content: "Message: " + safeMsg + "\nTitle:" }]
+            }));
+            return;
+        }
+
         var url = (GlobalConfig.ai.ollamaUrl || "http://localhost:11434") + "/api/generate";
         xhr.open("POST", url, true);
         xhr.setRequestHeader("Content-Type", "application/json");
@@ -428,22 +1159,14 @@ Item {
             if (xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {
                 try {
                     var parsed = JSON.parse(xhr.responseText);
-                    if (parsed.response) {
-                        var title = parsed.response.trim().replace(/^"|"$/g, '').replace(/\n/g, ' ');
-                        if (title.length > 40) title = title.substring(0, 40) + "...";
-                        if (title.length > 0) {
-                            updateChatTitle(chatId, title);
-                        }
-                        return;
-                    }
+                    if (parsed.response)
+                        root.applyGeneratedTitle(chatId, parsed.response);
                 } catch (e) {}
             }
         };
-        
-        var safeMsg = firstMessage.substring(0, 200);
         xhr.send(JSON.stringify({
             model: GlobalConfig.ai.defaultOllamaModel || "llama3",
-            system: "You are a title generator. Output ONLY a 2-4 word title representing the user's message. NO quotes, NO explanation.",
+            system: titleSystem,
             prompt: "Message: " + safeMsg + "\nTitle:",
             stream: false
         }));
@@ -492,6 +1215,9 @@ Item {
     function sendPrompt(promptText, isSystemToolResult = false, base64Image = null, toolName = "") {
         if (!promptText.trim() && !base64Image) return;
 
+        // Sending a message dismisses any open prompt suggestions.
+        promptSuggestions = [];
+
         if (!isSystemToolResult) {
             chatHistory.append({
                 "isUser": true,
@@ -501,6 +1227,11 @@ Item {
             });
             listView.positionViewAtEnd();
             saveHistory();
+        }
+
+        if (root.isClaude && root.getApiKey() === "") {
+            addAiMessage("⚠️ No Claude API key configured. Set the ANTHROPIC_API_KEY environment variable, or add a key in the AI settings.");
+            return;
         }
 
         isTyping = true;
@@ -522,14 +1253,30 @@ Item {
         } else {
             currentActionText = "Thinking...";
         }
+
+        // Claude Code (subscription CLI) uses a Process, not XMLHttpRequest.
+        if (root.isClaudeCode) {
+            root.sendClaudeCode(promptText);
+            return;
+        }
+
         var xhr = new XMLHttpRequest();
         root.currentRequest = xhr;
 
-        var ollamaModel = GlobalConfig.ai.defaultOllamaModel || "llama3";
-        var ollamaUrl = GlobalConfig.ai.ollamaUrl || "http://localhost:11434";
-        var url = ollamaUrl + "/api/chat";
-        xhr.open("POST", url, true);
-        xhr.setRequestHeader("Content-Type", "application/json");
+        var model = root.activeModel();
+        if (root.isClaude) {
+            var claudeBase = GlobalConfig.ai.anthropicUrl || "https://api.anthropic.com";
+            xhr.open("POST", claudeBase + "/v1/messages", true);
+            xhr.setRequestHeader("Content-Type", "application/json");
+            xhr.setRequestHeader("x-api-key", root.getApiKey());
+            xhr.setRequestHeader("anthropic-version", "2023-06-01");
+            // QML's XMLHttpRequest presents a browser-like origin; this header opts into direct access.
+            xhr.setRequestHeader("anthropic-dangerous-direct-browser-access", "true");
+        } else {
+            var ollamaUrl = GlobalConfig.ai.ollamaUrl || "http://localhost:11434";
+            xhr.open("POST", ollamaUrl + "/api/chat", true);
+            xhr.setRequestHeader("Content-Type", "application/json");
+        }
         
         var processedTextLength = 0;
         var accumulatedThoughtText = "";
@@ -563,58 +1310,94 @@ Item {
                     var linesToProcess = (xhr.readyState === XMLHttpRequest.DONE) ? lines.length : lines.length - 1;
                     
                     for (var i = 0; i < linesToProcess; i++) {
-                        var line = lines[i].trim();
+                        var rawLine = lines[i];
+                        var line = rawLine.trim();
                         if (line === "") {
-                            processedTextLength += lines[i].length + 1;
+                            processedTextLength += rawLine.length + 1;
                             continue;
                         }
-                        
-                        try {
-                            var parsed = JSON.parse(line);
-                            processedTextLength += lines[i].length + 1;
-                            
-                            if (parsed.message) {
-                                var chunkReasoning = parsed.message.thinking || parsed.message.reasoning || parsed.message.reasoning_content || "";
-                                if (chunkReasoning) {
-                                    accumulatedThoughtText += chunkReasoning;
-                                }
-                                
-                                var chunkContent = parsed.message.content || "";
-                                if (chunkContent) {
-                                    rawAccumulatedContentText += chunkContent;
-                                }
-                                
-                                var displayContent = stripToolCalls(rawAccumulatedContentText);
-                                var displayThought = accumulatedThoughtText;
-                                
-                                if (accumulatedThoughtText === "") {
-                                    var openThinkIdx = displayContent.indexOf("<think>");
-                                    var closeThinkIdx = displayContent.indexOf("</think>");
-                                    
-                                    if (openThinkIdx !== -1) {
-                                        if (closeThinkIdx !== -1) {
-                                            displayThought = displayContent.substring(openThinkIdx + 7, closeThinkIdx).trim();
-                                            displayContent = displayContent.substring(0, openThinkIdx) + displayContent.substring(closeThinkIdx + 8);
-                                        } else {
-                                            displayThought = displayContent.substring(openThinkIdx + 7).trim();
-                                            displayContent = displayContent.substring(0, openThinkIdx);
-                                        }
-                                    }
-                                }
-                                
-                                root.currentThoughtText = displayThought.trim();
-                                
-                                if (displayContent.trim() !== "") {
-                                    if (isThinking) isThinking = false;
-                                }
-                                
-                                chatHistory.setProperty(chatHistory.count - 1, "thoughtText", displayThought.trim());
-                                chatHistory.setProperty(chatHistory.count - 1, "text", displayContent.trim());
-                                listView.positionViewAtEnd();
+
+                        var chunkContent = "";
+                        var chunkReasoning = "";
+
+                        if (root.isClaude) {
+                            // Anthropic streams Server-Sent Events; only "data:" lines carry JSON.
+                            if (line.indexOf("event:") === 0) {
+                                processedTextLength += rawLine.length + 1;
+                                continue;
                             }
-                        } catch (e) {
-                            break;
+                            if (line.indexOf("data:") !== 0) {
+                                processedTextLength += rawLine.length + 1;
+                                continue;
+                            }
+                            var jsonStr = line.substring(5).trim();
+                            if (jsonStr === "" || jsonStr === "[DONE]") {
+                                processedTextLength += rawLine.length + 1;
+                                continue;
+                            }
+                            try {
+                                var evt = JSON.parse(jsonStr);
+                                processedTextLength += rawLine.length + 1;
+                                if (evt.type === "content_block_delta" && evt.delta) {
+                                    if (evt.delta.type === "text_delta")
+                                        chunkContent = evt.delta.text || "";
+                                    else if (evt.delta.type === "thinking_delta")
+                                        chunkReasoning = evt.delta.thinking || "";
+                                } else if (evt.type === "error") {
+                                    Logger.log("[AI] Claude stream error: " + JSON.stringify(evt.error || {}));
+                                }
+                            } catch (e) {
+                                break;
+                            }
+                        } else {
+                            // Ollama streams newline-delimited JSON objects.
+                            try {
+                                var parsed = JSON.parse(line);
+                                processedTextLength += rawLine.length + 1;
+                                if (parsed.message) {
+                                    chunkReasoning = parsed.message.thinking || parsed.message.reasoning || parsed.message.reasoning_content || "";
+                                    chunkContent = parsed.message.content || "";
+                                }
+                            } catch (e) {
+                                break;
+                            }
                         }
+
+                        if (chunkReasoning)
+                            accumulatedThoughtText += chunkReasoning;
+                        if (chunkContent)
+                            rawAccumulatedContentText += chunkContent;
+
+                        if (chunkContent === "" && chunkReasoning === "")
+                            continue;
+
+                        var displayContent = stripToolCalls(rawAccumulatedContentText);
+                        var displayThought = accumulatedThoughtText;
+
+                        if (accumulatedThoughtText === "") {
+                            var openThinkIdx = displayContent.indexOf("<think>");
+                            var closeThinkIdx = displayContent.indexOf("</think>");
+
+                            if (openThinkIdx !== -1) {
+                                if (closeThinkIdx !== -1) {
+                                    displayThought = displayContent.substring(openThinkIdx + 7, closeThinkIdx).trim();
+                                    displayContent = displayContent.substring(0, openThinkIdx) + displayContent.substring(closeThinkIdx + 8);
+                                } else {
+                                    displayThought = displayContent.substring(openThinkIdx + 7).trim();
+                                    displayContent = displayContent.substring(0, openThinkIdx);
+                                }
+                            }
+                        }
+
+                        root.currentThoughtText = displayThought.trim();
+
+                        if (displayContent.trim() !== "") {
+                            if (isThinking) isThinking = false;
+                        }
+
+                        chatHistory.setProperty(chatHistory.count - 1, "thoughtText", displayThought.trim());
+                        chatHistory.setProperty(chatHistory.count - 1, "text", displayContent.trim());
+                        listView.positionViewAtEnd();
                     }
                 }
                 
@@ -716,7 +1499,8 @@ Item {
                             inAgentLoop = false;
                         }
                     } else {
-                        var errMsg = (xhr.status === 0) ? "Generation cancelled" : "Ollama request failed (status " + xhr.status + ").";
+                        var providerName = root.isClaude ? "Claude" : "Ollama";
+                        var errMsg = (xhr.status === 0) ? "Generation cancelled" : (providerName + " request failed (status " + xhr.status + ")." + ((root.isClaude && xhr.status === 401) ? " Check your API key." : ""));
                         var currentText = chatHistory.get(chatHistory.count - 1).text;
                         if (currentText.trim() === "") {
                             chatHistory.setProperty(chatHistory.count - 1, "text", errMsg);
@@ -733,46 +1517,84 @@ Item {
             }
         };
 
-        var messages = [];
         var enableTools = GlobalConfig.ai.enableCelestialMode;
         var sysPrompt = "You are a helpful AI assistant integrated into the user's desktop OS shell (Caelestia, running on KDE Plasma/Wayland).";
         if (enableTools) {
             sysPrompt += "\n\nYou have access to the following tools. To call a tool, output a <tool_call> block containing ONLY valid JSON. Do not output any text inside the block other than the JSON object.\n\nFORMAT:\n<tool_call>\n{\"name\": \"TOOL_NAME\", \"args\": {ARGUMENTS}}\n</tool_call>\n\nAVAILABLE TOOLS:\n- take_screenshot: Captures the user's screen for visual analysis. Args: none.\n  Example: <tool_call>\n{\"name\": \"take_screenshot\", \"args\": {}}\n</tool_call>\n\n- web_search: Searches the web. Args: query (string, required), page (number, optional).\n  Example: <tool_call>\n{\"name\": \"web_search\", \"args\": {\"query\": \"latest news\"}}\n</tool_call>\n\n- read_webpage: Fetches and reads the text of a URL. Args: url (string, required).\n  Example: <tool_call>\n{\"name\": \"read_webpage\", \"args\": {\"url\": \"https://example.com\"}}\n</tool_call>\n\n- open_app: Launches an installed desktop application. Args: app_name (string, required).\n  Example: <tool_call>\n{\"name\": \"open_app\", \"args\": {\"app_name\": \"dolphin\"}}\n</tool_call>\n\n- set_timer: Sets a countdown timer that fires a desktop notification. Args: seconds (number, required), message (string, required).\n  Example: <tool_call>\n{\"name\": \"set_timer\", \"args\": {\"seconds\": 300, \"message\": \"Break time!\"}}\n</tool_call>\n\n- get_weather: Gets the current local weather from the system dashboard. Args: none.\n  Example: <tool_call>\n{\"name\": \"get_weather\", \"args\": {}}\n</tool_call>\n\n- caelestia_command: Runs a caelestia CLI command. Valid subcommands: shell, toggle, scheme, search, screenshot, record, clipboard, emoji, wallpaper, resizer, install, update. Args: subcommand (string, required), args (string, optional extra flags).\n  Example: <tool_call>\n{\"name\": \"caelestia_command\", \"args\": {\"subcommand\": \"wallpaper\", \"args\": \"--random\"}}\n</tool_call>\n\nCRITICAL RULES:\n1. ALWAYS use a <tool_call> block to call a tool. NEVER pretend to perform actions in plain text.\n2. You may output a brief acknowledgment before the <tool_call> block (e.g. 'Opening Dolphin for you!') but you MUST include the block.\n3. You can include multiple <tool_call> blocks in one response.\n4. After receiving tool results, respond naturally to the user based on what the tool returned.";
         }
         
-        messages.push({
-            "role": "system",
-            "content": sysPrompt
-        });
-
-        for (var i = 0; i < chatHistory.count; i++) {
-            var msg = chatHistory.get(i);
-            messages.push({
-                "role": msg.isUser ? "user" : "assistant",
-                "content": msg.text || ""
-            });
-        }
-
-        if (isSystemToolResult) {
-            var toolMsg = {
-                "role": "user",
-                "content": promptText
-            };
-            if (base64Image) {
-                toolMsg["images"] = [base64Image];
+        var requestBody;
+        if (root.isClaude) {
+            // Anthropic Messages API: system prompt is a top-level field; messages must
+            // carry non-empty content and cannot include the streaming placeholder.
+            var claudeMessages = [];
+            for (var i = 0; i < chatHistory.count; i++) {
+                var msg = chatHistory.get(i);
+                if (!msg.isUser && !msg.isFinished && (msg.text || "") === "")
+                    continue;
+                if ((msg.text || "") === "")
+                    continue;
+                claudeMessages.push({
+                    "role": msg.isUser ? "user" : "assistant",
+                    "content": msg.text
+                });
             }
-            messages.push(toolMsg);
+
+            if (isSystemToolResult) {
+                var claudeContent;
+                if (base64Image) {
+                    claudeContent = [
+                        { "type": "text", "text": promptText },
+                        { "type": "image", "source": { "type": "base64", "media_type": "image/jpeg", "data": base64Image } }
+                    ];
+                } else {
+                    claudeContent = promptText;
+                }
+                claudeMessages.push({ "role": "user", "content": claudeContent });
+            }
+
+            requestBody = {
+                "model": model,
+                "max_tokens": 4096,
+                "system": sysPrompt,
+                "messages": claudeMessages,
+                "stream": true
+            };
+        } else {
+            var messages = [];
+            messages.push({
+                "role": "system",
+                "content": sysPrompt
+            });
+
+            for (var j = 0; j < chatHistory.count; j++) {
+                var m = chatHistory.get(j);
+                messages.push({
+                    "role": m.isUser ? "user" : "assistant",
+                    "content": m.text || ""
+                });
+            }
+
+            if (isSystemToolResult) {
+                var toolMsg = {
+                    "role": "user",
+                    "content": promptText
+                };
+                if (base64Image) {
+                    toolMsg["images"] = [base64Image];
+                }
+                messages.push(toolMsg);
+            }
+
+            // Native tool-calling API removed; using text-based <tool_call> parsing instead,
+            // which is compatible with all models including llama3, mistral, phi, etc.
+            requestBody = {
+                "model": model,
+                "messages": messages,
+                "stream": true
+            };
         }
 
-        var requestBody = {
-            "model": ollamaModel,
-            "messages": messages,
-            "stream": true
-        };
-        
-        // Native tool-calling API removed; using text-based <tool_call> parsing instead,
-        // which is compatible with all models including llama3, mistral, phi, etc.
-        
         xhr.send(JSON.stringify(requestBody));
     }
 
@@ -901,7 +1723,48 @@ Item {
                  }
              }
 
-             Item { Layout.fillWidth: true } // Spacer pushes Model Selector to the right
+         }
+
+         // Provider + model (+ account) selectors on their own row; a Flow so the
+         // pills wrap to a second line instead of overflowing a narrow sidebar.
+         Flow {
+             id: selectorRow
+             anchors.top: modeSwitcherRow.bottom
+             anchors.left: parent.left
+             anchors.right: parent.right
+             anchors.topMargin: Tokens.spacing.small
+             z: 10
+             spacing: Tokens.spacing.small
+
+             // Provider Selector Split Button (Ollama / Claude Code)
+             SplitButton {
+                 id: providerSelector
+                 type: SplitButton.Tonal
+                 verticalPadding: 4
+                 visible: root.providerList.length > 1
+                 Layout.preferredWidth: implicitWidth
+
+                 active: menuItems.find(m => m.modelData === root.provider) ?? menuItems[0] ?? null
+                 menu.onItemSelected: item => {
+                     GlobalConfig.ai.defaultProvider = item.modelData;
+                 }
+
+                 menuItems: providerVariants.instances
+
+                 fallbackIcon: "cloud"
+                 fallbackText: qsTr("Provider")
+                 stateLayer.disabled: true
+
+                 Variants {
+                     id: providerVariants
+                     model: root.providerList
+
+                     delegate: MenuItem {
+                         required property string modelData
+                         text: root.providerLabel(modelData)
+                     }
+                 }
+             }
 
              // Model Selector Split Button
              SplitButton {
@@ -910,9 +1773,16 @@ Item {
                  verticalPadding: 4
                  Layout.preferredWidth: implicitWidth
 
-                 active: menuItems.find(m => m.modelData === GlobalConfig.ai.defaultOllamaModel) ?? menuItems[0] ?? null
+                 active: menuItems.find(m => m.modelData === root.activeModel()) ?? menuItems[0] ?? null
                  menu.onItemSelected: item => {
-                     GlobalConfig.ai.defaultOllamaModel = item.modelData;
+                     if (root.isClaudeCode) {
+                         GlobalConfig.ai.defaultClaudeCodeModel = item.modelData;
+                         // Effort levels differ per model — reset to default on model change.
+                         GlobalConfig.ai.claudeCodeEffort = "default";
+                     } else if (root.isClaude)
+                         GlobalConfig.ai.defaultClaudeModel = item.modelData;
+                     else
+                         GlobalConfig.ai.defaultOllamaModel = item.modelData;
                  }
 
                  menuItems: modelVariants.instances
@@ -924,6 +1794,10 @@ Item {
                  Variants {
                      id: modelVariants
                      model: {
+                         if (root.isClaudeCode)
+                             return root.claudeCodeModelsList;
+                         if (root.isClaude)
+                             return root.claudeModelsList;
                          return root.ollamaModelsList && root.ollamaModelsList.length > 0 ? root.ollamaModelsList : ["llama3", "mistral", "phi3", "gemma"];
                      }
 
@@ -934,12 +1808,70 @@ Item {
                  }
              }
 
+             // Effort / thinking-level Selector (Claude Code).
+             SplitButton {
+                 id: effortSelector
+                 type: SplitButton.Tonal
+                 verticalPadding: 4
+                 visible: root.isClaudeCode && root.claudeCodeEffortOptions.length > 0
+
+                 active: menuItems.find(m => m.modelData === (GlobalConfig.ai.claudeCodeEffort || "default")) ?? menuItems[0] ?? null
+                 menu.onItemSelected: item => {
+                     GlobalConfig.ai.claudeCodeEffort = item.modelData;
+                 }
+
+                 menuItems: effortVariants.instances
+
+                 fallbackIcon: "neurology"
+                 fallbackText: qsTr("Effort")
+                 stateLayer.disabled: true
+
+                 Variants {
+                     id: effortVariants
+                     model: root.claudeCodeEffortOptions
+
+                     delegate: MenuItem {
+                         required property string modelData
+                         text: modelData
+                     }
+                 }
+             }
+
+             // Account Selector (Claude Code multi-login) — only when >1 account exists.
+             SplitButton {
+                 id: accountSelector
+                 type: SplitButton.Tonal
+                 verticalPadding: 4
+                 visible: root.isClaudeCode && root.claudeAccountIds.length > 1
+
+                 active: menuItems.find(m => m.modelData === (GlobalConfig.ai.activeClaudeAccount || "")) ?? menuItems[0] ?? null
+                 menu.onItemSelected: item => {
+                     GlobalConfig.ai.activeClaudeAccount = item.modelData;
+                 }
+
+                 menuItems: accountVariants.instances
+
+                 fallbackIcon: "person"
+                 fallbackText: qsTr("Account")
+                 stateLayer.disabled: true
+
+                 Variants {
+                     id: accountVariants
+                     model: root.claudeAccountIds
+
+                     delegate: MenuItem {
+                         required property string modelData
+                         text: root.accountLabel(modelData)
+                     }
+                 }
+             }
+
 
          }
          
          Item {
              id: contentStack
-             anchors.top: modeSwitcherRow.bottom
+             anchors.top: selectorRow.bottom
              anchors.bottom: parent.bottom
              anchors.left: parent.left
              anchors.right: parent.right
@@ -1392,6 +2324,86 @@ Item {
                      }
                  }
 
+                 // Prompt suggestion chips (Claude Code) — float just above the input.
+                 ColumnLayout {
+                     id: suggestionBox
+                     anchors.bottom: inputBoxRow.top
+                     anchors.bottomMargin: Tokens.spacing.small
+                     anchors.left: parent.left
+                     anchors.right: parent.right
+                     z: 11
+                     spacing: Tokens.spacing.small
+                     visible: root.isClaudeCode && root.promptSuggestions.length > 0
+
+                     // Header with a close button.
+                     RowLayout {
+                         Layout.fillWidth: true
+                         spacing: Tokens.spacing.small
+
+                         StyledText {
+                             Layout.fillWidth: true
+                             text: qsTr("Suggestions")
+                             color: Colours.palette.m3onSurfaceVariant
+                             font: Tokens.font.label.small
+                         }
+
+                         Item {
+                             Layout.preferredWidth: 24
+                             Layout.preferredHeight: 24
+
+                             MaterialIcon {
+                                 anchors.centerIn: parent
+                                 text: "close"
+                                 color: closeSugMouse.containsMouse ? Colours.palette.m3onSurface : Colours.palette.m3onSurfaceVariant
+                                 font: Tokens.font.icon.small
+                             }
+
+                             MouseArea {
+                                 id: closeSugMouse
+                                 anchors.fill: parent
+                                 hoverEnabled: true
+                                 cursorShape: Qt.PointingHandCursor
+                                 onClicked: root.promptSuggestions = []
+                             }
+                         }
+                     }
+
+                     Repeater {
+                         model: root.promptSuggestions
+
+                         StyledRect {
+                             required property string modelData
+                             Layout.fillWidth: true
+                             implicitHeight: sugChipText.implicitHeight + Tokens.padding.medium * 2
+                             radius: Tokens.rounding.large
+                             color: Colours.tPalette.m3surfaceContainerHigh
+
+                             StateLayer {
+                                 radius: Tokens.rounding.large
+                                 onClicked: {
+                                     inputArea.text = modelData;
+                                     root.promptSuggestions = [];
+                                     inputArea.forceActiveFocus();
+                                 }
+                             }
+
+                             StyledText {
+                                 id: sugChipText
+                                 anchors.left: parent.left
+                                 anchors.right: parent.right
+                                 anchors.top: parent.top
+                                 anchors.leftMargin: Tokens.padding.medium
+                                 anchors.rightMargin: Tokens.padding.medium
+                                 anchors.topMargin: Tokens.padding.medium
+                                 text: parent.modelData
+                                 color: Colours.palette.m3onSurface
+                                 font: Tokens.font.body.small
+                                 wrapMode: Text.Wrap
+                             }
+                         }
+                     }
+                 }
+
                  // Input Box Row
                  StyledRect {
                      id: inputBoxRow
@@ -1476,6 +2488,28 @@ Item {
                              }
                          }
 
+                         // Prompt suggestions trigger (Claude Code).
+                         Item {
+                             visible: root.isClaudeCode
+                             Layout.preferredWidth: visible ? 32 : 0
+                             Layout.preferredHeight: 32
+
+                             MaterialIcon {
+                                 anchors.centerIn: parent
+                                 text: root.loadingSuggestions ? "hourglass_empty" : "lightbulb"
+                                 color: sugMouse.containsMouse ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                                 font: Tokens.font.icon.small
+                             }
+
+                             MouseArea {
+                                 id: sugMouse
+                                 anchors.fill: parent
+                                 hoverEnabled: true
+                                 cursorShape: Qt.PointingHandCursor
+                                 onClicked: root.fetchPromptSuggestions()
+                             }
+                         }
+
                          Item {
                              Layout.preferredWidth: 36
                              Layout.preferredHeight: 36
@@ -1500,6 +2534,7 @@ Item {
                                              if (root.currentRequest) {
                                                  root.currentRequest.abort();
                                              }
+                                             root.stopClaudeCode();
                                              root.isTyping = false;
                                              root.isThinking = false;
                                              root.inAgentLoop = false;

--- a/shell/modules/sidebar/AiAssistant.qml
+++ b/shell/modules/sidebar/AiAssistant.qml
@@ -67,6 +67,7 @@ Item {
     // Refresh the model list when switching to an OpenAI-compatible provider, so a
     // key added after startup takes effect without a reload.
     onProviderChanged: {
+        cancelRateLimitRetry();
         if (isOpenaiCompat)
             fetchOpenaiCompatModels(provider);
         else if (isClaude)
@@ -525,6 +526,66 @@ Item {
     }
     property bool inAgentLoop: false
 
+    // Rate limiting. Providers answer a 429 with how long to wait, so honour that
+    // instead of surfacing an error the user can only respond to by waiting anyway.
+    property int rateLimitRetries: 0
+    readonly property int maxRateLimitRetries: 3
+    property bool onFreeTier: false   // learned from the quota metric name in a 429
+
+    // Ticks once a second so the status line counts down rather than showing a
+    // number frozen at whatever the wait started as.
+    property int rateLimitSecondsLeft: 0
+
+    // A pending retry belongs to the conversation and model it was scheduled for.
+    // Without this a wait left over from a cancelled chat fires later and answers
+    // a prompt the user has already moved on from — on whatever model is selected
+    // by then — and those stray requests go on to trigger fresh rate limits.
+    function cancelRateLimitRetry(): void {
+        rateLimitRetryTimer.stop();
+        rateLimitRetryTimer.retryFn = null;
+        rateLimitSecondsLeft = 0;
+        rateLimitRetries = 0;
+    }
+
+    Timer {
+        id: rateLimitRetryTimer
+        interval: 1000
+        repeat: true
+        property var retryFn: null
+        property string forChat: ""
+        property string forModel: ""
+        onTriggered: {
+            root.rateLimitSecondsLeft--;
+            if (root.rateLimitSecondsLeft > 0) {
+                root.currentActionText = qsTr("Rate limited — retrying in %1s…").arg(root.rateLimitSecondsLeft);
+                return;
+            }
+            stop();
+            if (forChat !== root.currentChatId || forModel !== root.activeModel()) {
+                retryFn = null;          // the user moved on; the answer is no longer wanted
+                root.currentActionText = "";
+                root.isTyping = false;
+                root.isThinking = false;
+                root.inAgentLoop = false;
+                return;
+            }
+            if (retryFn) { const f = retryFn; retryFn = null; f(); }
+        }
+    }
+
+    // Seconds to wait, from the provider's own answer: the Retry-After header if
+    // present, else the "retry in 12.3s" the message spells out. Falls back to a
+    // short pause when neither is given.
+    function rateLimitDelayMs(xhr) {
+        const header = xhr.getResponseHeader("Retry-After");
+        if (header && !isNaN(parseFloat(header)))
+            return Math.ceil(parseFloat(header) * 1000) + 500;
+        const m = /retry in ([0-9.]+)\s*s/i.exec(xhr.responseText || "");
+        if (m)
+            return Math.ceil(parseFloat(m[1]) * 1000) + 500;
+        return 15000;
+    }
+
     function shellQuote(str) {
         if (str === null || str === undefined) return "''";
         return "'" + String(str).replace(/'/g, "'\\''") + "'";
@@ -614,7 +675,7 @@ Item {
         } else if (type === "screenshot_encode") {
             var b64 = stdout.replace(/\n/g, "").trim();
             accumulatedToolImage = b64;
-            accumulatedToolResults += "Tool: take_screenshot\nResult: Screenshot taken. Analyze the attached image.\n\n";
+            accumulatedToolResults += "Result of take_screenshot:\nScreenshot taken. Analyse the attached image.\n\n";
             runningToolsCount--;
             checkToolsFinished();
         } else if (type.startsWith("exec_")) {
@@ -624,7 +685,13 @@ Item {
             if (!outText && !errText) {
                 outText = "(Command completed with no output. If it was a background task, it has been launched successfully.)";
             }
-            accumulatedToolResults += "Tool: " + toolName + "\nCommand executed: " + cmd + "\nOutput: " + outText + "\nError: " + errText + "\n\n";
+            // Plain prose, not a pseudo-protocol dump. The old "Tool:/Command
+            // executed:/Output:/Error:" framing made Gemini either imitate the
+            // format back (answering with fake tool output) or refuse outright with
+            // finish_reason function_call_filter: MALFORMED_FUNCTION_CALL and an
+            // empty response, which looked like generation stopping dead. Echoing
+            // the raw command array back at the model never helped it either.
+            accumulatedToolResults += "Result of " + toolName + ":\n" + outText + (errText ? "\n\nErrors reported:\n" + errText : "") + "\n\n";
             runningToolsCount--;
             checkToolsFinished();
         }
@@ -1063,8 +1130,15 @@ Item {
         return root.openaiCompatModels[p || provider] || [];
     }
 
-    function fetchOpenaiCompatModels(p) {
+    // Providers charge a request for their model list too, and on a free tier that
+    // is quota the user would rather spend on answers — so fetch each provider's
+    // list once per session instead of every time the sidebar opens.
+    property var modelsFetched: ({})
+
+    function fetchOpenaiCompatModels(p, force = false) {
         const which = p || provider;
+        if (!force && root.modelsFetched[which])
+            return;
         const key = root.getApiKeyFor(which);
         // OpenRouter publishes its catalogue without auth; the other two need the key.
         if (key === "" && which !== "openrouter")
@@ -1103,6 +1177,10 @@ Item {
                 next[which] = list;
                 root.openaiCompatModels = next;
 
+                const seen = root.modelsFetched;
+                seen[which] = true;
+                root.modelsFetched = seen;
+
                 // Keep the saved default honest: if it isn't offered, fall back to the first.
                 const cfgKey = which === "openai" ? "defaultOpenaiModel" : (which === "gemini" ? "defaultGeminiModel" : "defaultOpenrouterModel");
                 if (list.indexOf(GlobalConfig.ai[cfgKey]) === -1)
@@ -1117,6 +1195,7 @@ Item {
     property var allChatSessions: []
 
     function createNewChat() {
+        cancelRateLimitRetry();
         typingTimer.stop();
         stopClaudeCode();
         isTyping = false;
@@ -1128,6 +1207,7 @@ Item {
     }
 
     function loadChat(id) {
+        cancelRateLimitRetry();
         typingTimer.stop();
         stopClaudeCode();
         isTyping = false;
@@ -1248,6 +1328,7 @@ Item {
     }
 
     function deleteChat(id) {
+        cancelRateLimitRetry();
         var idx = -1;
         for (var i = 0; i < allChatSessions.length; i++) {
             if (allChatSessions[i].id === id) {
@@ -1278,6 +1359,7 @@ Item {
     }
 
     function clearAllHistory() {
+        cancelRateLimitRetry();
         allChatSessions = [];
         historySessionsModel.clear();
         GlobalConfig.ai.ollamaHistoryJson = "[]";
@@ -1419,13 +1501,16 @@ Item {
         saveHistory();
     }
 
-    function sendPrompt(promptText, isSystemToolResult = false, base64Image = null, toolName = "") {
+    function sendPrompt(promptText, isSystemToolResult = false, base64Image = null, toolName = "", isRetry = false) {
         if (!promptText.trim() && !base64Image) return;
 
         // Sending a message dismisses any open prompt suggestions.
         promptSuggestions = [];
 
-        if (!isSystemToolResult) {
+        if (!isRetry)
+            cancelRateLimitRetry();   // a new send supersedes any wait still pending
+
+        if (!isSystemToolResult && !isRetry) {
             chatHistory.append({
                 "isUser": true,
                 "text": promptText || "",
@@ -1653,7 +1738,8 @@ Item {
                 
                 if (xhr.readyState === XMLHttpRequest.DONE) {
                     if (xhr.status === 200) {
-                        chatHistory.setProperty(chatHistory.count - 1, "isFinished", true);
+                            root.rateLimitRetries = 0;
+                    chatHistory.setProperty(chatHistory.count - 1, "isFinished", true);
                         saveHistory();
                         
                         var enableTools = GlobalConfig.ai.enableCelestialMode;
@@ -1750,7 +1836,60 @@ Item {
                         }
                     } else {
                         var providerName = root.providerLabel(root.provider);
-                        var errMsg = (xhr.status === 0) ? "Generation cancelled" : (providerName + " request failed (status " + xhr.status + ")." + ((root.needsApiKey && (xhr.status === 401 || xhr.status === 403)) ? " Check your API key." : ""));
+                        // Providers explain themselves in the error body — a rate limit
+                        // even says how long to wait. Surfacing that beats a bare status
+                        // code the user can do nothing with.
+                        var apiDetail = "";
+                        try {
+                            const errBody = JSON.parse(xhr.responseText);
+                            const e = Array.isArray(errBody) ? (errBody[0] || {}).error : errBody.error;
+                            if (e) {
+                                // OpenRouter wraps the upstream provider's error: its own
+                                // message is just "Provider returned error", and the part
+                                // worth reading (which model, which provider, what to do)
+                                // sits in metadata.raw.
+                                const raw = e.metadata && e.metadata.raw ? String(e.metadata.raw) : "";
+                                const provider = e.metadata && e.metadata.provider_name ? String(e.metadata.provider_name) : "";
+                                if (raw)
+                                    apiDetail = " " + (provider ? provider + ": " : "") + raw.split("\n")[0];
+                                else if (e.message)
+                                    apiDetail = " " + String(e.message).split("\n")[0];
+                            }
+                        } catch (e) {}
+                        // A rate limit is not really a failure — the provider told us
+                        // when it will accept the next request, so wait that long and
+                        // finish the answer instead of dropping it on the user.
+                        // A daily quota does not come back in the seconds the provider
+                        // suggests retrying after, so retrying just spends more of the
+                        // very allowance that ran out. Only wait out short-term limits.
+                        const perDayQuota = /PerDay|per day/i.test(xhr.responseText || "");
+                        if (xhr.status === 429 && perDayQuota)
+                            root.cancelRateLimitRetry();
+
+                        if (xhr.status === 429 && !perDayQuota && root.rateLimitRetries < root.maxRateLimitRetries) {
+                            if ((xhr.responseText || "").indexOf("free_tier") !== -1)
+                                root.onFreeTier = true;
+                            const waitMs = root.rateLimitDelayMs(xhr);
+                            root.rateLimitRetries++;
+                            root.rateLimitSecondsLeft = Math.max(1, Math.round(waitMs / 1000));
+                            root.currentActionText = qsTr("Rate limited — retrying in %1s…").arg(root.rateLimitSecondsLeft);
+                            root.isTyping = true;
+                            root.isThinking = true;
+                            rateLimitRetryTimer.forChat = root.currentChatId;
+                            rateLimitRetryTimer.forModel = root.activeModel();
+                            rateLimitRetryTimer.retryFn = () => root.sendPrompt(promptText, isSystemToolResult, base64Image, toolName, true);
+                            rateLimitRetryTimer.restart();
+                            return;
+                        }
+
+                        var hint = "";
+                        if (xhr.status === 429 && perDayQuota)
+                            hint = " This model's daily free quota is used up — it resets tomorrow. Pick another model, or use Claude Code, which is not on this quota.";
+                        else if (xhr.status === 429)
+                            hint = " Rate limit reached and still limited after " + root.maxRateLimitRetries + " retries — wait a minute and try again.";
+                        else if (root.needsApiKey && (xhr.status === 401 || xhr.status === 403))
+                            hint = " Check your API key.";
+                        var errMsg = (xhr.status === 0) ? "Generation cancelled" : (providerName + " request failed (status " + xhr.status + ")." + hint + apiDetail);
                         var currentText = chatHistory.get(chatHistory.count - 1).text;
                         if (currentText.trim() === "") {
                             chatHistory.setProperty(chatHistory.count - 1, "text", errMsg);
@@ -2798,6 +2937,7 @@ Item {
                                      cursorShape: (inputArea.text.length > 0 || root.isTyping) ? Qt.PointingHandCursor : Qt.ArrowCursor
                                      onClicked: {
                                          if (root.isTyping) {
+                                             root.cancelRateLimitRetry();
                                              if (root.currentRequest) {
                                                  root.currentRequest.abort();
                                              }

--- a/shell/modules/sidebar/Content.qml
+++ b/shell/modules/sidebar/Content.qml
@@ -19,9 +19,15 @@ Item {
 
     property string activeTab: "notifications"
 
+    // The AI tab shows when the master switch is on AND at least one provider is enabled.
+    readonly property bool aiEnabled: GlobalConfig.ai.enableAiAssistant && (GlobalConfig.ai.enableOllama || GlobalConfig.ai.enableClaudeCode || GlobalConfig.ai.enableClaude)
+
     Connections {
         target: GlobalConfig.ai
+        function onEnableAiAssistantChanged() { checkAiTab(); }
         function onEnableOllamaChanged() { checkAiTab(); }
+        function onEnableClaudeCodeChanged() { checkAiTab(); }
+        function onEnableClaudeChanged() { checkAiTab(); }
         function onShowNewsChanged() { checkAiTab(); }
     }
 
@@ -36,7 +42,7 @@ Item {
     }
 
     function checkAiTab() {
-        if (!GlobalConfig.ai.enableOllama && root.activeTab === "ai") {
+        if (!root.aiEnabled && root.activeTab === "ai") {
             root.activeTab = "notifications";
         }
         if (!GlobalConfig.ai.showNews && root.activeTab === "news") {
@@ -69,8 +75,8 @@ Item {
                 Item {
                     id: headerContainer
                     Layout.fillWidth: true
-                    implicitHeight: (!GlobalConfig.ai.enableOllama && !GlobalConfig.ai.showNews) ? 0 : 64
-                    visible: GlobalConfig.ai.enableOllama || GlobalConfig.ai.showNews
+                    implicitHeight: (!root.aiEnabled && !GlobalConfig.ai.showNews) ? 0 : 64
+                    visible: root.aiEnabled || GlobalConfig.ai.showNews
                     clip: true
 
                     RowLayout {
@@ -85,7 +91,7 @@ Item {
                                 var tabs = [
                                     { id: "notifications", label: qsTr("Notifications"), icon: "notifications" }
                                 ];
-                                if (GlobalConfig.ai.enableOllama) {
+                                if (root.aiEnabled) {
                                     tabs.push({ id: "ai", label: qsTr("AI Assistant"), icon: "smart_toy" });
                                 }
                                 if (GlobalConfig.ai.showNews) {
@@ -172,7 +178,7 @@ Item {
                 StyledRect {
                     Layout.fillWidth: true
                     implicitHeight: 1
-                    visible: GlobalConfig.ai.enableOllama || GlobalConfig.ai.showNews
+                    visible: root.aiEnabled || GlobalConfig.ai.showNews
                     color: Colours.palette.m3outlineVariant
                 }
 

--- a/shell/modules/sidebar/Content.qml
+++ b/shell/modules/sidebar/Content.qml
@@ -20,6 +20,10 @@ Item {
     property string activeTab: "notifications"
 
     // The AI tab shows when the master switch is on AND at least one provider is enabled.
+    // True while the assistant is mid-answer, so the sidebar can stay loaded long
+    // enough to finish instead of taking the request down with it when it closes.
+    readonly property bool aiBusy: aiLoader.item ? (aiLoader.item.isTyping || aiLoader.item.inAgentLoop) : false
+
     readonly property bool aiEnabled: GlobalConfig.ai.enableAiAssistant && (GlobalConfig.ai.enableOllama || GlobalConfig.ai.enableClaudeCode || GlobalConfig.ai.enableClaude || GlobalConfig.ai.enableOpenai || GlobalConfig.ai.enableGemini || GlobalConfig.ai.enableOpenrouter)
 
     Connections {
@@ -208,6 +212,7 @@ Item {
                     }
 
                     Loader {
+                        id: aiLoader
                         property bool hasBeenActive: false
                         active: hasBeenActive || root.activeTab === "ai"
                         onActiveChanged: if (active) hasBeenActive = true

--- a/shell/modules/sidebar/Content.qml
+++ b/shell/modules/sidebar/Content.qml
@@ -20,7 +20,7 @@ Item {
     property string activeTab: "notifications"
 
     // The AI tab shows when the master switch is on AND at least one provider is enabled.
-    readonly property bool aiEnabled: GlobalConfig.ai.enableAiAssistant && (GlobalConfig.ai.enableOllama || GlobalConfig.ai.enableClaudeCode || GlobalConfig.ai.enableClaude)
+    readonly property bool aiEnabled: GlobalConfig.ai.enableAiAssistant && (GlobalConfig.ai.enableOllama || GlobalConfig.ai.enableClaudeCode || GlobalConfig.ai.enableClaude || GlobalConfig.ai.enableOpenai || GlobalConfig.ai.enableGemini || GlobalConfig.ai.enableOpenrouter)
 
     Connections {
         target: GlobalConfig.ai
@@ -28,6 +28,9 @@ Item {
         function onEnableOllamaChanged() { checkAiTab(); }
         function onEnableClaudeCodeChanged() { checkAiTab(); }
         function onEnableClaudeChanged() { checkAiTab(); }
+        function onEnableOpenaiChanged() { checkAiTab(); }
+        function onEnableGeminiChanged() { checkAiTab(); }
+        function onEnableOpenrouterChanged() { checkAiTab(); }
         function onShowNewsChanged() { checkAiTab(); }
     }
 

--- a/shell/modules/sidebar/Wrapper.qml
+++ b/shell/modules/sidebar/Wrapper.qml
@@ -14,6 +14,16 @@ Item {
     readonly property Props props: Props {}
 
     readonly property bool shouldBeActive: visibilities.sidebar && Config.sidebar.enabled
+
+    property bool aiBusy: false
+
+    Connections {
+        target: content.item
+        ignoreUnknownSignals: true
+        function onAiBusyChanged(): void {
+            root.aiBusy = content.item ? content.item.aiBusy : false;
+        }
+    }
     property real offsetScale: shouldBeActive ? 0 : 1
 
     visible: offsetScale < 1
@@ -36,7 +46,11 @@ Item {
         anchors.margins: CUtils.clamp(anchors.leftMargin - Config.border.thickness, 0, anchors.leftMargin)
         anchors.bottomMargin: 0
 
-        active: root.shouldBeActive || root.visible
+        // Closing the sidebar used to destroy the assistant along with any request
+        // it had in flight, losing the answer. Stay loaded until it has finished.
+        // root.aiBusy is assigned rather than bound: reading content.item from this
+        // binding would make the loader's own contents decide whether it loads.
+        active: root.shouldBeActive || root.visible || root.aiBusy
 
         sourceComponent: Content {
             implicitWidth: Tokens.sizes.sidebar.width - content.anchors.leftMargin - content.anchors.margins

--- a/shell/plugin/src/Caelestia/Config/aiconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/aiconfig.hpp
@@ -30,6 +30,36 @@ class AiConfig : public ConfigObject {
     CONFIG_PROPERTY(QString, activeProvider, u"ollama"_s)
     CONFIG_PROPERTY(QString, activeOllamaModel, u"llama3"_s)
 
+    // Master switch for the whole sidebar AI assistant (independent of which
+    // providers are enabled). When false, the AI tab is hidden entirely.
+    CONFIG_PROPERTY(bool, enableAiAssistant, true)
+
+    // Claude Code provider: shells out to the `claude` CLI in headless mode, using
+    // the user's existing subscription login (~/.claude) — no API key required.
+    CONFIG_PROPERTY(bool, enableClaudeCode, true)
+    CONFIG_PROPERTY(QString, claudeCodeBin, u"claude"_s)
+    CONFIG_PROPERTY(QString, defaultClaudeCodeModel, u"default"_s)
+    // Effort / thinking level passed to `claude --effort` ("default" = don't pass).
+    CONFIG_PROPERTY(QString, claudeCodeEffort, u"default"_s)
+
+    // Multiple Claude accounts, each backed by its own CLAUDE_CONFIG_DIR.
+    // claudeAccountsJson: JSON array of {"id","name"} (the default ~/.claude login
+    // is always available as an implicit "Default" entry, id ""). activeClaudeAccount
+    // holds the selected account id ("" = default). loginTerminal is the terminal
+    // emulator used for the interactive `claude` login.
+    CONFIG_PROPERTY(QString, claudeAccountsJson, u"[]"_s)
+    CONFIG_PROPERTY(QString, activeClaudeAccount, u""_s)
+    CONFIG_PROPERTY(QString, loginTerminal, u"konsole"_s)
+
+    // Anthropic (Claude) HTTP API provider (pay-per-token, API key).
+    // Disabled by default; enable to expose it in the provider selector.
+    // The API key is stored here in plaintext; the ANTHROPIC_API_KEY environment
+    // variable takes precedence when set (see getApiKey() in AiAssistant.qml).
+    CONFIG_PROPERTY(bool, enableClaude, false)
+    CONFIG_PROPERTY(QString, anthropicApiKey, u""_s)
+    CONFIG_PROPERTY(QString, anthropicUrl, u"https://api.anthropic.com"_s)
+    CONFIG_PROPERTY(QString, defaultClaudeModel, u"claude-sonnet-5"_s)
+
 public:
     explicit AiConfig(QObject* parent = nullptr)
         : ConfigObject(parent) {}

--- a/shell/plugin/src/Caelestia/Config/aiconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/aiconfig.hpp
@@ -58,7 +58,32 @@ class AiConfig : public ConfigObject {
     CONFIG_PROPERTY(bool, enableClaude, false)
     CONFIG_PROPERTY(QString, anthropicApiKey, u""_s)
     CONFIG_PROPERTY(QString, anthropicUrl, u"https://api.anthropic.com"_s)
-    CONFIG_PROPERTY(QString, defaultClaudeModel, u"claude-sonnet-5"_s)
+    CONFIG_PROPERTY(QString, defaultClaudeModel, u""_s)
+
+    // OpenAI-compatible providers. All three speak the same /chat/completions and
+    // /models API, so they share one code path in AiAssistant.qml and differ only
+    // by base URL, key and model list. Each is off by default; the matching
+    // environment variable takes precedence over the key stored here.
+    // The model defaults are empty on purpose: the list is fetched from the
+    // provider, and the first entry is selected until the user picks one, so no
+    // model name has to be maintained here as vendors ship new ones.
+    // OPENAI_API_KEY
+    CONFIG_PROPERTY(bool, enableOpenai, false)
+    CONFIG_PROPERTY(QString, openaiApiKey, u""_s)
+    CONFIG_PROPERTY(QString, openaiUrl, u"https://api.openai.com/v1"_s)
+    CONFIG_PROPERTY(QString, defaultOpenaiModel, u""_s)
+
+    // GEMINI_API_KEY — Google's OpenAI-compatible endpoint, not the native one.
+    CONFIG_PROPERTY(bool, enableGemini, false)
+    CONFIG_PROPERTY(QString, geminiApiKey, u""_s)
+    CONFIG_PROPERTY(QString, geminiUrl, u"https://generativelanguage.googleapis.com/v1beta/openai"_s)
+    CONFIG_PROPERTY(QString, defaultGeminiModel, u""_s)
+
+    // OPENROUTER_API_KEY — aggregator, model ids look like "vendor/model".
+    CONFIG_PROPERTY(bool, enableOpenrouter, false)
+    CONFIG_PROPERTY(QString, openrouterApiKey, u""_s)
+    CONFIG_PROPERTY(QString, openrouterUrl, u"https://openrouter.ai/api/v1"_s)
+    CONFIG_PROPERTY(QString, defaultOpenrouterModel, u""_s)
 
 public:
     explicit AiConfig(QObject* parent = nullptr)

--- a/shell/services/UpdateChecker.qml
+++ b/shell/services/UpdateChecker.qml
@@ -53,6 +53,7 @@ Singleton {
         if (branch !== "") currentBranch = clampBranch(branch);
         else currentBranch = clampBranch(currentBranch);
         checkingUpdates = true;
+        checkClaudeCodeUpdate();
         
         let bashCmd = `
     CURRENT_BRANCH="$1"
@@ -558,6 +559,51 @@ fi
 
     property alias deployConfigs: updaterSettings.deployConfigs
     property alias buildShell: updaterSettings.buildShell
+
+    // ---- Claude Code (the `claude` CLI backing the AI assistant) ----
+    // Checked alongside the shell's own updates so the AI settings page can offer
+    // "Update" or "Check for updates" without having to poll on its own.
+    property string claudeCodeVersion: ""       // installed, "" when not installed
+    property string claudeCodeLatestVersion: "" // newest published, "" when unknown
+    property bool claudeCodeChecking: false
+    readonly property bool claudeCodeInstalled: claudeCodeVersion !== ""
+    readonly property bool claudeCodeHasUpdate: claudeCodeInstalled
+        && claudeCodeLatestVersion !== ""
+        && claudeCodeLatestVersion !== claudeCodeVersion
+
+    function checkClaudeCodeUpdate(): void {
+        if (!GlobalConfig.ai.enableClaudeCode)
+            return;
+        claudeCodeChecking = true;
+        claudeCodeProcess.running = false;
+        claudeCodeProcess.running = true;
+    }
+
+    Process {
+        id: claudeCodeProcess
+
+        // Prints "<installed>|<latest>". The published version comes from the same
+        // endpoint claude.ai/install.sh reads, which is what the settings page's
+        // install/update button runs, so the two can't disagree about what "latest" is.
+        command: ["sh", "-c", `
+BIN="$HOME/.local/bin/claude"
+INSTALLED=""
+[ -x "$BIN" ] && INSTALLED="$("$BIN" --version 2>/dev/null | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' | head -1)"
+LATEST="$(curl -fsSL --max-time 10 https://downloads.claude.ai/claude-code-releases/latest 2>/dev/null | head -1)"
+case "$LATEST" in [0-9]*) ;; *) LATEST="" ;; esac
+echo "$INSTALLED|$LATEST"
+`]
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const parts = (text || "").trim().split("|");
+                root.claudeCodeVersion = (parts[0] || "").trim();
+                root.claudeCodeLatestVersion = (parts[1] || "").trim();
+                root.claudeCodeChecking = false;
+            }
+        }
+        onExited: root.claudeCodeChecking = false
+    }
 
     Timer {
         interval: 30000


### PR DESCRIPTION


---

## Fixes folded in after live testing

The providers were then exercised against their real APIs, which turned up several things the first revision got wrong:

- **Tool results broke the agent loop on Gemini.** They were handed back as a pseudo-protocol dump (`Tool: / Command executed: / Output: / Error:`). Gemini's OpenAI-compatible endpoint refuses that: the follow-up turn returns no content and `finish_reason: function_call_filter: MALFORMED_FUNCTION_CALL`, so the assistant announces a search and stops dead. Drop only the empty assistant message and it answers but *imitates the framing*, replying with invented tool output. Results now go back as plain prose.
- **Rate limits are waited out**, using the delay the provider states, with a countdown in the status line. A pending retry belongs to the conversation and model it was scheduled for and is dropped if either changes — otherwise it later answers an abandoned prompt on whatever model is now selected, and spends quota seeding further limits. Per-day quotas are not retried at all, since the suggested delay is seconds while the allowance returns tomorrow.
- **Errors say what actually happened**, including the upstream error OpenRouter nests in `metadata.raw` (its own message is only "Provider returned error").
- **Model lists are fetched once per session**, not on every sidebar open — on a free tier those requests alone could exhaust the quota.
- **Closing the sidebar no longer kills an in-flight answer.**

All verified against the live APIs rather than reasoned about: the malformed-function-call refusal and its fix, the retry-delay parsing (`59.141469639s`), the per-day quota (`GenerateRequestsPerDayPerProjectPerModel-FreeTier`, value 20), and OpenRouter's nested 429.
