### PR TITLE
feat(ai): add Claude Code as a provider (2/3)

### DIFF
--- a/shell/modules/sidebar/AiAssistant.qml
+++ b/shell/modules/sidebar/AiAssistant.qml
@@ -86,10 +86,311 @@ Item {
 
     Component.onCompleted: {
         fetchOllamaModels();
+        fetchClaudeCodeModels();
         loadHistory();
     }
 
     property var ollamaModelsList: []
+
+    property var claudeCodeModelsList: ["default"]
+    readonly property var claudeCodeEffortOptions: {
+        var lv = effortLevelsFor(activeModel());
+        return lv.length > 0 ? ["default"].concat(lv) : [];
+    }
+    property var claudeCodeSessions: ({})
+
+    function claudeCodeBinPath() {
+        var b = (GlobalConfig.ai.claudeCodeBin || "claude").trim();
+        if (b === "" || b === "claude") {
+            var home = Quickshell.env("HOME") || "";
+            if (home !== "")
+                return home + "/.local/bin/claude";
+            return "claude";
+        }
+        return b;
+    }
+
+    function claudeAccounts() {
+        var list = [{ "id": "", "name": "Default", "dir": "" }];
+        try {
+            var parsed = JSON.parse(GlobalConfig.ai.claudeAccountsJson || "[]");
+            if (Array.isArray(parsed)) {
+                var home = Quickshell.env("HOME") || "";
+                for (var i = 0; i < parsed.length; i++) {
+                    var a = parsed[i];
+                    if (a && a.id)
+                        list.push({
+                            "id": String(a.id),
+                            "name": String(a.name || a.id),
+                            "dir": home + "/.config/caelestia/claude/" + String(a.id)
+                        });
+                }
+            }
+        } catch (e) {}
+        return list;
+    }
+
+    function activeClaudeConfigDir() {
+        return activeClaudeAccountObj().dir || "";
+    }
+
+    function claudeCodeEnvSnippet() {
+        var dir = activeClaudeConfigDir();
+        if (dir && dir !== "")
+            return "    environment: ({ \"CLAUDE_CONFIG_DIR\": " + JSON.stringify(dir) + " })\n";
+        return "";
+    }
+
+    function claudeCodeTranscript() {
+        var lines = [];
+        var count = 0;
+        for (var i = 0; i < chatHistory.count; i++) {
+            var m = chatHistory.get(i);
+            if (!m.isUser && !m.isFinished)
+                continue;
+            var t = (m.text || "").trim();
+            if (t === "")
+                continue;
+            lines.push((m.isUser ? "User: " : "Assistant: ") + t);
+            count++;
+        }
+        if (count <= 1)
+            return "";
+        return "Continue this conversation. Conversation so far:\n\n" + lines.join("\n\n") + "\n\nReply to the last user message.";
+    }
+
+    function isClaudeCodeAuthError(text) {
+        if (!text)
+            return false;
+        var t = String(text).toLowerCase();
+        return t.indexOf("login") !== -1
+            || t.indexOf("log in") !== -1
+            || t.indexOf("logged in") !== -1
+            || t.indexOf("not authenticated") !== -1
+            || t.indexOf("unauthorized") !== -1
+            || t.indexOf("authentication") !== -1
+            || t.indexOf("oauth") !== -1
+            || t.indexOf("invalid api key") !== -1
+            || t.indexOf("api key") !== -1
+            || t.indexOf("expired") !== -1
+            || t.indexOf("sign in") !== -1
+            || t.indexOf("credentials") !== -1;
+    }
+
+    function effortLevelsFor(model) {
+        var m = String(model || "default").toLowerCase();
+        if (m === "haiku")
+            return [];
+        if (m === "default" || m === "opus" || m === "sonnet" || m === "fable")
+            return ["low", "medium", "high", "xhigh", "max"];
+
+        var fam = m.indexOf("opus") !== -1 ? "opus"
+                : m.indexOf("sonnet") !== -1 ? "sonnet"
+                : m.indexOf("haiku") !== -1 ? "haiku"
+                : m.indexOf("fable") !== -1 ? "fable" : "";
+        var nums = (m.match(/\d+/g) || []).map(Number);
+        var major = nums.length >= 1 ? nums[0] : 0;
+        var minor = nums.length >= 2 ? nums[1] : 0;
+
+        if (fam === "haiku")
+            return [];
+        if (fam === "fable")
+            return ["low", "medium", "high", "xhigh", "max"];
+        if (fam === "opus") {
+            if (major > 4 || (major === 4 && minor >= 7))
+                return ["low", "medium", "high", "xhigh", "max"];
+            if (major === 4 && minor === 6)
+                return ["low", "medium", "high", "max"];
+            if (major === 4 && minor === 5)
+                return ["low", "medium", "high"];
+            return [];
+        }
+        if (fam === "sonnet") {
+            if (major >= 5)
+                return ["low", "medium", "high", "xhigh", "max"];
+            if (major === 4 && minor === 6)
+                return ["low", "medium", "high", "max"];
+            return [];
+        }
+        return [];
+    }
+
+    function fetchClaudeCodeModels() {
+        var bin = claudeCodeBinPath();
+        var script =
+            "t=\"$(readlink -f " + JSON.stringify(bin) + " 2>/dev/null)\"; [ -z \"$t\" ] && t=" + JSON.stringify(bin) + "; " +
+            "strings \"$t\" 2>/dev/null | grep -oE 'claude-(opus|sonnet|haiku|fable)-[0-9]+(-[0-9]+)?' | sort -u";
+        var commandStr = JSON.stringify(["sh", "-c", script]);
+        var qml =
+            "import QtQuick\n" +
+            "import Quickshell.Io\n" +
+            "Process {\n" +
+            "    id: mp\n" +
+            "    command: " + commandStr + "\n" +
+            "    stdout: StdioCollector { onStreamFinished: root.applyClaudeCodeModels(text || \"\"); }\n" +
+            "    onExited: code => mp.destroy()\n" +
+            "}";
+        try {
+            var o = Qt.createQmlObject(qml, root, "ccModelsProc");
+            o.running = true;
+        } catch (e) {
+            Logger.log("[AI] claude-code model fetch error: " + e.message);
+        }
+    }
+
+    function applyClaudeCodeModels(text) {
+        // The binary also embeds unrelated strings that merely start with "claude-"
+        // and long-dead models, so only ids shaped like <family>-<version> survive,
+        // minus dated snapshots (…-20250514) and the ".0" aliases of a base version.
+        var ids = [];
+        var seen = {};
+        const lines = (text || "").split("\n");
+        for (var i = 0; i < lines.length; i++) {
+            const id = lines[i].trim();
+            if (id === "" || seen[id])
+                continue;
+            if (/-\d{5,}$/.test(id) || /-0$/.test(id))
+                continue;
+            seen[id] = true;
+            ids.push(id);
+        }
+
+        // A family's bare major ("claude-opus-4") is just a stub for its newest
+        // minor, so drop it when a more specific id for the same major exists.
+        ids = ids.filter(id => !ids.some(other => other !== id && other.indexOf(id + "-") === 0));
+
+        // Newest first: sort by family version, descending.
+        ids.sort((a, b) => {
+            const va = (a.match(/\d+/g) || []).map(Number);
+            const vb = (b.match(/\d+/g) || []).map(Number);
+            for (var k = 0; k < Math.max(va.length, vb.length); k++) {
+                const d = (vb[k] || 0) - (va[k] || 0);
+                if (d !== 0)
+                    return d;
+            }
+            return a.localeCompare(b);
+        });
+
+        claudeCodeModelsList = ["default"].concat(ids);
+    }
+
+    function sendClaudeCode(promptText) {
+        // Drop any stale empty assistant placeholder, then add a fresh bubble to stream into.
+        for (var i = chatHistory.count - 1; i >= 0; i--) {
+            var m = chatHistory.get(i);
+            if (!m.isUser && !m.isFinished && m.text === "")
+                chatHistory.remove(i);
+        }
+        chatHistory.append({
+            "isUser": false,
+            "text": "",
+            "isFinished": false,
+            "thoughtText": ""
+        });
+        listView.positionViewAtEnd();
+
+        var bin = claudeCodeBinPath();
+        var sid = claudeCodeSessionFor(currentChatId);
+
+        // Fresh session (new chat, or the active account changed) → seed it with the
+        // prior transcript so the new account continues the same conversation.
+        var promptToSend = promptText;
+        if (sid === "") {
+            var transcript = claudeCodeTranscript();
+            if (transcript !== "")
+                promptToSend = transcript;
+        }
+
+        var cmd = [bin, "-p", promptToSend, "--output-format", "stream-json", "--verbose", "--include-partial-messages", "--dangerously-skip-permissions"];
+
+        var mdl = GlobalConfig.ai.defaultClaudeCodeModel || "default";
+        if (mdl && mdl !== "default") {
+            cmd.push("--model");
+            cmd.push(mdl);
+        }
+
+        var eff = GlobalConfig.ai.claudeCodeEffort || "default";
+        if (eff && eff !== "default" && effortLevelsFor(mdl).indexOf(eff) !== -1) {
+            cmd.push("--effort");
+            cmd.push(eff);
+        }
+
+        if (sid !== "") {
+            cmd.push("--resume");
+            cmd.push(sid);
+        }
+
+        var commandStr = JSON.stringify(cmd);
+        var cwdStr = JSON.stringify(claudeCodeCwd());
+        var processQml =
+            "import QtQuick\n" +
+            "import Quickshell.Io\n" +
+            "Process {\n" +
+            "    id: proc\n" +
+            "    command: " + commandStr + "\n" +
+            "    workingDirectory: " + cwdStr + "\n" +
+            claudeCodeEnvSnippet() +
+            "    property string acc: \"\"\n" +
+            "    property string thought: \"\"\n" +
+            "    property string sess: \"\"\n" +
+            "    property string errAcc: \"\"\n" +
+            "    property bool done: false\n" +
+            "    stdout: SplitParser { onRead: line => root.onClaudeCodeLine(proc, line) }\n" +
+            "    stderr: SplitParser { onRead: line => root.logClaudeCodeStderr(proc, line) }\n" +
+            "    onExited: code => root.onClaudeCodeExit(proc, code)\n" +
+            "}";
+        try {
+            var obj = Qt.createQmlObject(processQml, root, "claudeCodeProc");
+            root.currentClaudeCodeProc = obj;
+            obj.running = true;
+        } catch (e) {
+            console.error("CLAUDE CODE PROCESS ERROR: " + e.message);
+            chatHistory.setProperty(chatHistory.count - 1, "text", "⚠️ Failed to launch Claude Code: " + e.message);
+            chatHistory.setProperty(chatHistory.count - 1, "isFinished", true);
+            isTyping = false;
+            isThinking = false;
+            inAgentLoop = false;
+            saveHistory();
+        }
+    }
+
+    function stopClaudeCode() {
+        if (root.currentClaudeCodeProc) {
+            try {
+                root.currentClaudeCodeProc.running = false;
+            } catch (e) {}
+            root.currentClaudeCodeProc = null;
+        }
+    }
+
+    function generateClaudeCodeTitleAsync(chatId, firstMessage) {
+        if (!firstMessage)
+            return;
+        var safeMsg = firstMessage.substring(0, 200);
+        var prompt = "Output ONLY a concise 2-4 word title for the following message. No quotes, no trailing punctuation, no explanation.\n\nMessage: " + safeMsg;
+
+        var cmd = [claudeCodeBinPath(), "-p", prompt, "--output-format", "json", "--dangerously-skip-permissions"];
+        var commandStr = JSON.stringify(cmd);
+        var cwdStr = JSON.stringify(claudeCodeCwd());
+        var chatIdStr = JSON.stringify(chatId);
+        var qml =
+            "import QtQuick\n" +
+            "import Quickshell.Io\n" +
+            "Process {\n" +
+            "    id: tproc\n" +
+            "    command: " + commandStr + "\n" +
+            "    workingDirectory: " + cwdStr + "\n" +
+            claudeCodeEnvSnippet() +
+            "    stdout: StdioCollector { onStreamFinished: root.handleClaudeCodeTitle(" + chatIdStr + ", text || \"\", tproc); }\n" +
+            "    onExited: code => { if (code !== 0) tproc.destroy(); }\n" +
+            "}";
+        try {
+            var obj = Qt.createQmlObject(qml, root, "claudeCodeTitleProc");
+            obj.running = true;
+        } catch (e) {
+            Logger.log("[AI] claude-code title process error: " + e.message);
+        }
+    }
 
     // Which backend the chat talks to. Only Ollama exists today; this is the seam
     // the others slot into, so the chat never has to know which one is active.
@@ -101,17 +402,24 @@ Item {
         const l = [];
         if (GlobalConfig.ai.enableOllama)
             l.push("ollama");
+        if (GlobalConfig.ai.enableClaudeCode)
+            l.push("claude-code");
         if (l.length === 0)
             l.push("ollama");
         return l;
     }
 
     function providerLabel(p: string): string {
-        return "Ollama";
+        return p === "claude-code" ? "Claude Code" : "Ollama";
     }
+
+    // The `claude` CLI, not an HTTP endpoint — it drives a subprocess instead.
+    readonly property bool isClaudeCode: provider === "claude-code"
 
     // The model to send for the active provider.
     function activeModel(): string {
+        if (isClaudeCode)
+            return GlobalConfig.ai.defaultClaudeCodeModel || "default";
         return GlobalConfig.ai.defaultOllamaModel || root.ollamaModelsList[0] || "";
     }
     property bool isTyping: false
@@ -546,6 +854,13 @@ Item {
         } else {
             currentActionText = "Thinking...";
         }
+
+        // Claude Code drives a subprocess, not an HTTP request.
+        if (root.isClaudeCode) {
+            root.sendClaudeCode(promptText);
+            return;
+        }
+
         var xhr = new XMLHttpRequest();
         root.currentRequest = xhr;
 
@@ -966,7 +1281,12 @@ Item {
 
                  active: menuItems.find(m => m.modelData === root.activeModel()) ?? menuItems[0] ?? null
                  menu.onItemSelected: item => {
-                     GlobalConfig.ai.defaultOllamaModel = item.modelData;
+                     if (root.isClaudeCode) {
+                         GlobalConfig.ai.defaultClaudeCodeModel = item.modelData;
+                         // Effort levels differ per model — reset when it changes.
+                         GlobalConfig.ai.claudeCodeEffort = "default";
+                     } else
+                         GlobalConfig.ai.defaultOllamaModel = item.modelData;
                  }
 
                  menuItems: modelVariants.instances
@@ -977,7 +1297,37 @@ Item {
 
                  Variants {
                      id: modelVariants
-                     model: root.ollamaModelsList
+                     model: root.isClaudeCode ? root.claudeCodeModelsList : root.ollamaModelsList
+
+                     delegate: MenuItem {
+                         required property string modelData
+                         text: modelData
+                     }
+                 }
+             }
+
+             // Effort / thinking level. Which levels a model supports varies, and
+             // several support none — the selector hides itself in that case.
+             SplitButton {
+                 id: effortSelector
+                 type: SplitButton.Tonal
+                 verticalPadding: 4
+                 visible: root.isClaudeCode && root.claudeCodeEffortOptions.length > 0
+
+                 active: menuItems.find(m => m.modelData === (GlobalConfig.ai.claudeCodeEffort || "default")) ?? menuItems[0] ?? null
+                 menu.onItemSelected: item => {
+                     GlobalConfig.ai.claudeCodeEffort = item.modelData;
+                 }
+
+                 menuItems: effortVariants.instances
+
+                 fallbackIcon: "psychology"
+                 fallbackText: qsTr("Effort")
+                 stateLayer.disabled: true
+
+                 Variants {
+                     id: effortVariants
+                     model: root.claudeCodeEffortOptions
 
                      delegate: MenuItem {
                          required property string modelData
@@ -1551,6 +1901,7 @@ Item {
                                          if (root.isTyping) {
                                              if (root.currentRequest) {
                                                  root.currentRequest.abort();
+                                             root.stopClaudeCode();
                                              }
                                              root.isTyping = false;
                                              root.isThinking = false;

--- a/shell/modules/sidebar/AiAssistant.qml
+++ b/shell/modules/sidebar/AiAssistant.qml
@@ -90,6 +90,30 @@ Item {
     }
 
     property var ollamaModelsList: []
+
+    // Which backend the chat talks to. Only Ollama exists today; this is the seam
+    // the others slot into, so the chat never has to know which one is active.
+    readonly property string provider: GlobalConfig.ai.defaultProvider || "ollama"
+
+    // Providers offered in the selector, respecting their enable toggles. Never
+    // empty — falling back to Ollama beats presenting no choice at all.
+    readonly property var providerList: {
+        const l = [];
+        if (GlobalConfig.ai.enableOllama)
+            l.push("ollama");
+        if (l.length === 0)
+            l.push("ollama");
+        return l;
+    }
+
+    function providerLabel(p: string): string {
+        return "Ollama";
+    }
+
+    // The model to send for the active provider.
+    function activeModel(): string {
+        return GlobalConfig.ai.defaultOllamaModel || root.ollamaModelsList[0] || "";
+    }
     property bool isTyping: false
     property bool isThinking: false
     property string currentThoughtText: ""
@@ -229,12 +253,12 @@ Item {
                             }
                         }
                         if (list.length > 0) {
+                            // Only what this instance actually has pulled — a guessed
+                            // list just offers models that are not installed.
                             ollamaModelsList = list;
                             if (list.indexOf(GlobalConfig.ai.defaultOllamaModel) === -1) {
                                 GlobalConfig.ai.defaultOllamaModel = list[0];
                             }
-                        } else {
-                            ollamaModelsList = ["llama3", "mistral", "phi3", "gemma"];
                         }
                     } catch (e) {
                         Logger.log("Error parsing Ollama models: " + e.message);
@@ -904,13 +928,43 @@ Item {
              Item { Layout.fillWidth: true } // Spacer pushes Model Selector to the right
 
              // Model Selector Split Button
+             // Provider selector. Hidden while there is only one to choose from, so
+             // it costs nothing until more than Ollama is available.
+             SplitButton {
+                 id: providerSelector
+                 type: SplitButton.Tonal
+                 verticalPadding: 4
+                 visible: root.providerList.length > 1
+
+                 active: menuItems.find(m => m.modelData === root.provider) ?? menuItems[0] ?? null
+                 menu.onItemSelected: item => {
+                     GlobalConfig.ai.defaultProvider = item.modelData;
+                 }
+
+                 menuItems: providerVariants.instances
+
+                 fallbackIcon: "hub"
+                 fallbackText: qsTr("Provider")
+                 stateLayer.disabled: true
+
+                 Variants {
+                     id: providerVariants
+                     model: root.providerList
+
+                     delegate: MenuItem {
+                         required property string modelData
+                         text: root.providerLabel(modelData)
+                     }
+                 }
+             }
+
              SplitButton {
                  id: modelSelector
                  type: SplitButton.Tonal
                  verticalPadding: 4
                  Layout.preferredWidth: implicitWidth
 
-                 active: menuItems.find(m => m.modelData === GlobalConfig.ai.defaultOllamaModel) ?? menuItems[0] ?? null
+                 active: menuItems.find(m => m.modelData === root.activeModel()) ?? menuItems[0] ?? null
                  menu.onItemSelected: item => {
                      GlobalConfig.ai.defaultOllamaModel = item.modelData;
                  }
@@ -923,9 +977,7 @@ Item {
 
                  Variants {
                      id: modelVariants
-                     model: {
-                         return root.ollamaModelsList && root.ollamaModelsList.length > 0 ? root.ollamaModelsList : ["llama3", "mistral", "phi3", "gemma"];
-                     }
+                     model: root.ollamaModelsList
 
                      delegate: MenuItem {
                          required property string modelData

--- a/shell/modules/sidebar/Content.qml
+++ b/shell/modules/sidebar/Content.qml
@@ -19,8 +19,13 @@ Item {
 
     property string activeTab: "notifications"
 
+    // The assistant has its own switch now, so turning a provider off no longer
+    // takes the whole tab with it.
+    readonly property bool aiEnabled: GlobalConfig.ai.enableAiAssistant && GlobalConfig.ai.enableOllama
+
     Connections {
         target: GlobalConfig.ai
+        function onEnableAiAssistantChanged() { checkAiTab(); }
         function onEnableOllamaChanged() { checkAiTab(); }
         function onShowNewsChanged() { checkAiTab(); }
     }
@@ -36,7 +41,7 @@ Item {
     }
 
     function checkAiTab() {
-        if (!GlobalConfig.ai.enableOllama && root.activeTab === "ai") {
+        if (!root.aiEnabled && root.activeTab === "ai") {
             root.activeTab = "notifications";
         }
         if (!GlobalConfig.ai.showNews && root.activeTab === "news") {
@@ -69,8 +74,8 @@ Item {
                 Item {
                     id: headerContainer
                     Layout.fillWidth: true
-                    implicitHeight: (!GlobalConfig.ai.enableOllama && !GlobalConfig.ai.showNews) ? 0 : 64
-                    visible: GlobalConfig.ai.enableOllama || GlobalConfig.ai.showNews
+                    implicitHeight: (!root.aiEnabled && !GlobalConfig.ai.showNews) ? 0 : 64
+                    visible: root.aiEnabled || GlobalConfig.ai.showNews
                     clip: true
 
                     RowLayout {
@@ -85,7 +90,7 @@ Item {
                                 var tabs = [
                                     { id: "notifications", label: qsTr("Notifications"), icon: "notifications" }
                                 ];
-                                if (GlobalConfig.ai.enableOllama) {
+                                if (root.aiEnabled) {
                                     tabs.push({ id: "ai", label: qsTr("AI Assistant"), icon: "smart_toy" });
                                 }
                                 if (GlobalConfig.ai.showNews) {
@@ -172,7 +177,7 @@ Item {
                 StyledRect {
                     Layout.fillWidth: true
                     implicitHeight: 1
-                    visible: GlobalConfig.ai.enableOllama || GlobalConfig.ai.showNews
+                    visible: root.aiEnabled || GlobalConfig.ai.showNews
                     color: Colours.palette.m3outlineVariant
                 }
 

--- a/shell/plugin/src/Caelestia/Config/aiconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/aiconfig.hpp
@@ -23,6 +23,21 @@ class AiConfig : public ConfigObject {
     CONFIG_PROPERTY(QString, defaultProvider, u"ollama"_s)
     CONFIG_PROPERTY(bool, enableOllama, true)
 
+    // Claude Code provider: shells out to the `claude` CLI in headless mode using
+    // the user's existing subscription login (~/.claude) — no API key involved.
+    CONFIG_PROPERTY(bool, enableClaudeCode, false)
+    CONFIG_PROPERTY(QString, claudeCodeBin, u"claude"_s)
+    CONFIG_PROPERTY(QString, defaultClaudeCodeModel, u"default"_s)
+    // Effort / thinking level passed to `claude --effort` ("default" = don't pass).
+    CONFIG_PROPERTY(QString, claudeCodeEffort, u"default"_s)
+
+    // Multiple logins, each backed by its own CLAUDE_CONFIG_DIR. claudeAccountsJson
+    // is a JSON array of {"id","name"}; the ~/.claude login is always present as an
+    // implicit "Default" (id ""). loginTerminal is used for the interactive login.
+    CONFIG_PROPERTY(QString, claudeAccountsJson, u"[]"_s)
+    CONFIG_PROPERTY(QString, activeClaudeAccount, u""_s)
+    CONFIG_PROPERTY(QString, loginTerminal, u"konsole"_s)
+
     // Master switch for the sidebar assistant, independent of which providers are
     // enabled — so turning a provider off no longer means losing the whole tab.
     CONFIG_PROPERTY(bool, enableAiAssistant, true)

--- a/shell/plugin/src/Caelestia/Config/aiconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/aiconfig.hpp
@@ -22,6 +22,10 @@ class AiConfig : public ConfigObject {
 
     CONFIG_PROPERTY(QString, defaultProvider, u"ollama"_s)
     CONFIG_PROPERTY(bool, enableOllama, true)
+
+    // Master switch for the sidebar assistant, independent of which providers are
+    // enabled — so turning a provider off no longer means losing the whole tab.
+    CONFIG_PROPERTY(bool, enableAiAssistant, true)
     CONFIG_PROPERTY(bool, enableCelestialMode, true)
     CONFIG_PROPERTY(bool, showNews, true)
     CONFIG_PROPERTY(bool, showCaelestiaMode, true)


### PR DESCRIPTION
Second of the three pieces #255 is being split into. Stacked on #261 — review that one first; this diff is against it.

## What

Adds **Claude Code** as a provider: the `claude` CLI driven headlessly against the user's existing subscription login in `~/.claude`, so it needs **no API key**.

- Streams `stream-json` from the CLI, resumes sessions, and generates chat titles through it.
- **Models are read from the installed binary** rather than hardcoded, so the list tracks the CLI as it updates instead of going stale in-tree.
- **Effort levels are resolved per model.** Not every model exposes the same set and several expose none, so the selector hides itself rather than offering levels that do not exist.
- **Multiple logins** via per-account `CLAUDE_CONFIG_DIR`. Switching account mid-conversation replays the transcript, because a bare `--resume` fails across accounts.

Off by default — enabling it in config is what puts it in the selector, so nothing changes for anyone who does not.

## Verified

Builds clean, loads with no QML errors, the provider registers when enabled and the CLI's model list resolves.

One bug worth noting, found while testing rather than reasoned about: the early return that routes sends to the CLI initially landed in `fetchOllamaModels()` instead of `sendPrompt()` — same `XMLHttpRequest` line in both — and showed up as `ReferenceError: promptText is not defined`. Fixed and re-verified.

## Not included here

The Settings → AI Assistant page (install/update/login UI for Claude Code) is deliberately left out to keep this reviewable; it comes with piece 3, where the other providers' key entry lives and it can be built once for all of them.

## Next

3. HTTP providers — Claude API, ChatGPT, Gemini, OpenRouter on one shared OpenAI-compatible path, plus keyring storage, the settings page and the libsecret dependency

That was originally two PRs; the agent-loop hardening turned out to be fixes to code introduced in (3) rather than separate work, so it ships with it — see #263.
