### PR TITLE
feat(clipboard): tell the user when cliphist is missing

### DIFF
--- a/shell/modules/launcher/ContentList.qml
+++ b/shell/modules/launcher/ContentList.qml
@@ -346,6 +346,10 @@ Item {
     Row {
         id: empty
 
+        /// The clipboard list is a mode of the app list rather than a state of
+        /// its own, so ask the list itself.
+        readonly property bool cliphistMissing: root.currentList?.state === "clipboard" && !Clipboard.available
+
         opacity: root.currentList?.count === 0 ? 1 : 0
         scale: root.currentList?.count === 0 ? 1 : 0.5
 
@@ -357,6 +361,8 @@ Item {
 
         MaterialIcon {
             text: {
+                if (empty.cliphistMissing)
+                    return "content_paste_off";
                 if (root.state === "wallpapers")
                     return "wallpaper_slideshow";
                 if (root.state === "keybinds")
@@ -376,6 +382,8 @@ Item {
 
             StyledText {
                 text: {
+                    if (empty.cliphistMissing)
+                        return qsTr("cliphist not found");
                     if (root.state === "wallpapers")
                         return qsTr("No wallpapers found");
                     if (root.state === "keybinds")
@@ -390,6 +398,8 @@ Item {
 
             StyledText {
                 text: {
+                    if (empty.cliphistMissing)
+                        return qsTr("Install cliphist to enable clipboard history");
                     if (root.state === "wallpapers")
                         return Wallpapers.list.length === 0 ? qsTr("Try putting some wallpapers in %1").arg(Paths.shortenHome(Paths.wallsdir)) : qsTr("Try searching for something else");
                     if (root.state === "keybinds")

--- a/shell/modules/launcher/services/Clipboard.qml
+++ b/shell/modules/launcher/services/Clipboard.qml
@@ -11,6 +11,10 @@ QtObject {
 
     readonly property var items: ClipboardManager.items
 
+    /// False when the cliphist binary could not be started, so the launcher can
+    /// explain the empty list instead of looking broken.
+    readonly property bool available: ClipboardManager.available
+
     /// Forwarded from C++ so QML items can connect to a single source of truth.
     signal imageReady(int id, string path)
     signal clearHistoryFinished(bool success)

--- a/shell/plugin/src/Caelestia/Services/clipboardmanager.cpp
+++ b/shell/plugin/src/Caelestia/Services/clipboardmanager.cpp
@@ -24,6 +24,16 @@ QVariantList ClipboardManager::items() const { return m_items; }
 
 QString ClipboardManager::imageCacheDir() const { return m_imageCacheDir; }
 
+bool ClipboardManager::available() const { return m_available; }
+
+void ClipboardManager::setAvailable(bool available) {
+    if (m_available == available) {
+        return;
+    }
+    m_available = available;
+    emit availableChanged();
+}
+
 void ClipboardManager::reload() {
     // Kill any in-flight list process
     if (m_listProc && m_listProc->state() != QProcess::NotRunning) {
@@ -119,11 +129,17 @@ void ClipboardManager::reload() {
         }
     });
 
-    connect(proc, &QProcess::errorOccurred, this, [release](QProcess::ProcessError err) {
+    // started() fires exactly when the binary was found and launched, which is
+    // the question `available` answers — independent of what cliphist then
+    // does with its exit code.
+    connect(proc, &QProcess::started, this, [this] { setAvailable(true); });
+
+    connect(proc, &QProcess::errorOccurred, this, [this, release](QProcess::ProcessError err) {
         qCWarning(lcClipboard) << "cliphist list process error:" << err;
         // FailedToStart is the only error for which finished() is not also
         // emitted, so it is the only one this handler has to clean up after.
         if (err == QProcess::FailedToStart) {
+            setAvailable(false);
             release();
         }
     });

--- a/shell/plugin/src/Caelestia/Services/clipboardmanager.cpp
+++ b/shell/plugin/src/Caelestia/Services/clipboardmanager.cpp
@@ -31,23 +31,38 @@ void ClipboardManager::reload() {
         m_listProc->waitForFinished(200);
     }
 
-    m_listProc = new QProcess(this);
-    m_listProc->setProgram("cliphist");
-    m_listProc->setArguments({"list"});
+    auto* proc = new QProcess(this);
+    m_listProc = proc;
+    proc->setProgram("cliphist");
+    proc->setArguments({"list"});
 
-    connect(m_listProc, &QProcess::finished, this, [this](int exitCode, QProcess::ExitStatus) {
-        if (exitCode != 0) {
-            qCWarning(lcClipboard) << "cliphist list failed with exit code" << exitCode;
-            m_items.clear();
-            emit itemsChanged();
-            m_listProc->deleteLater();
+    // Capture the process itself rather than reading m_listProc from the
+    // handlers: a crashed cliphist emits errorOccurred() *and* finished() for
+    // the same instance, and a superseded reload can deliver signals after
+    // m_listProc has already been reassigned.
+    const auto release = [this, proc] {
+        if (m_listProc == proc) {
             m_listProc = nullptr;
+        }
+        proc->deleteLater();
+    };
+
+    connect(proc, &QProcess::finished, this, [this, proc, release](int exitCode, QProcess::ExitStatus status) {
+        const bool current = m_listProc == proc;
+        const auto output = proc->readAllStandardOutput();
+        release();
+
+        // A newer reload() already replaced this process; its result wins.
+        if (!current) {
             return;
         }
 
-        const auto output = m_listProc->readAllStandardOutput();
-        m_listProc->deleteLater();
-        m_listProc = nullptr;
+        if (status == QProcess::CrashExit || exitCode != 0) {
+            qCWarning(lcClipboard) << "cliphist list failed with exit code" << exitCode;
+            m_items.clear();
+            emit itemsChanged();
+            return;
+        }
 
         // Parse natively: each line is "<id>\t<preview>"
         static const QRegularExpression imageRe(
@@ -104,13 +119,16 @@ void ClipboardManager::reload() {
         }
     });
 
-    connect(m_listProc, &QProcess::errorOccurred, this, [this](QProcess::ProcessError err) {
+    connect(proc, &QProcess::errorOccurred, this, [release](QProcess::ProcessError err) {
         qCWarning(lcClipboard) << "cliphist list process error:" << err;
-        m_listProc->deleteLater();
-        m_listProc = nullptr;
+        // FailedToStart is the only error for which finished() is not also
+        // emitted, so it is the only one this handler has to clean up after.
+        if (err == QProcess::FailedToStart) {
+            release();
+        }
     });
 
-    m_listProc->start();
+    proc->start();
 }
 
 void ClipboardManager::decodeImage(int id, const QString& outPath) {

--- a/shell/plugin/src/Caelestia/Services/clipboardmanager.hpp
+++ b/shell/plugin/src/Caelestia/Services/clipboardmanager.hpp
@@ -25,12 +25,16 @@ class ClipboardManager : public QObject {
 
     Q_PROPERTY(QVariantList items READ items NOTIFY itemsChanged)
     Q_PROPERTY(QString imageCacheDir READ imageCacheDir CONSTANT)
+    /// False once cliphist has been found to be missing or unusable, so the UI
+    /// can say so instead of showing an unexplained empty list.
+    Q_PROPERTY(bool available READ available NOTIFY availableChanged)
 
 public:
     explicit ClipboardManager(QObject* parent = nullptr);
 
     [[nodiscard]] QVariantList items() const;
     [[nodiscard]] QString imageCacheDir() const;
+    [[nodiscard]] bool available() const;
 
     Q_INVOKABLE void reload();
     Q_INVOKABLE void decodeImage(int id, const QString& outPath);
@@ -42,9 +46,13 @@ signals:
     void imageReady(int id, const QString& path);
     /// Emitted when clearHistory() completes.
     void clearHistoryFinished(bool success);
+    void availableChanged();
 
 private:
+    void setAvailable(bool available);
+
     QVariantList m_items;
+    bool m_available = true;
     QProcess* m_listProc = nullptr;
     QProcess* m_wipeProc = nullptr;
     QString m_imageCacheDir;


### PR DESCRIPTION
Closes #269.

**Stacked on #288** — the first commit here is that PR, since both touch `reload()`'s `errorOccurred` handler. Review the second commit, or merge #288 first and this rebases to a single commit.

Without cliphist installed the only feedback was a `qCWarning` in the log and a blank clipboard list, which reads as a bug rather than a missing optional dependency.

`ClipboardManager` now exposes `available`, driven by `QProcess::started` and `FailedToStart`. Those answer exactly the question the property asks — whether the binary could be launched — unlike the exit code, which conflates "not installed" with "cliphist ran and failed".

The launcher empty state gains a matching case, following the shape the wallpapers state already uses to tell an empty collection apart from an unmatched search:

> **cliphist not found**
> Install cliphist to enable clipboard history

The clipboard list is a mode of the app list rather than a `ContentList` state of its own, so the condition reads `root.currentList?.state === "clipboard"`.

Verified by running `reload()` under a PATH with no cliphist — `available` goes true to false with one `availableChanged` — and again with it present, where it stays true and emits nothing. Since `started()` drives the true case, installing cliphist while the shell is running clears the hint on the next reload rather than needing a restart. Build and qmllint are clean.