### PR TITLE
fix: pick up scheme.json when it's created after startup

### DIFF
--- a/shell/plugin/src/Caelestia/Services/schemeloader.cpp
+++ b/shell/plugin/src/Caelestia/Services/schemeloader.cpp
@@ -5,6 +5,7 @@
 
 #include <qdir.h>
 #include <qfile.h>
+#include <qfileinfo.h>
 #include <qfilesystemwatcher.h>
 #include <qjsondocument.h>
 #include <qjsonobject.h>
@@ -23,15 +24,24 @@ SchemeLoader::SchemeLoader(QObject* parent)
         QDir::homePath() + "/.local/state");
     m_schemeStatePath = stateDir + "/caelestia/scheme.json";
 
-    // Watch for changes to scheme.json
-    if (QFile::exists(m_schemeStatePath)) {
-        m_watcher->addPath(m_schemeStatePath);
-    }
+    // Watch for changes to scheme.json. On a fresh install the file does not
+    // exist yet, so also watch its directory and pick the file up once it
+    // appears — otherwise the first `caelestia scheme set` would need a full
+    // shell restart to take effect.
+    const auto schemeDir = QFileInfo(m_schemeStatePath).absolutePath();
+    QDir().mkpath(schemeDir);
+    m_watcher->addPath(schemeDir);
+    watchSchemeState();
+
     connect(m_watcher, &QFileSystemWatcher::fileChanged, this, [this](const QString&) {
         loadCurrentScheme();
         // Re-add path because some editors replace files atomically
-        if (!m_watcher->files().contains(m_schemeStatePath)) {
-            m_watcher->addPath(m_schemeStatePath);
+        watchSchemeState();
+    });
+    connect(m_watcher, &QFileSystemWatcher::directoryChanged, this, [this](const QString&) {
+        // The file may have just been created (or recreated) in the directory.
+        if (watchSchemeState()) {
+            loadCurrentScheme();
         }
     });
 
@@ -47,6 +57,13 @@ QString SchemeLoader::currentVariant() const { return m_currentVariant; }
 
 void SchemeLoader::reloadCurrent() {
     loadCurrentScheme();
+}
+
+bool SchemeLoader::watchSchemeState() {
+    if (m_watcher->files().contains(m_schemeStatePath) || !QFile::exists(m_schemeStatePath)) {
+        return false;
+    }
+    return m_watcher->addPath(m_schemeStatePath);
 }
 
 void SchemeLoader::loadSchemes() {

--- a/shell/plugin/src/Caelestia/Services/schemeloader.hpp
+++ b/shell/plugin/src/Caelestia/Services/schemeloader.hpp
@@ -43,6 +43,9 @@ signals:
 private:
     void loadSchemes();
     void loadCurrentScheme();
+    // Starts watching scheme.json if it exists and is not watched yet.
+    // Returns true if the watch was newly established.
+    bool watchSchemeState();
 
     QFileSystemWatcher* m_watcher;
     QVariantList m_schemes;


### PR DESCRIPTION
Closes #271.

`SchemeLoader` only calls `addPath(m_schemeStatePath)` if the file already exists when the constructor runs, and the `fileChanged` handler can only re-arm a path that is already watched. On a fresh install, or a first login before `caelestia scheme set` has ever run, the file does not exist yet, so the watch is never established and the first scheme change needs a full shell restart to show up.

Now the state directory is watched as well, and `directoryChanged` starts watching the file once it appears.

Measured it with a small harness that constructs `SchemeLoader` against an empty state dir, then creates and updates scheme.json: before the change it emitted `currentSchemeChanged` zero times, after it caught all three (creation by the `caelestia scheme list` call, then both writes).

`watchSchemeState()` is idempotent, so the extra `directoryChanged` traffic from unrelated files in the directory costs a `QStringList::contains` and does not re-trigger a load.