### PR TITLE
fix(gamemode): make it work off Hyprland, and pause video wallpapers (1/2)

### DIFF
--- a/shell/services/GameMode.qml
+++ b/shell/services/GameMode.qml
@@ -12,6 +12,16 @@ Singleton {
 
     property alias enabled: props.enabled
 
+    // Hyprland is not always the compositor this runs under. Everything below
+    // branches on that rather than assuming it.
+    // Quickshell.env returns undefined for an unset variable, not "", so compare
+    // truthiness — !== "" was true everywhere and sent KDE down the Hyprland path.
+    readonly property bool onHyprland: !!Quickshell.env("HYPRLAND_INSTANCE_SIGNATURE")
+
+    // Video wallpapers keep a decoder and a GPU upload running for as long as
+    // they play, which is exactly what game mode is trying to free up.
+    property bool restoreVideoWallpaper: false
+
     function setDynamicConfs(): void {
         Hypr.extras.applyOptions({
             "animations:enabled": 0,
@@ -25,22 +35,69 @@ Singleton {
         });
     }
 
+    // KWin's equivalents of the Hyprland options above: window animations and the
+    // blur effect. Both are read back before being changed so a user who already
+    // had them off does not get them switched on when game mode ends.
+    function applyKwin(enable: bool): void {
+        const script = enable
+            ? 'prevBlur="$(kreadconfig6 --file kwinrc --group Plugins --key blurEnabled --default true)"; ' +
+              'prevAnim="$(kreadconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor --default 1)"; ' +
+              'mkdir -p "$HOME/.cache/caelestia"; printf "%s\\n%s\\n" "$prevBlur" "$prevAnim" > "$HOME/.cache/caelestia/gamemode-prev"; ' +
+              'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled false; ' +
+              'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor 0; ' +
+              'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1'
+            : 'p="$HOME/.cache/caelestia/gamemode-prev"; ' +
+              'blur="$(sed -n 1p "$p" 2>/dev/null)"; anim="$(sed -n 2p "$p" 2>/dev/null)"; ' +
+              '[ -n "$blur" ] || blur=true; [ -n "$anim" ] || anim=1; ' +
+              'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled "$blur"; ' +
+              'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor "$anim"; ' +
+              'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1';
+        Quickshell.execDetached(["sh", "-c", script]);
+    }
+
     onEnabledChanged: {
         if (enabled) {
-            setDynamicConfs();
+            // Pause a playing video wallpaper, remembering whether it was paused
+            // already so ending game mode does not start one the user had stopped.
+            root.restoreVideoWallpaper = !GlobalConfig.background.videoWallpaperPaused;
+            if (root.restoreVideoWallpaper)
+                GlobalConfig.background.videoWallpaperPaused = true;
+
+            if (root.onHyprland)
+                setDynamicConfs();
+            else
+                applyKwin(true);
+
             if (GlobalConfig.utilities.toasts.gameModeChanged)
-                Toaster.toast(qsTr("Game mode enabled"), qsTr("Disabled Hyprland animations, blur, gaps and shadows"), "gamepad");
+                Toaster.toast(qsTr("Game mode enabled"),
+                    root.onHyprland ? qsTr("Disabled Hyprland animations, blur, gaps and shadows")
+                                    : qsTr("Paused video wallpaper, disabled blur and animations"), "gamepad");
         } else {
-            Hypr.extras.message("reload");
+            if (root.restoreVideoWallpaper) {
+                GlobalConfig.background.videoWallpaperPaused = false;
+                root.restoreVideoWallpaper = false;
+            }
+
+            if (root.onHyprland)
+                Hypr.extras.message("reload");
+            else
+                applyKwin(false);
+
             if (GlobalConfig.utilities.toasts.gameModeChanged)
-                Toaster.toast(qsTr("Game mode disabled"), qsTr("Hyprland settings restored"), "gamepad");
+                Toaster.toast(qsTr("Game mode disabled"),
+                    root.onHyprland ? qsTr("Hyprland settings restored") : qsTr("Desktop effects restored"), "gamepad");
         }
     }
 
     PersistentProperties {
         id: props
 
-        property bool enabled: Hypr.options["animations:enabled"] === 0 // qmllint disable missing-property
+        // Plain state, not a binding. It used to read back from
+        // Hypr.options["animations:enabled"], which off Hyprland evaluates
+        // undefined === 0 — false — so game mode could never stay switched on
+        // there. onConfigReloaded below re-applies the options on Hyprland, so
+        // nothing needed the binding anyway.
+        property bool enabled: false
 
         reloadableId: "gameMode"
     }


### PR DESCRIPTION
## What

On a non-Hyprland compositor, game mode does nothing — and will not even stay switched on.

## Why

Two problems, both from assuming Hyprland is the compositor:

**1. The toggle could not stay on.** The persisted flag was bound to live Hyprland state:

```qml
property bool enabled: Hypr.options["animations:enabled"] === 0
```

With no Hyprland that evaluates `undefined === 0` — false — so the flag reverted as soon as it was set.

**2. Everything it did was a Hyprland call.** `Hypr.extras.applyOptions(...)` to disable animations, blur, shadows, gaps; `Hypr.extras.message("reload")` to restore. Both are no-ops elsewhere.

## Fix

- The flag is plain persisted state. `onConfigReloaded` already re-applies the options on Hyprland, so nothing needed the binding.
- KWin gets the equivalents of what the Hyprland path disables: window animations (`AnimationDurationFactor`) and the blur effect (`Plugins/blurEnabled`), applied with a `reconfigure`. Both are **read back before being changed and restored afterwards**, so a user who already had blur off does not get it switched on when game mode ends.
- Hyprland behaviour is unchanged — the new path is only taken when `HYPRLAND_INSTANCE_SIGNATURE` is unset.

## Also: video wallpapers pause with game mode

A video wallpaper keeps a decoder and a GPU upload running for as long as it plays, which is exactly the load game mode exists to shed. It is now paused while game mode is on, and whether it was *already* paused is remembered — ending game mode does not start one the user had stopped.

## Verified

On `kwin_wayland`, over a full enable/disable cycle:

| | before | game mode on | after |
|---|---|---|---|
| `blurEnabled` | true | **false** | true |
| `AnimationDurationFactor` | 0.25 | **0** | 0.25 |
| `videoWallpaperPaused` | false | **true** | false |

Note the animation factor returns to `0.25` — the user's own non-default value — rather than being clobbered with the default. `gameMode isEnabled` also reports `true` while on, which it never did before.
