### PR TITLE
fix(launcher): stop the previous list rendering on top of the new one

### DIFF
--- a/shell/modules/launcher/ContentList.qml
+++ b/shell/modules/launcher/ContentList.qml
@@ -76,19 +76,6 @@ Item {
         }
     }
 
-    onStateChanged: {
-        if (state === "keybinds") {
-            keybindsList.active = true;
-        } else {
-            keybindsList.active = false;
-        }
-        if (state === "animations") {
-            animationsList.active = true;
-        } else {
-            animationsList.active = false;
-        }
-    }
-
     states: [
         State {
             name: "apps"
@@ -97,10 +84,6 @@ Item {
                 target: root
                 implicitWidth: root.Tokens.sizes.launcher.itemWidth
                 implicitHeight: Math.min(root.maxHeight, appList.implicitHeight > 0 ? appList.implicitHeight : empty.implicitHeight)
-            }
-            PropertyChanges {
-                target: appList
-                active: true
             }
 
         },
@@ -112,10 +95,6 @@ Item {
                 implicitWidth: Math.max(root.Tokens.sizes.launcher.itemWidth * 1.2, wallpaperList.implicitWidth)
                 implicitHeight: root.Tokens.sizes.launcher.wallpaperHeight + 56 // Extra space for color buttons
             }
-            PropertyChanges {
-                target: wallpaperList
-                active: true
-            }
         },
         State {
             name: "windowSwitcher"
@@ -124,10 +103,6 @@ Item {
                 target: root
                 implicitWidth: Math.max(root.Tokens.sizes.launcher.itemWidth * 1.2, windowSwitcherList.implicitWidth)
                 implicitHeight: root.Tokens.sizes.launcher.windowSwitcherHeight
-            }
-            PropertyChanges {
-                target: windowSwitcherList
-                active: true
             }
         },
         State {
@@ -138,10 +113,6 @@ Item {
                 implicitWidth: root.Tokens.sizes.launcher.itemWidth
                 implicitHeight: Math.min(root.maxHeight, root.Tokens.sizes.launcher.itemHeight * 7)
             }
-            PropertyChanges {
-                target: keybindsList
-                active: true
-            }
 
         },
         State {
@@ -151,10 +122,6 @@ Item {
                 target: root
                 implicitWidth: root.Tokens.sizes.launcher.itemWidth
                 implicitHeight: Math.min(root.maxHeight, root.Tokens.sizes.launcher.itemHeight * 7)
-            }
-            PropertyChanges {
-                target: animationsList
-                active: true
             }
 
         }
@@ -171,10 +138,18 @@ Item {
         }
     }
 
+    // Each list owns its own `active`, derived from the state it belongs to.
+    // It used to be set from two places at once — `PropertyChanges` in the states
+    // and an imperative onStateChanged handler — which broke state restoration:
+    // entering a state captured the value the imperative write had just set, so
+    // leaving it "restored" active back to true and the old list stayed loaded,
+    // drawing on top of the new one. Binding to root.state (rather than the
+    // show* flags) keeps the existing cross-fade timing, since the state change
+    // itself is deferred by the Behavior below.
     Loader {
         id: appList
 
-        active: false
+        active: root.state === "apps"
 
         anchors.fill: parent
 
@@ -188,7 +163,7 @@ Item {
         id: wallpaperList
 
         asynchronous: true
-        active: false
+        active: root.state === "wallpapers"
 
         anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
@@ -328,7 +303,7 @@ Item {
         id: windowSwitcherList
 
         asynchronous: true
-        active: false
+        active: root.state === "windowSwitcher"
 
         anchors.top: parent.top
         anchors.bottom: parent.bottom
@@ -345,7 +320,7 @@ Item {
     Loader {
         id: keybindsList
 
-        active: false
+        active: root.state === "keybinds"
 
         anchors.fill: parent
 
@@ -358,7 +333,7 @@ Item {
     Loader {
         id: animationsList
 
-        active: false
+        active: root.state === "animations"
 
         anchors.fill: parent
 


### PR DESCRIPTION
## What

Open the launcher's keybinds list (`>keybinds`), then clear the search text. The keybinds entries stay on screen and the app list paints on top of them — both sets of rows render superimposed.

The same applies to the animations list.

## Why

Each list's `Loader.active` was set from two places at once:

```qml
onStateChanged: {
    if (state === "keybinds") keybindsList.active = true;
    else keybindsList.active = false;
    ...
}

State {
    name: "keybinds"
    PropertyChanges { target: keybindsList; active: true }
}
```

`PropertyChanges` captures the property's value on state entry so it can restore it on exit. Because the imperative handler had already written `true`, that is the value captured — so leaving the state "restores" `active` back to `true` and the list never unloads. All the list Loaders are `anchors.fill: parent` siblings, so the stale one simply keeps drawing underneath the new one.

## Fix

Give each Loader sole ownership of its own `active`, derived from the state it belongs to, and drop both the `PropertyChanges` and the imperative handler:

```qml
Loader {
    id: keybindsList
    active: root.state === "keybinds"
}
```

Binding to `root.state` rather than to the `show*` flags is deliberate: the state change is deferred by the `Behavior on state` cross-fade, so this keeps the existing fade timing instead of unloading the outgoing list a frame early.

The `implicitWidth`/`implicitHeight` `PropertyChanges` are untouched — only the `active` ones are removed.

## Verified

Instrumented the settled loader values across transitions: exactly one list is active in each state (`apps` → only `appList`, `keybinds` → only `keybindsList`), where previously the outgoing one stayed loaded. The reporter also confirmed the overlap is gone in normal use.

Independent of #253, #254, #255 and #256 — #256 also touches the launcher but a different file.
