### PR TITLE
fix(arpc): prefer the focused window for custom-app presence

### DIFF
--- a/shell/services/DiscordRPC.qml
+++ b/shell/services/DiscordRPC.qml
@@ -97,6 +97,7 @@ Item {
         enabled: root.active
         ignoreUnknownSignals: true
         function onWindowListChanged() { root.updatePresence(); }
+        function onActiveWindowChanged() { root.updatePresence(); }
     }
 
     Connections {
@@ -149,6 +150,20 @@ Item {
         let topTargetClass = "";
         let topTargetTitle = "";
         let topTargetMatchIdx = -1;
+
+        // Priority 2 prefers the focused window: a background app that happens
+        // to match the regex shouldn't describe you better than what you're
+        // actually looking at. Seeding the values here means the scan below
+        // only fills them in when nothing focused matched.
+        const activeClass = KWinActiveWindowBridge.activeWindow.class ?? "";
+        if (activeClass !== "") {
+            const activeIdx = root.findMatchingIndex(GlobalConfig.services.arpcTargetWindows, activeClass);
+            if (activeIdx >= 0) {
+                topTargetClass = activeClass;
+                topTargetTitle = KWinActiveWindowBridge.activeWindow.title ?? "";
+                topTargetMatchIdx = activeIdx;
+            }
+        }
 
         for (const toplevel of KWinActiveWindowBridge.windowList) {
             let winClass = toplevel.class ?? "";


### PR DESCRIPTION
Closes #276.

Priority 2 took the first window in `KWinActiveWindowBridge.windowList` matching `arpcTargetWindows`, so a background app could own your presence purely because of window-list ordering.

The focused window is now matched first. The seeding happens before the existing loop, and the loop already guards on `topTargetClass === ""`, so the full-list scan is untouched and still runs whenever nothing focused matches — behaviour only changes in the case the issue describes. Priority 1 keeps scanning the whole list, as suggested.

Two details beyond the literal ask:

- The match index comes from the focused window as well, so the custom label from `arpcTargetWindowLabels` belongs to the pattern that actually matched rather than to whichever one the list scan found.
- `onActiveWindowChanged` is now connected to `updatePresence()`. Only `onWindowListChanged` was wired up, so alt-tabbing between two matching apps would not have refreshed the presence and the fix would have been mostly invisible in practice.

Verified the selection with the patched control flow over five cases. With targets `["^code$", "^firefox$"]` and a window list ordered firefox-then-code:

| focused | result |
| --- | --- |
| `code` | `code` (previously `firefox`) |
| `firefox` | `firefox` |
| `dolphin` (no match) | `firefox`, via the fallback scan |
| nothing focused | `firefox`, via the fallback scan |
| no targets configured | no match |

That exercises a copy of the selection logic rather than the live component — `DiscordRPC.qml` pulls in DiscordIpc, GlobalConfig, SysInfo, Colours and CUtils, so standing it up headless was not worth the scaffolding. qmllint on the real file is clean.