### PR TITLE
fix(launcher): unstick the window switcher after a fast Alt+Tab

### DIFF
--- a/shell/modules/launcher/Content.qml
+++ b/shell/modules/launcher/Content.qml
@@ -252,6 +252,12 @@ Item {
                             search.text = Visibilities.launcherInitialSearch;
                             Visibilities.launcherInitialSearch = "";
                         }
+                        // Re-opening reuses an already-built Content, which does not
+                        // run Component.onCompleted again — without this the search
+                        // field never regains focus, and since the Alt release that
+                        // commits the window switcher is delivered to this field,
+                        // the switcher would stay open and stop cycling.
+                        search.forceActiveFocus();
                     }
                 }
 

--- a/shell/modules/launcher/Wrapper.qml
+++ b/shell/modules/launcher/Wrapper.qml
@@ -15,6 +15,23 @@ Item {
 
     readonly property bool shouldBeActive: visibilities.launcher && Config.launcher.enabled
 
+    // Building the launcher's content is the expensive part of opening it, and it
+    // used to happen on every open — noticeably slow the first time and while a
+    // game has the CPU busy. Worse, the window switcher commits on the Alt release
+    // delivered to the search field, so anything that delays the field appearing
+    // is a window in which a quick Alt+Tab leaves the switcher stuck open.
+    //
+    // Build it once and keep it: after the first open, and pre-emptively a few
+    // seconds into the session so even that first Alt+Tab is instant.
+    property bool contentBuilt: false
+
+    Timer {
+        interval: 5000
+        running: !root.contentBuilt && Config.launcher.enabled
+        repeat: false
+        onTriggered: root.contentBuilt = true
+    }
+
     readonly property real maxHeight: {
         let max = screen.height - Config.border.thickness * 2 + Tokens.padding.extraLarge;
         if (visibilities.dashboard)
@@ -25,9 +42,10 @@ Item {
     property real offsetScale: shouldBeActive ? 0 : 1
 
     onShouldBeActiveChanged: {
-        if (shouldBeActive)
+        if (shouldBeActive) {
+            contentBuilt = true;
             implicitHeight = Qt.binding(() => content.implicitHeight);
-        else
+        } else
             implicitHeight = implicitHeight; // Break binding during close anim
     }
 
@@ -51,7 +69,8 @@ Item {
         anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
 
-        active: root.shouldBeActive || root.visible
+        active: root.shouldBeActive || root.visible || root.contentBuilt
+        asynchronous: !root.shouldBeActive
 
         sourceComponent: Component {
             Content {

--- a/shell/modules/launcher/Wrapper.qml
+++ b/shell/modules/launcher/Wrapper.qml
@@ -15,22 +15,6 @@ Item {
 
     readonly property bool shouldBeActive: visibilities.launcher && Config.launcher.enabled
 
-    // Building the launcher's content is the expensive part of opening it, and it
-    // used to happen on every open — noticeably slow the first time and while a
-    // game has the CPU busy. Worse, the window switcher commits on the Alt release
-    // delivered to the search field, so anything that delays the field appearing
-    // is a window in which a quick Alt+Tab leaves the switcher stuck open.
-    //
-    // Build it once and keep it: after the first open, and pre-emptively a few
-    // seconds into the session so even that first Alt+Tab is instant.
-    property bool contentBuilt: false
-
-    Timer {
-        interval: 5000
-        running: !root.contentBuilt && Config.launcher.enabled
-        repeat: false
-        onTriggered: root.contentBuilt = true
-    }
 
     readonly property real maxHeight: {
         let max = screen.height - Config.border.thickness * 2 + Tokens.padding.extraLarge;
@@ -43,7 +27,6 @@ Item {
 
     onShouldBeActiveChanged: {
         if (shouldBeActive) {
-            contentBuilt = true;
             implicitHeight = Qt.binding(() => content.implicitHeight);
         } else
             implicitHeight = implicitHeight; // Break binding during close anim
@@ -69,8 +52,7 @@ Item {
         anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
 
-        active: root.shouldBeActive || root.visible || root.contentBuilt
-        asynchronous: !root.shouldBeActive
+        active: root.shouldBeActive || root.visible
 
         sourceComponent: Component {
             Content {

--- a/shell/modules/launcher/items/WindowSwitcherItem.qml
+++ b/shell/modules/launcher/items/WindowSwitcherItem.qml
@@ -73,17 +73,27 @@ Item {
         implicitWidth: Tokens.sizes.launcher.windowSwitcherWidth
         implicitHeight: implicitWidth / 16 * 9
 
+        // Asking KWin for a live PipeWire feed is the expensive part of showing the
+        // switcher, and it used to happen for every window at once, 20ms after the
+        // list was built — which is exactly when the machine is busiest, and the
+        // reason the switcher stutters on first open while a game is running.
+        // Only previews actually on the path ask for a feed, and only once they
+        // have settled, so cycling quickly past a window no longer starts a stream
+        // that is dropped a frame later.
+        readonly property bool previewWanted: root.PathView.onPath
+
         Timer {
-            id: debounceTimer
-            interval: 20
-            running: true
+            id: settleTimer
+            property bool settled: false
+            interval: 120
+            running: previewBox.previewWanted && !settled
             repeat: false
-            onTriggered: screencastLoader.active = true
+            onTriggered: settled = true
         }
 
         Loader {
             id: screencastLoader
-            active: false
+            active: previewBox.previewWanted && settleTimer.settled
             sourceComponent: WindowScreencastRequest {
                 uuid: root.modelData?.address ?? ""
             }

--- a/shell/modules/launcher/items/WindowSwitcherItem.qml
+++ b/shell/modules/launcher/items/WindowSwitcherItem.qml
@@ -73,27 +73,17 @@ Item {
         implicitWidth: Tokens.sizes.launcher.windowSwitcherWidth
         implicitHeight: implicitWidth / 16 * 9
 
-        // Asking KWin for a live PipeWire feed is the expensive part of showing the
-        // switcher, and it used to happen for every window at once, 20ms after the
-        // list was built — which is exactly when the machine is busiest, and the
-        // reason the switcher stutters on first open while a game is running.
-        // Only previews actually on the path ask for a feed, and only once they
-        // have settled, so cycling quickly past a window no longer starts a stream
-        // that is dropped a frame later.
-        readonly property bool previewWanted: root.PathView.onPath
-
         Timer {
-            id: settleTimer
-            property bool settled: false
-            interval: 120
-            running: previewBox.previewWanted && !settled
+            id: debounceTimer
+            interval: 20
+            running: true
             repeat: false
-            onTriggered: settled = true
+            onTriggered: screencastLoader.active = true
         }
 
         Loader {
             id: screencastLoader
-            active: previewBox.previewWanted && settleTimer.settled
+            active: false
             sourceComponent: WindowScreencastRequest {
                 uuid: root.modelData?.address ?? ""
             }


### PR DESCRIPTION
## What

Pressing Alt+Tab quickly sometimes leaves the window switcher **open and no longer cycling**.

## Why

`Component.onCompleted` focuses the launcher's search field, but re-opening reuses a `Content` that is already built, so that never runs again — and `onLauncherChanged` set the search text without focusing it. The Alt release that commits the switcher is delivered to that field (`Keys.onReleased`), so with focus elsewhere the release is never seen: the switcher stays open and stops cycling.

## Fix

Re-opening focuses the search field the same way the first open does.

## Verified

Confirmed at runtime: `activeFocus == true` after a re-open, where previously nothing set it at all.

## What was dropped from this PR

Two performance changes were in earlier revisions of this branch and have both been removed after testing:

- **Keeping the launcher content built** (and pre-building it a few seconds into the session), to take construction off the open path. It held everything the launcher had loaded — including full-size wallpaper images — resident for the whole session, and the resulting memory pressure made unrelated things crawl: changing a wallpaper took minutes with the shell over a gigabyte resident.
- **Gating each window preview's screencast request** on `PathView.onPath` plus a settle delay, so the switcher would not ask KWin for a feed for every window at once. This broke the previews.

Both were speculative optimisations that I had not verified against the behaviour they changed, unlike the focus fix. Mentioning them in case either idea looks tempting later — neither is as free as it appears.

## Note

Independent of #253, #254, #255 and #257.
