### PR TITLE
fix: don't run gdbus through a shell in GlobalShortcut

### DIFF
--- a/shell/plugin/src/Caelestia/Services/globalshortcut.cpp
+++ b/shell/plugin/src/Caelestia/Services/globalshortcut.cpp
@@ -3,9 +3,49 @@
 #include <KGlobalAccel>
 #include <QKeySequence>
 #include <QDebug>
-#include <cstdlib>
+#include <QProcess>
 #include "../Config/config.hpp"
 #include "../Config/generalconfig.hpp"
+
+namespace {
+
+// gdbus parses its arguments as GVariant text, where single quotes delimit
+// strings. Component and action names come from other applications'
+// KGlobalAccel registrations, so they are untrusted input and must be escaped
+// before being placed inside a quoted GVariant string.
+QString escapeGVariantString(const QString &value)
+{
+    QString escaped = value;
+    escaped.replace('\\', QStringLiteral("\\\\"));
+    escaped.replace('\'', QStringLiteral("\\'"));
+    return escaped;
+}
+
+// Passes the arguments as real argv entries so no shell ever re-parses them.
+void setShortcutKeys(const QString &component, const QString &action, const QString &keys)
+{
+    QProcess proc;
+    proc.setProgram(QStringLiteral("gdbus"));
+    proc.setArguments({
+        QStringLiteral("call"),
+        QStringLiteral("--session"),
+        QStringLiteral("--dest"), QStringLiteral("org.kde.kglobalaccel"),
+        QStringLiteral("--object-path"), QStringLiteral("/kglobalaccel"),
+        QStringLiteral("--method"), QStringLiteral("org.kde.KGlobalAccel.setShortcutKeys"),
+        QString("['%1', '%2', '', '']").arg(escapeGVariantString(component), escapeGVariantString(action)),
+        keys,
+        QStringLiteral("4"),
+    });
+    proc.setStandardOutputFile(QProcess::nullDevice());
+    proc.setStandardErrorFile(QProcess::nullDevice());
+    proc.start();
+    if (!proc.waitForFinished(2000)) {
+        proc.kill();
+        proc.waitForFinished(200);
+    }
+}
+
+} // namespace
 
 GlobalShortcut::GlobalShortcut(QObject *parent)
     : QObject(parent), m_action(new QAction(this))
@@ -31,14 +71,7 @@ GlobalShortcut::~GlobalShortcut()
             arrayStr = "[([0, 0, 0, 0],)]";
         }
         
-        QString cmd = QString("gdbus call --session --dest org.kde.kglobalaccel "
-                              "--object-path /kglobalaccel "
-                              "--method org.kde.KGlobalAccel.setShortcutKeys "
-                              "\"['%1', '%2', '', '']\" \"%3\" 4 > /dev/null 2>&1")
-                              .arg(stolen.component)
-                              .arg(stolen.action)
-                              .arg(arrayStr);
-        system(cmd.toUtf8().constData());
+        setShortcutKeys(stolen.component, stolen.action, arrayStr);
     }
 }
 
@@ -128,13 +161,8 @@ void GlobalShortcut::updateShortcut()
                 }
 
                 // 2. Unbind foreign shortcuts natively via gdbus
-                QString cmd = QString("gdbus call --session --dest org.kde.kglobalaccel "
-                                      "--object-path /kglobalaccel "
-                                      "--method org.kde.KGlobalAccel.setShortcutKeys "
-                                      "\"['%1', '%2', '', '']\" \"[([0, 0, 0, 0],)]\" 4 > /dev/null 2>&1")
-                                      .arg(info.componentUniqueName())
-                                      .arg(info.uniqueName());
-                system(cmd.toUtf8().constData());
+                setShortcutKeys(info.componentUniqueName(), info.uniqueName(),
+                                QStringLiteral("[([0, 0, 0, 0],)]"));
             }
         }
     }


### PR DESCRIPTION
Closes #272.

`~GlobalShortcut()` and `updateShortcut()` built a gdbus command line by interpolating `componentUniqueName()` and `uniqueName()` into a string and ran it with `system()`. Those names come from other applications KGlobalAccel registrations, not from Caelestia, so a single quote in either one closes the quoted argument and `/bin/sh` runs whatever follows with the user privileges. It fires whenever a shortcut conflict is detected, or on shutdown when stolen shortcuts are restored.

Both call sites now go through one helper that runs gdbus via `QProcess` with an argument list, so the values become real argv entries and no shell re-parses them. They are also escaped for GVariant text, because gdbus itself parses that argument as GVariant where single quotes delimit strings.

Behaviour is otherwise unchanged: the call still blocks, now with a 2s timeout instead of none.

Checked the escaping output directly — `evil'; rm -rf ~ #` comes out as `evil\'; rm -rf ~ #` inside the GVariant string rather than terminating it.