### PR TITLE
feat(ai): add the provider seam, and discover models honestly (1/3)

### DIFF
--- a/shell/modules/sidebar/AiAssistant.qml
+++ b/shell/modules/sidebar/AiAssistant.qml
@@ -90,6 +90,30 @@ Item {
     }
 
     property var ollamaModelsList: []
+
+    // Which backend the chat talks to. Only Ollama exists today; this is the seam
+    // the others slot into, so the chat never has to know which one is active.
+    readonly property string provider: GlobalConfig.ai.defaultProvider || "ollama"
+
+    // Providers offered in the selector, respecting their enable toggles. Never
+    // empty — falling back to Ollama beats presenting no choice at all.
+    readonly property var providerList: {
+        const l = [];
+        if (GlobalConfig.ai.enableOllama)
+            l.push("ollama");
+        if (l.length === 0)
+            l.push("ollama");
+        return l;
+    }
+
+    function providerLabel(p: string): string {
+        return "Ollama";
+    }
+
+    // The model to send for the active provider.
+    function activeModel(): string {
+        return GlobalConfig.ai.defaultOllamaModel || root.ollamaModelsList[0] || "";
+    }
     property bool isTyping: false
     property bool isThinking: false
     property string currentThoughtText: ""
@@ -229,12 +253,12 @@ Item {
                             }
                         }
                         if (list.length > 0) {
+                            // Only what this instance actually has pulled — a guessed
+                            // list just offers models that are not installed.
                             ollamaModelsList = list;
                             if (list.indexOf(GlobalConfig.ai.defaultOllamaModel) === -1) {
                                 GlobalConfig.ai.defaultOllamaModel = list[0];
                             }
-                        } else {
-                            ollamaModelsList = ["llama3", "mistral", "phi3", "gemma"];
                         }
                     } catch (e) {
                         Logger.log("Error parsing Ollama models: " + e.message);
@@ -904,13 +928,43 @@ Item {
              Item { Layout.fillWidth: true } // Spacer pushes Model Selector to the right
 
              // Model Selector Split Button
+             // Provider selector. Hidden while there is only one to choose from, so
+             // it costs nothing until more than Ollama is available.
+             SplitButton {
+                 id: providerSelector
+                 type: SplitButton.Tonal
+                 verticalPadding: 4
+                 visible: root.providerList.length > 1
+
+                 active: menuItems.find(m => m.modelData === root.provider) ?? menuItems[0] ?? null
+                 menu.onItemSelected: item => {
+                     GlobalConfig.ai.defaultProvider = item.modelData;
+                 }
+
+                 menuItems: providerVariants.instances
+
+                 fallbackIcon: "hub"
+                 fallbackText: qsTr("Provider")
+                 stateLayer.disabled: true
+
+                 Variants {
+                     id: providerVariants
+                     model: root.providerList
+
+                     delegate: MenuItem {
+                         required property string modelData
+                         text: root.providerLabel(modelData)
+                     }
+                 }
+             }
+
              SplitButton {
                  id: modelSelector
                  type: SplitButton.Tonal
                  verticalPadding: 4
                  Layout.preferredWidth: implicitWidth
 
-                 active: menuItems.find(m => m.modelData === GlobalConfig.ai.defaultOllamaModel) ?? menuItems[0] ?? null
+                 active: menuItems.find(m => m.modelData === root.activeModel()) ?? menuItems[0] ?? null
                  menu.onItemSelected: item => {
                      GlobalConfig.ai.defaultOllamaModel = item.modelData;
                  }
@@ -923,9 +977,7 @@ Item {
 
                  Variants {
                      id: modelVariants
-                     model: {
-                         return root.ollamaModelsList && root.ollamaModelsList.length > 0 ? root.ollamaModelsList : ["llama3", "mistral", "phi3", "gemma"];
-                     }
+                     model: root.ollamaModelsList
 
                      delegate: MenuItem {
                          required property string modelData

--- a/shell/modules/sidebar/Content.qml
+++ b/shell/modules/sidebar/Content.qml
@@ -19,8 +19,13 @@ Item {
 
     property string activeTab: "notifications"
 
+    // The assistant has its own switch now, so turning a provider off no longer
+    // takes the whole tab with it.
+    readonly property bool aiEnabled: GlobalConfig.ai.enableAiAssistant && GlobalConfig.ai.enableOllama
+
     Connections {
         target: GlobalConfig.ai
+        function onEnableAiAssistantChanged() { checkAiTab(); }
         function onEnableOllamaChanged() { checkAiTab(); }
         function onShowNewsChanged() { checkAiTab(); }
     }
@@ -36,7 +41,7 @@ Item {
     }
 
     function checkAiTab() {
-        if (!GlobalConfig.ai.enableOllama && root.activeTab === "ai") {
+        if (!root.aiEnabled && root.activeTab === "ai") {
             root.activeTab = "notifications";
         }
         if (!GlobalConfig.ai.showNews && root.activeTab === "news") {
@@ -69,8 +74,8 @@ Item {
                 Item {
                     id: headerContainer
                     Layout.fillWidth: true
-                    implicitHeight: (!GlobalConfig.ai.enableOllama && !GlobalConfig.ai.showNews) ? 0 : 64
-                    visible: GlobalConfig.ai.enableOllama || GlobalConfig.ai.showNews
+                    implicitHeight: (!root.aiEnabled && !GlobalConfig.ai.showNews) ? 0 : 64
+                    visible: root.aiEnabled || GlobalConfig.ai.showNews
                     clip: true
 
                     RowLayout {
@@ -85,7 +90,7 @@ Item {
                                 var tabs = [
                                     { id: "notifications", label: qsTr("Notifications"), icon: "notifications" }
                                 ];
-                                if (GlobalConfig.ai.enableOllama) {
+                                if (root.aiEnabled) {
                                     tabs.push({ id: "ai", label: qsTr("AI Assistant"), icon: "smart_toy" });
                                 }
                                 if (GlobalConfig.ai.showNews) {
@@ -172,7 +177,7 @@ Item {
                 StyledRect {
                     Layout.fillWidth: true
                     implicitHeight: 1
-                    visible: GlobalConfig.ai.enableOllama || GlobalConfig.ai.showNews
+                    visible: root.aiEnabled || GlobalConfig.ai.showNews
                     color: Colours.palette.m3outlineVariant
                 }
 

--- a/shell/plugin/src/Caelestia/Config/aiconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/aiconfig.hpp
@@ -22,6 +22,10 @@ class AiConfig : public ConfigObject {
 
     CONFIG_PROPERTY(QString, defaultProvider, u"ollama"_s)
     CONFIG_PROPERTY(bool, enableOllama, true)
+
+    // Master switch for the sidebar assistant, independent of which providers are
+    // enabled — so turning a provider off no longer means losing the whole tab.
+    CONFIG_PROPERTY(bool, enableAiAssistant, true)
     CONFIG_PROPERTY(bool, enableCelestialMode, true)
     CONFIG_PROPERTY(bool, showNews, true)
     CONFIG_PROPERTY(bool, showCaelestiaMode, true)


### PR DESCRIPTION
First of the three pieces #255 is being split into, as agreed there. **Ollama remains the only provider — nothing here changes what the assistant talks to.** This is just the seam the others slot into.

## What

- **A provider abstraction** the chat reads through: `provider`, `providerList`, `providerLabel()`, `activeModel()`. The chat no longer reaches for `defaultOllamaModel` directly, so adding a backend later does not mean touching the send path. A provider selector sits next to the model selector and stays **hidden while there is only one choice**, so it costs nothing today.
- **`enableAiAssistant`** — a master switch for the sidebar tab. Turning Ollama off used to remove the whole assistant; the two are now independent.
- **Honest model discovery** — the list no longer falls back to inventing `llama3/mistral/phi3/gemma` when the daemon is unreachable. Offering models that are not installed is worse than showing none, and every provider added later reports its own list.

## Verified

Builds clean and loads with no QML errors. With a single provider the UI is unchanged by design, so there is deliberately nothing new to see yet.

## Next

2. Claude Code provider — the CLI path, multi-account
3. HTTP providers — Claude API, ChatGPT, Gemini, OpenRouter on one shared OpenAI-compatible path, plus keyring storage, the settings page and the libsecret dependency

Originally planned as four; the fourth was agent-loop hardening, which turned out to be fixes to code introduced in (3) rather than separate work — see #263 for the reasoning.
