### PR TITLE
feat: automatic light/dark scheme switching on a schedule

### DIFF
--- a/shell/modules/nexus/pages/ServicesPage.qml
+++ b/shell/modules/nexus/pages/ServicesPage.qml
@@ -1,3 +1,5 @@
+import "../../../utils/scripts/solartime.js" as Solar
+
 import QtQuick
 import QtQuick.Layouts
 import Quickshell
@@ -11,6 +13,30 @@ import qs.modules.nexus.common
 
 PageBase {
     id: root
+
+    readonly property list<MenuItem> autoSchemeItems: [
+        MenuItem {
+            text: qsTr("Sunrise and sunset")
+        },
+        MenuItem {
+            text: qsTr("Fixed times")
+        }
+    ]
+    readonly property list<string> autoSchemeValues: ["solar", "fixed"]
+
+    /// The hour of an "HH:MM" config value, for the steppers.
+    function schemeHour(time: string): int {
+        const minutes = Solar.parseTime(time);
+        return minutes < 0 ? 0 : Math.floor(minutes / 60);
+    }
+
+    /// Replaces only the hour, so minutes set by hand in the config file are
+    /// not thrown away by touching the stepper.
+    function withHour(time: string, hour: int): string {
+        const minutes = Solar.parseTime(time);
+        const mins = minutes < 0 ? 0 : minutes % 60;
+        return `${String(hour).padStart(2, "0")}:${String(mins).padStart(2, "0")}`;
+    }
 
     // Lyrics backends, ordered to match LyricsBackend::Backend (Auto, Local, LRCLIB, NetEase)
     readonly property list<MenuItem> lyricsItems: [
@@ -207,6 +233,40 @@ PageBase {
             subtext: qsTr("Derive theme mode and variant from the wallpaper")
             checked: GlobalConfig.services.smartScheme
             onToggled: GlobalConfig.services.smartScheme = checked
+        }
+
+        ToggleRow {
+            text: qsTr("Automatic light and dark")
+            subtext: qsTr("Switch the theme mode on a schedule")
+            checked: GlobalConfig.services.autoSchemeEnabled
+            onToggled: GlobalConfig.services.autoSchemeEnabled = checked
+        }
+
+        SelectRow {
+            Layout.fillWidth: true
+            label: qsTr("Schedule")
+            subtext: AutoScheme.coords ? qsTr("Sunrise and sunset use your weather location") : qsTr("Set a weather location to use sunrise and sunset")
+            menuItems: root.autoSchemeItems
+            active: root.autoSchemeItems[Math.max(0, root.autoSchemeValues.indexOf(GlobalConfig.services.autoSchemeMode))]
+            onSelected: item => GlobalConfig.services.autoSchemeMode = root.autoSchemeValues[root.autoSchemeItems.indexOf(item)]
+        }
+
+        StepperRow {
+            label: qsTr("Light mode hour")
+            subtext: qsTr("Switches at %1").arg(GlobalConfig.services.autoSchemeLightTime)
+            value: root.schemeHour(GlobalConfig.services.autoSchemeLightTime)
+            from: 0
+            to: 23
+            onMoved: h => GlobalConfig.services.autoSchemeLightTime = root.withHour(GlobalConfig.services.autoSchemeLightTime, h)
+        }
+
+        StepperRow {
+            label: qsTr("Dark mode hour")
+            subtext: qsTr("Switches at %1, also used when sunrise and sunset are unavailable").arg(GlobalConfig.services.autoSchemeDarkTime)
+            value: root.schemeHour(GlobalConfig.services.autoSchemeDarkTime)
+            from: 0
+            to: 23
+            onMoved: h => GlobalConfig.services.autoSchemeDarkTime = root.withHour(GlobalConfig.services.autoSchemeDarkTime, h)
         }
 
         SelectRow {

--- a/shell/plugin/src/Caelestia/Config/serviceconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/serviceconfig.hpp
@@ -30,6 +30,15 @@ class ServiceConfig : public ConfigObject {
     CONFIG_GLOBAL_PROPERTY(qreal, brightnessIncrement, 0.1)
     CONFIG_GLOBAL_PROPERTY(qreal, maxVolume, 1.0)
     CONFIG_GLOBAL_PROPERTY(bool, smartScheme, true)
+
+    // Automatic light/dark switching.
+    CONFIG_GLOBAL_PROPERTY(bool, autoSchemeEnabled, false)
+    // "solar" derives the times from weatherLocation; "fixed" uses the two below.
+    CONFIG_GLOBAL_PROPERTY(QString, autoSchemeMode, u"solar"_s)
+    // "HH:MM", local time. Also used as the fallback when solar times cannot be
+    // computed (no location set, or polar day/night).
+    CONFIG_GLOBAL_PROPERTY(QString, autoSchemeLightTime, u"07:00"_s)
+    CONFIG_GLOBAL_PROPERTY(QString, autoSchemeDarkTime, u"19:00"_s)
     CONFIG_GLOBAL_PROPERTY(QString, defaultPlayer, u"Spotify"_s)
     CONFIG_GLOBAL_PROPERTY(QVariantList, playerAliases,
         { vmap({ { u"from"_s, u"com.github.th_ch.youtube_music"_s }, { u"to"_s, u"YT Music"_s } }) })

--- a/shell/services/AutoScheme.qml
+++ b/shell/services/AutoScheme.qml
@@ -1,0 +1,107 @@
+pragma Singleton
+
+import "../utils/scripts/solartime.js" as Solar
+
+import QtQuick
+import Quickshell
+import Caelestia.Config
+import qs.services
+
+/// Switches the colour scheme between light and dark on a schedule, either at
+/// fixed times or at local sunrise and sunset.
+///
+/// The check is driven by the ticking clock rather than a one-shot timer armed
+/// for the next boundary, because a timer set eight hours ahead does not
+/// survive a suspend/resume or a system clock change.
+Singleton {
+    id: root
+
+    readonly property bool enabled: GlobalConfig.services.autoSchemeEnabled
+    readonly property bool solar: GlobalConfig.services.autoSchemeMode === "solar"
+
+    /// Reuses the coordinates already configured for the weather service, so
+    /// this needs no location setting of its own.
+    readonly property var coords: Solar.parseCoords(GlobalConfig.services.weatherLocation)
+
+    /// The last mode this service applied, so a manual switch is not undone on
+    /// the next tick — it stands until the next real boundary.
+    property string lastApplied: ""
+
+    /// The two boundaries for the given moment, as minutes since local
+    /// midnight. Falls back to the fixed times whenever solar times are
+    /// unavailable, so enabling this without a location still does something
+    /// sensible.
+    function boundariesFor(date: date): var {
+        if (root.solar && root.coords) {
+            const times = Solar.solarTimes(date, root.coords.lat, root.coords.lon);
+            if (times)
+                return {
+                    light: times.sunrise,
+                    dark: times.sunset
+                };
+        }
+
+        const light = Solar.parseTime(GlobalConfig.services.autoSchemeLightTime);
+        const dark = Solar.parseTime(GlobalConfig.services.autoSchemeDarkTime);
+        if (light < 0 || dark < 0 || light === dark)
+            return null;
+        return {
+            light: light,
+            dark: dark
+        };
+    }
+
+    /// `force` applies the mode even when this service did not choose the
+    /// current one, which is what startup and the enable toggle want.
+    function apply(force: bool): void {
+        if (!root.enabled)
+            return;
+
+        const now = Time.date;
+        const bounds = root.boundariesFor(now);
+        if (!bounds)
+            return;
+
+        const minutes = now.getHours() * 60 + now.getMinutes();
+        const target = Solar.isLightAt(minutes, bounds.light, bounds.dark) ? "light" : "dark";
+
+        // Only act on a boundary crossing. Between boundaries a manual switch
+        // is left alone rather than being reverted a minute later.
+        if (!force && target === root.lastApplied)
+            return;
+
+        root.lastApplied = target;
+
+        if ((target === "light") !== Colours.light)
+            Colours.setMode(target);
+    }
+
+    onEnabledChanged: {
+        if (root.enabled)
+            root.apply(true);
+        else
+            root.lastApplied = "";
+    }
+
+    Component.onCompleted: root.apply(true)
+
+    Connections {
+        target: Time
+        enabled: root.enabled
+
+        // Minute precision is plenty, and keeps this off the per-second tick.
+        function onMinutesChanged(): void {
+            root.apply(false);
+        }
+    }
+
+    Connections {
+        target: GlobalConfig.services
+        enabled: root.enabled
+
+        function onAutoSchemeModeChanged(): void { root.apply(true); }
+        function onAutoSchemeLightTimeChanged(): void { root.apply(true); }
+        function onAutoSchemeDarkTimeChanged(): void { root.apply(true); }
+        function onWeatherLocationChanged(): void { root.apply(true); }
+    }
+}

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -140,4 +140,5 @@ ShellRoot {
     property var _arpcInit: DiscordRPC
     property var _gameModeInit: GameMode
     property var _updateCheckerInit: UpdateChecker
+    property var _autoSchemeInit: AutoScheme
 }

--- a/shell/utils/scripts/solartime.js
+++ b/shell/utils/scripts/solartime.js
@@ -1,0 +1,78 @@
+.pragma library
+
+// Pure time arithmetic for the automatic light/dark schedule. Kept free of
+// config and service dependencies so it can be reasoned about on its own.
+
+/// "HH:MM" to minutes since local midnight, or -1 if unparseable.
+function parseTime(str) {
+    const m = /^\s*(\d{1,2}):(\d{2})\s*$/.exec(str || "");
+    if (!m)
+        return -1;
+    const h = Number(m[1]);
+    const min = Number(m[2]);
+    if (h > 23 || min > 59)
+        return -1;
+    return h * 60 + min;
+}
+
+/// Parses the "lat,lon" string the weather service already stores. Null if it
+/// is empty or malformed.
+function parseCoords(raw) {
+    const parts = String(raw || "").trim().split(",");
+    if (parts.length !== 2)
+        return null;
+    const lat = Number(parts[0].trim());
+    const lon = Number(parts[1].trim());
+    if (!isFinite(lat) || !isFinite(lon) || Math.abs(lat) > 90 || Math.abs(lon) > 180)
+        return null;
+    return { lat: lat, lon: lon };
+}
+
+/// Sunrise and sunset for `date` at `lat`/`lon`, as minutes since local
+/// midnight. Null during polar day or polar night, when there is no sunrise or
+/// sunset to switch on.
+///
+/// NOAA's low-precision solar position algorithm; accurate to about a minute,
+/// far tighter than this feature needs.
+function solarTimes(date, lat, lon) {
+    const rad = Math.PI / 180;
+    const epoch = Date.UTC(2000, 0, 1, 12);
+
+    const days = Math.floor((date.getTime() - epoch) / 86400000);
+    const meanSolarNoon = days + 0.0008 - lon / 360;
+
+    const anomaly = (357.5291 + 0.98560028 * meanSolarNoon) % 360;
+    const centre = 1.9148 * Math.sin(anomaly * rad) + 0.02 * Math.sin(2 * anomaly * rad) + 0.0003 * Math.sin(3 * anomaly * rad);
+    const eclipticLon = (anomaly + centre + 180 + 102.9372) % 360;
+
+    const transit = meanSolarNoon + 0.0053 * Math.sin(anomaly * rad) - 0.0069 * Math.sin(2 * eclipticLon * rad);
+
+    const sinDecl = Math.sin(eclipticLon * rad) * Math.sin(23.44 * rad);
+    const cosDecl = Math.cos(Math.asin(sinDecl));
+
+    // -0.833° accounts for atmospheric refraction and the solar disc radius.
+    const cosHourAngle = (Math.sin(-0.833 * rad) - Math.sin(lat * rad) * sinDecl) / (Math.cos(lat * rad) * cosDecl);
+    if (cosHourAngle > 1 || cosHourAngle < -1)
+        return null;
+
+    const hourAngle = Math.acos(cosHourAngle) / rad;
+
+    function toLocalMinutes(julian) {
+        const d = new Date(epoch + julian * 86400000);
+        return d.getHours() * 60 + d.getMinutes();
+    }
+
+    return {
+        sunrise: toLocalMinutes(transit - hourAngle / 360),
+        sunset: toLocalMinutes(transit + hourAngle / 360)
+    };
+}
+
+/// Whether `minutes` falls in the light window. Handles a window that wraps
+/// past midnight, which a high latitude or a deliberately inverted pair of
+/// fixed times produces.
+function isLightAt(minutes, light, dark) {
+    if (light < dark)
+        return minutes >= light && minutes < dark;
+    return minutes >= light || minutes < dark;
+}


### PR DESCRIPTION
Closes #277.

Optional scheduler that flips the theme mode at fixed times or at local sunrise and sunset. Solar times reuse the coordinates already in `weatherLocation`, so there is no second location setting to keep in sync. The fixed times double as the fallback when solar times are unavailable — no location set, or polar day/night — so enabling this without a location still does something sensible.

Two decisions worth flagging:

- The check runs off the ticking clock, not a one-shot timer armed for the next boundary. A timer set eight hours ahead does not survive suspend/resume or a system clock change, which is what a laptop hits every night.
- It only acts on a boundary crossing. A manual mode switch stands until the next real sunrise or sunset instead of being reverted a minute later, and `setMode()` is skipped when the mode is already correct, so there is no redundant `caelestia scheme set` and no spurious notification.

The time arithmetic sits in `utils/scripts/solartime.js`, following the existing pattern for pure logic (see `Searcher.qml`), which keeps it free of config and service dependencies.

Checked the solar maths against known values, all within a minute:

| location / date | computed | published |
| --- | --- | --- |
| London 2026-06-21 | 03:44 / 20:22 UTC | 03:43 / 20:21 |
| London 2026-12-21 | 08:04 / 15:53 UTC | 08:04 / 15:53 |
| Sydney 2026-06-21 | 07:00 / 16:54 AEST | 07:00 / 16:54 |
| Tromso Jun and Dec | no sunrise/sunset | polar day / night |

Also covered `parseTime` edge cases (`24:00`, `12:60`, `0700` rejected), `parseCoords` range checks, and a full-day simulation confirming exactly two transitions in a normal window and correct behaviour in one wrapping past midnight. In that simulation a manual switch at 12:00 was left alone and produced no redundant call at the 19:00 boundary.

`shell.qml` needed `_autoSchemeInit`. Quickshell singletons are lazy, so without it the scheduler would only have run once someone opened the settings page.

Scope limit: the config takes `HH:MM` but the UI steps in whole hours. The stepper preserves minutes set by hand, so `07:30` in the config keeps its `:30` when the hour is changed. A minute-level picker would have meant changing the shared `CustomSpinBox`.
