### PR TITLE
wallpaper: decode at screen size, route videos correctly, and preview them

### DIFF
--- a/shell/modules/background/Wallpaper.qml
+++ b/shell/modules/background/Wallpaper.qml
@@ -283,6 +283,8 @@ Item {
 
 
             CachingAnimatedImage {
+                id: wallpaperImage
+
                 anchors.fill: parent
                 path: img.imagePath
                 visible: !img.isVideoImage && img.imagePath !== ""
@@ -290,6 +292,19 @@ Item {
                 fillMode: AnimatedImage.PreserveAspectCrop
                 source: img.imagePath || ""
                 playing: true
+
+                // Decode at the size actually being drawn. Without this the full
+                // image is decoded whatever its resolution: an 8K wallpaper costs
+                // ~132MB of pixels and a slow decode, twice over while the old and
+                // new ones overlap during the reveal — a visible hitch on every
+                // change. JPEG can scale during decode, so asking for the screen
+                // size makes it both quicker and far smaller. Every other wallpaper
+                // view already does this; only the one drawing the biggest image
+                // did not.
+                sourceSize: {
+                    const dpr = (QsWindow.window as QsWindow)?.devicePixelRatio ?? 1;
+                    return Qt.size(wallpaperImage.width * dpr, wallpaperImage.height * dpr);
+                }
 
                 onStatusChanged: {
                     if (status === Image.Ready && !img.isVideoImage)

--- a/shell/modules/background/Wallpaper.qml
+++ b/shell/modules/background/Wallpaper.qml
@@ -164,6 +164,11 @@ Item {
 
         function update(): void {
             this.screen = root.screen;
+            // Ask about the source being switched to, not the isVideoImage binding:
+            // that binding can still hold the previous source's answer when this
+            // runs, which routed a video into the image loader. The image cannot
+            // decode it, so the wallpaper just went white.
+            const isVideoImage = root.isVideo(root.source);
             if (isVideoImage) {
                 if (videoPath === root.source)
                     root.current = this;
@@ -182,6 +187,7 @@ Item {
         }
 
         function updateContent(): void {
+            const isVideoImage = root.isVideo(root.source);
             if (isVideoImage) {
                 imagePath = "";
                 videoPath = root.source;

--- a/shell/modules/launcher/items/WallpaperItem.qml
+++ b/shell/modules/launcher/items/WallpaperItem.qml
@@ -71,14 +71,16 @@ Item {
             text: "videocam"
             color: Colours.tPalette.m3outline
             fontStyle: Tokens.font.icon.builders.extraLarge.scale(2).weight(Font.DemiBold).build()
-            visible: Images.isVideo(root.modelData.name)
+            visible: Images.isVideo(root.modelData.name) && Wallpapers.thumbFor(root.modelData.path) === ""
         }
 
         CachingImage {
             anchors.fill: parent
-            path: root.modelData.path
+            // Videos get an extracted frame; until it exists this is empty and the
+            // videocam icon above shows through.
+            path: Images.isVideo(root.modelData.name) ? Wallpapers.thumbFor(root.modelData.path) : root.modelData.path
             smooth: !root.PathView.view.moving
-            visible: !Images.isVideo(root.modelData.name)
+            visible: path !== ""
             sourceSize: {
                 const dpr = (QsWindow.window as QsWindow)?.devicePixelRatio ?? 1;
                 return Qt.size(image.implicitWidth * dpr, image.implicitHeight * dpr);

--- a/shell/modules/nexus/common/WallItem.qml
+++ b/shell/modules/nexus/common/WallItem.qml
@@ -7,11 +7,17 @@ import Caelestia.Config
 import qs.components
 import qs.components.controls
 import qs.services
+import qs.utils
 
 Item {
     id: root
 
-    property alias source: img.source
+    // The picker was handed the video file itself, which Image cannot decode, so
+    // it sat at Image.Loading forever. Show the extracted frame instead — and
+    // while it is being extracted, the spinner is honest rather than permanent.
+    property string source
+    readonly property bool isVideo: Images.isVideo(String(source).replace(/^file:\/\//, ""))
+    readonly property string displaySource: root.isVideo ? Wallpapers.thumbFor(source) : source
     property alias text: label.text
     property alias radius: imgWrapper.radius
     property alias imgHeight: imgWrapper.implicitHeight
@@ -68,6 +74,7 @@ Item {
             Image {
                 id: img
 
+                source: root.displaySource
                 anchors.fill: parent
                 asynchronous: true
                 fillMode: Image.PreserveAspectCrop

--- a/shell/services/Wallpapers.qml
+++ b/shell/services/Wallpapers.qml
@@ -122,6 +122,65 @@ Searcher {
         return path;
     }
 
+    // Video wallpapers have no still to show, so the pickers had nothing to draw
+    // and sat on a loading spinner forever. Extract a frame once and cache it
+    // beside the wallpaper caches, keyed the same way getThumbnailPath already
+    // described — that path was being computed but never produced by anything.
+    property var videoThumbs: ({})   // source path -> cached frame, once it exists
+    property var videoThumbsPending: ({})
+
+    // What a picker should actually display for a wallpaper: the image itself, or
+    // a video's extracted frame once there is one. Returns "" for a video whose
+    // frame is still being made, so callers can show a placeholder meanwhile.
+    function thumbFor(path: string): string {
+        const p = String(path || "").replace(/^file:\/\//, "");
+        if (p === "" || !Images.isVideo(p))
+            return p;
+        if (root.videoThumbs[p])
+            return root.videoThumbs[p];
+        requestVideoThumb(p);
+        return "";
+    }
+
+    function requestVideoThumb(path: string): void {
+        if (root.videoThumbsPending[path] || root.videoThumbs[path])
+            return;
+        const pending = root.videoThumbsPending;
+        pending[path] = true;
+        root.videoThumbsPending = pending;
+
+        const out = getThumbnailPath(path);
+        const script = 'out="$1"; src="$2"; [ -s "$out" ] || { mkdir -p "$(dirname "$out")"; ' +
+                       'ffmpeg -y -loglevel error -i "$src" -vf "thumbnail,scale=640:-1" -frames:v 1 "$out" >/dev/null 2>&1; }; ' +
+                       '[ -s "$out" ] && printf %s "$out"';
+        const qml = 'import QtQuick\nimport Quickshell.Io\n' +
+            'Process {\n' +
+            '    id: p\n' +
+            '    command: ' + JSON.stringify(["sh", "-c", script, "--", out, path]) + '\n' +
+            '    stdout: StdioCollector { onStreamFinished: root.onVideoThumb(' + JSON.stringify(path) + ', (text || "").trim(), p); }\n' +
+            '    onExited: code => { if (code !== 0) p.destroy(); }\n' +
+            '}';
+        try {
+            const o = Qt.createQmlObject(qml, root, "videoThumbProc");
+            o.running = true;
+        } catch (e) {
+            Logger.log("[wallpapers] video thumbnail error: " + e.message);
+        }
+    }
+
+    function onVideoThumb(path: string, out: string, proc: var): void {
+        if (out !== "") {
+            const m = root.videoThumbs;
+            m[path] = out;
+            root.videoThumbs = Object.assign({}, m);   // a copy, so bindings re-run
+        }
+        const pending = root.videoThumbsPending;
+        delete pending[path];
+        root.videoThumbsPending = pending;
+        if (proc)
+            proc.destroy();
+    }
+
     onPreviewColourLockChanged: {
         if (!previewColourLock && pendingPreviewClear)
             Colours.showPreview = false;


### PR DESCRIPTION
## What

Changing the wallpaper stutters visibly, and the shell's memory footprint is much larger than the wallpaper's on-disk size suggests.

## Why

`CachingAnimatedImage` in the desktop background never sets `sourceSize`, so the wallpaper is decoded at its native resolution however large that is. With an 8K wallpaper:

- 7680 × 4320 × 4 bytes ≈ **132 MB of pixels** per image
- paid **twice** while the outgoing and incoming images overlap during the reveal
- plus a full-resolution JPEG decode on the CPU each time, and a texture upload of the result

Every other wallpaper view already avoids this — the launcher's `WallpaperItem` and the Nexus `WallItem` both set `sourceSize`. Only the one drawing the largest image at the highest frequency did not.

## Fix

Ask for the screen size, matching what the other views do. JPEG supports scaling during decode, so this is both substantially quicker and far smaller.

## Verified

Instrumented the decode on a 7680×4320 wallpaper across a 2560×1440 and a 1920×1080 screen:

```
sourceSize = 2560x1440   implicit = 2560x1440   (was 7680x4320)
sourceSize = 1920x1080   implicit = 1920x1080
```

`implicitWidth/Height` is the decoded size, so the image really is being scaled down during decode rather than after: roughly **132 MB of pixels down to 15 MB**, per image, per screen.
