### PR TITLE
feat(gamemode): act on the auto-enable rules (2/2)

### DIFF
--- a/shell/services/GameMode.qml
+++ b/shell/services/GameMode.qml
@@ -12,6 +12,16 @@ Singleton {
 
     property alias enabled: props.enabled
 
+    // Hyprland is not always the compositor this runs under. Everything below
+    // branches on that rather than assuming it.
+    // Quickshell.env returns undefined for an unset variable, not "", so compare
+    // truthiness — !== "" was true everywhere and sent KDE down the Hyprland path.
+    readonly property bool onHyprland: !!Quickshell.env("HYPRLAND_INSTANCE_SIGNATURE")
+
+    // Video wallpapers keep a decoder and a GPU upload running for as long as
+    // they play, which is exactly what game mode is trying to free up.
+    property bool restoreVideoWallpaper: false
+
     function setDynamicConfs(): void {
         Hypr.extras.applyOptions({
             "animations:enabled": 0,
@@ -25,22 +35,69 @@ Singleton {
         });
     }
 
+    // KWin's equivalents of the Hyprland options above: window animations and the
+    // blur effect. Both are read back before being changed so a user who already
+    // had them off does not get them switched on when game mode ends.
+    function applyKwin(enable: bool): void {
+        const script = enable
+            ? 'prevBlur="$(kreadconfig6 --file kwinrc --group Plugins --key blurEnabled --default true)"; ' +
+              'prevAnim="$(kreadconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor --default 1)"; ' +
+              'mkdir -p "$HOME/.cache/caelestia"; printf "%s\\n%s\\n" "$prevBlur" "$prevAnim" > "$HOME/.cache/caelestia/gamemode-prev"; ' +
+              'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled false; ' +
+              'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor 0; ' +
+              'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1'
+            : 'p="$HOME/.cache/caelestia/gamemode-prev"; ' +
+              'blur="$(sed -n 1p "$p" 2>/dev/null)"; anim="$(sed -n 2p "$p" 2>/dev/null)"; ' +
+              '[ -n "$blur" ] || blur=true; [ -n "$anim" ] || anim=1; ' +
+              'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled "$blur"; ' +
+              'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor "$anim"; ' +
+              'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1';
+        Quickshell.execDetached(["sh", "-c", script]);
+    }
+
     onEnabledChanged: {
         if (enabled) {
-            setDynamicConfs();
+            // Pause a playing video wallpaper, remembering whether it was paused
+            // already so ending game mode does not start one the user had stopped.
+            root.restoreVideoWallpaper = !GlobalConfig.background.videoWallpaperPaused;
+            if (root.restoreVideoWallpaper)
+                GlobalConfig.background.videoWallpaperPaused = true;
+
+            if (root.onHyprland)
+                setDynamicConfs();
+            else
+                applyKwin(true);
+
             if (GlobalConfig.utilities.toasts.gameModeChanged)
-                Toaster.toast(qsTr("Game mode enabled"), qsTr("Disabled Hyprland animations, blur, gaps and shadows"), "gamepad");
+                Toaster.toast(qsTr("Game mode enabled"),
+                    root.onHyprland ? qsTr("Disabled Hyprland animations, blur, gaps and shadows")
+                                    : qsTr("Paused video wallpaper, disabled blur and animations"), "gamepad");
         } else {
-            Hypr.extras.message("reload");
+            if (root.restoreVideoWallpaper) {
+                GlobalConfig.background.videoWallpaperPaused = false;
+                root.restoreVideoWallpaper = false;
+            }
+
+            if (root.onHyprland)
+                Hypr.extras.message("reload");
+            else
+                applyKwin(false);
+
             if (GlobalConfig.utilities.toasts.gameModeChanged)
-                Toaster.toast(qsTr("Game mode disabled"), qsTr("Hyprland settings restored"), "gamepad");
+                Toaster.toast(qsTr("Game mode disabled"),
+                    root.onHyprland ? qsTr("Hyprland settings restored") : qsTr("Desktop effects restored"), "gamepad");
         }
     }
 
     PersistentProperties {
         id: props
 
-        property bool enabled: Hypr.options["animations:enabled"] === 0 // qmllint disable missing-property
+        // Plain state, not a binding. It used to read back from
+        // Hypr.options["animations:enabled"], which off Hyprland evaluates
+        // undefined === 0 — false — so game mode could never stay switched on
+        // there. onConfigReloaded below re-applies the options on Hyprland, so
+        // nothing needed the binding anyway.
+        property bool enabled: false
 
         reloadableId: "gameMode"
     }

--- a/shell/services/GameMode.qml
+++ b/shell/services/GameMode.qml
@@ -5,6 +5,7 @@ import Quickshell
 import Quickshell.Io
 import Caelestia
 import Caelestia.Config
+import Caelestia.Services
 import qs.services
 
 Singleton {
@@ -21,6 +22,58 @@ Singleton {
     // Video wallpapers keep a decoder and a GPU upload running for as long as
     // they play, which is exactly what game mode is trying to free up.
     property bool restoreVideoWallpaper: false
+
+    // ---- Auto-enable rules ----
+    // The rules were editable in settings but nothing ever evaluated them, so
+    // launching a listed game did nothing. Watch the open windows and match them.
+    // Only a run that switched itself on switches itself back off, so a manual
+    // toggle is never undone by a game closing.
+    property bool autoEnabled: false
+
+    readonly property var _windows: {
+        if (typeof KWinActiveWindowBridge !== "undefined" && KWinActiveWindowBridge.windowList && KWinActiveWindowBridge.windowList.length > 0)
+            return KWinActiveWindowBridge.windowList;
+        return HyprlandData.windowList;
+    }
+
+    function _matchesRule(w): bool {
+        const rules = GlobalConfig.utilities.gameMode.autoEnableRegexes || [];
+        if (rules.length === 0 || !w)
+            return false;
+        const fields = [w.class || "", w.initialClass || "", w.title || ""];
+        for (let i = 0; i < rules.length; i++) {
+            const rule = String(rules[i] || "");
+            if (rule === "")
+                continue;
+            for (let f = 0; f < fields.length; f++) {
+                if (fields[f] === rule)
+                    return true;          // plain name, the common case
+                try {
+                    if (new RegExp(rule).test(fields[f]))
+                        return true;
+                } catch (e) {
+                    // A rule like "Minecraft* 1.21.11" is a window title, not a
+                    // valid regex — the exact match above already covers it.
+                }
+            }
+        }
+        return false;
+    }
+
+    on_WindowsChanged: {
+        const wins = root._windows || [];
+        let matched = false;
+        for (let i = 0; i < wins.length; i++)
+            if (root._matchesRule(wins[i])) { matched = true; break; }
+
+        if (matched && !root.enabled) {
+            root.autoEnabled = true;
+            root.enabled = true;
+        } else if (!matched && root.enabled && root.autoEnabled) {
+            root.autoEnabled = false;
+            root.enabled = false;
+        }
+    }
 
     function setDynamicConfs(): void {
         Hypr.extras.applyOptions({
@@ -56,6 +109,9 @@ Singleton {
     }
 
     onEnabledChanged: {
+        if (!enabled)
+            root.autoEnabled = false;
+
         if (enabled) {
             // Pause a playing video wallpaper, remembering whether it was paused
             // already so ending game mode does not start one the user had stopped.


### PR DESCRIPTION
Split out of #260 as asked. Stacked on it — review that one first; this diff is the 56 lines on top.

## What

`utilities.gameMode.autoEnableRegexes` was editable in Settings but **nothing anywhere evaluated it**. It appears only in the config definition and the page that edits the list, so a user could add `Minecraft* 1.21.11`, launch the game, and nothing would happen — the UI promised something the shell never acted on.

The rules are now matched against the open windows, from the same source the dock and switcher use (`KWinActiveWindowBridge.windowList`, falling back to `HyprlandData.windowList`), on class, initial class and title.

## Two details worth a look

**Each rule is tried as a plain name before being treated as a regex.** Entries like `Minecraft* 1.21.11` are window titles, not patterns — handing that straight to `new RegExp()` either throws or matches something unintended (`t*` meaning "zero or more t"). Exact match first, regex as a fallback, and a rule that fails to compile is skipped rather than taking the evaluation down with it.

**Only a run that switched itself on switches itself back off.** A manual toggle is never undone by a game closing, which would otherwise be a confusing way to lose your setting.

## Verified

Builds and loads clean. The matching itself I have not been able to exercise end to end — it needs a listed game actually running, and I could not reproduce that here reliably. The mechanism is the same window list the dock already renders from, so the data is known good, but treat the match path as untested if that matters to you.
