### PR TITLE
feat(clipboard): pin entries so they survive rotation and Clear History

### DIFF
--- a/shell/modules/launcher/items/ClipItem.qml
+++ b/shell/modules/launcher/items/ClipItem.qml
@@ -2,7 +2,6 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import Caelestia
-import Caelestia.Config
 import qs.components
 import qs.components.images
 import qs.services
@@ -14,17 +13,33 @@ Item {
     required property var modelData
     required property var list
 
+    readonly property bool isPinned: root.modelData?.isPinned ?? false
+
     function clicked() {
         if (!root.modelData)
             return;
         root.list.visibilities.launcher = false;
         const preview = root.modelData.preview.length > 30 ? root.modelData.preview.slice(0, 30) + "..." : root.modelData.preview;
-        Quickshell.execDetached(["sh", "-c", "cliphist decode " + root.modelData.id + " | wl-copy"]);
+
+        // A pinned entry may have rotated out of cliphist, so `cliphist decode`
+        // can no longer produce it — the stored bytes are the source of truth.
+        if (root.isPinned)
+            Clipboard.copyPinned(root.modelData.pinId);
+        else
+            Quickshell.execDetached(["sh", "-c", "cliphist decode " + root.modelData.id + " | wl-copy"]);
+
         Toaster.toast(qsTr("Copied to clipboard"), preview, "content_paste");
     }
 
     Component.onCompleted: {
         if (!root.modelData?.isImage) return;
+
+        // A pinned image has its own stored copy; nothing pre-warms it and no
+        // imageReady will ever arrive for it.
+        if (root.isPinned) {
+            imagePreview.imagePath = root.modelData.imagePath ?? "";
+            return;
+        }
 
         // Check whether the image was already pre-warmed during reload()
         const cached = Clipboard.getImagePath(root.modelData.id);
@@ -94,7 +109,7 @@ Item {
         StyledText {
             anchors.left: icon.right
             anchors.leftMargin: Tokens.spacing.medium
-            anchors.right: favIcon.left
+            anchors.right: pinIcon.left
             anchors.rightMargin: Tokens.spacing.small
             anchors.verticalCenter: parent.verticalCenter
 
@@ -105,7 +120,7 @@ Item {
         }
 
         MouseArea {
-            id: favIcon
+            id: pinIcon
 
             width: 32
             height: 32
@@ -113,25 +128,19 @@ Item {
             anchors.right: parent.right
             hoverEnabled: true
             onClicked: {
-                const clipId = String(root.modelData?.id);
-                if (!clipId)
+                if (!root.modelData)
                     return;
-                const favClips = GlobalConfig.launcher.favouriteClips ? [...GlobalConfig.launcher.favouriteClips] : [];
-                if (favClips.includes(clipId)) {
-                    const idx = favClips.indexOf(clipId);
-                    if (idx !== -1)
-                        favClips.splice(idx, 1);
-                } else {
-                    favClips.push(clipId);
-                }
-                GlobalConfig.launcher.favouriteClips = favClips;
+                if (root.isPinned)
+                    Clipboard.unpin(root.modelData.pinId);
+                else
+                    Clipboard.pin(root.modelData.id);
             }
 
             MaterialIcon {
                 anchors.centerIn: parent
-                text: GlobalConfig.launcher.favouriteClips && GlobalConfig.launcher.favouriteClips.includes(String(root.modelData?.id)) ? "favorite" : "favorite_border"
-                fill: GlobalConfig.launcher.favouriteClips && GlobalConfig.launcher.favouriteClips.includes(String(root.modelData?.id)) ? 1 : 0
-                color: favIcon.containsMouse ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                text: root.isPinned ? "keep" : "keep_off"
+                fill: root.isPinned ? 1 : 0
+                color: pinIcon.containsMouse ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
             }
         }
     }

--- a/shell/modules/launcher/services/Clipboard.qml
+++ b/shell/modules/launcher/services/Clipboard.qml
@@ -15,9 +15,14 @@ QtObject {
     /// explain the empty list instead of looking broken.
     readonly property bool available: ClipboardManager.available
 
+    /// Entries kept outside cliphist's rotation, so they survive both the
+    /// history filling up and a Clear History.
+    readonly property var pinnedItems: ClipboardManager.pinnedItems
+
     /// Forwarded from C++ so QML items can connect to a single source of truth.
     signal imageReady(int id, string path)
     signal clearHistoryFinished(bool success)
+    signal pinFailed(int id)
 
     readonly property string imageCacheDir: ClipboardManager.imageCacheDir
 
@@ -29,24 +34,62 @@ QtObject {
         ClipboardManager.clearHistory();
     }
 
+    function pin(clipId: int): void {
+        ClipboardManager.pin(clipId);
+    }
+
+    function unpin(pinId: int): void {
+        ClipboardManager.unpin(pinId);
+    }
+
+    function copyPinned(pinId: int): void {
+        ClipboardManager.copyPinned(pinId);
+    }
+
+    /// Pinned entries carry a negative id so they never collide with a cliphist
+    /// one, and so existing code that keys on `id` keeps working.
+    function toPinnedEntry(pin: var): var {
+        return {
+            id: -pin.pinId,
+            pinId: pin.pinId,
+            preview: pin.preview,
+            isImage: pin.isImage,
+            imagePath: pin.imagePath,
+            isPinned: true
+        };
+    }
+
     function getSortedItems(): var {
-        if (!items.length)
-            return [];
-        const favClips = new Set((GlobalConfig.launcher.favouriteClips || []).map(String));
-        const favs = [];
-        const rest = [];
-        for (const item of items) {
-            if (favClips.has(String(item.id))) {
-                favs.push(item);
-            } else {
-                rest.push(item);
-            }
-        }
-        return [...favs, ...rest];
+        const pinned = (pinnedItems || []).map(p => root.toPinnedEntry(p));
+
+        // A pinned entry usually also sits in the live list until it rotates
+        // out; show it once, as the pinned copy. Previews are what the user
+        // sees, so matching on them is the right granularity here.
+        const pinnedPreviews = new Set(pinned.map(p => p.preview));
+        const rest = (items || []).filter(item => !pinnedPreviews.has(item.preview));
+
+        return [...pinned, ...rest];
     }
 
     function getImagePath(clipId: int): string {
         return imageCacheDir + "/" + clipId + ".png";
+    }
+
+    /// favouriteClips stored cliphist ids, which do not survive rotation or a
+    /// Clear History — the star silently became a dangling reference and the
+    /// dead ids piled up in the config. Convert whatever is still resolvable
+    /// into real pins, once, then stop tracking it.
+    function migrateFavourites(): void {
+        const favs = GlobalConfig.launcher.favouriteClips || [];
+        if (!favs.length || !items.length)
+            return;
+
+        const live = new Set(items.map(item => String(item.id)));
+        for (const fav of favs)
+            if (live.has(String(fav)))
+                root.pin(Number(fav));
+
+        GlobalConfig.launcher.favouriteClips = [];
     }
 
     /// Connections block to forward the C++ imageReady signal to the QML world.
@@ -57,6 +100,12 @@ QtObject {
         }
         function onClearHistoryFinished(success: bool): void {
             root.clearHistoryFinished(success);
+        }
+        function onPinFailed(id: int): void {
+            root.pinFailed(id);
+        }
+        function onItemsChanged(): void {
+            root.migrateFavourites();
         }
     }
 }

--- a/shell/plugin/src/Caelestia/Services/clipboardmanager.cpp
+++ b/shell/plugin/src/Caelestia/Services/clipboardmanager.cpp
@@ -7,6 +7,9 @@
 #include <qdir.h>
 #include <qfile.h>
 #include <qfileinfo.h>
+#include <qjsonarray.h>
+#include <qjsondocument.h>
+#include <qjsonobject.h>
 #include <qloggingcategory.h>
 #include <qregularexpression.h>
 
@@ -18,6 +21,12 @@ ClipboardManager::ClipboardManager(QObject* parent)
     : QObject(parent) {
     const auto runtimeDir = qEnvironmentVariable("XDG_RUNTIME_DIR", "/tmp");
     m_imageCacheDir = runtimeDir + "/caelestia-clipboard";
+
+    // Pins live in the state dir, not the runtime dir: they have to outlive a
+    // reboot, and they must not sit inside the cache clearHistory() wipes.
+    const auto stateDir = qEnvironmentVariable("XDG_STATE_HOME", QDir::homePath() + "/.local/state");
+    m_pinDir = stateDir + "/caelestia/clipboard-pins";
+    loadPins();
 }
 
 QVariantList ClipboardManager::items() const { return m_items; }
@@ -32,6 +41,224 @@ void ClipboardManager::setAvailable(bool available) {
     }
     m_available = available;
     emit availableChanged();
+}
+
+QVariantList ClipboardManager::pinnedItems() const { return m_pinnedItems; }
+
+QString ClipboardManager::pinFilePath(int pinId, bool isImage) const {
+    return m_pinDir + "/" + QString::number(pinId) + (isImage ? ".png" : ".bin");
+}
+
+void ClipboardManager::loadPins() {
+    QFile index(m_pinDir + "/index.json");
+    if (!index.exists() || !index.open(QIODevice::ReadOnly)) {
+        return;
+    }
+
+    const auto doc = QJsonDocument::fromJson(index.readAll());
+    index.close();
+    if (!doc.isObject()) {
+        qCWarning(lcClipboard) << "Ignoring malformed clipboard pin index";
+        return;
+    }
+
+    const auto obj = doc.object();
+    m_nextPinId = obj.value("nextPinId").toInt(1);
+
+    QVariantList loaded;
+    const auto entries = obj.value("pins").toArray();
+    for (const auto& value : entries) {
+        const auto entry = value.toObject();
+        const int pinId = entry.value("pinId").toInt(-1);
+        if (pinId < 0) {
+            continue;
+        }
+        const bool isImage = entry.value("isImage").toBool();
+
+        // Drop entries whose payload went missing rather than showing a pin
+        // that cannot be pasted.
+        const auto path = pinFilePath(pinId, isImage);
+        if (!QFileInfo::exists(path)) {
+            qCWarning(lcClipboard) << "Dropping clipboard pin with missing payload:" << path;
+            continue;
+        }
+
+        loaded.append(QVariantMap{
+            { "pinId",     pinId                          },
+            { "preview",   entry.value("preview").toString() },
+            { "isImage",   isImage                        },
+            { "imagePath", isImage ? path : QString()     },
+        });
+    }
+
+    m_pinnedItems = loaded;
+    if (!m_pinnedItems.isEmpty()) {
+        emit pinnedItemsChanged();
+    }
+}
+
+void ClipboardManager::savePins() {
+    if (!QDir().mkpath(m_pinDir)) {
+        qCWarning(lcClipboard) << "Failed to create clipboard pin directory:" << m_pinDir;
+        return;
+    }
+
+    QJsonArray entries;
+    for (const auto& value : std::as_const(m_pinnedItems)) {
+        const auto map = value.toMap();
+        entries.append(QJsonObject{
+            { "pinId",   map.value("pinId").toInt()        },
+            { "preview", map.value("preview").toString()   },
+            { "isImage", map.value("isImage").toBool()     },
+        });
+    }
+
+    const QJsonObject root{
+        { "nextPinId", m_nextPinId },
+        { "pins",      entries     },
+    };
+
+    QFile index(m_pinDir + "/index.json");
+    if (!index.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        qCWarning(lcClipboard) << "Failed to write clipboard pin index:" << index.fileName();
+        return;
+    }
+    index.write(QJsonDocument(root).toJson(QJsonDocument::Compact));
+    index.close();
+}
+
+void ClipboardManager::pin(int id) {
+    // The preview and kind come from the live list; the bytes come from
+    // cliphist, since `preview` is truncated and not the real content.
+    QVariantMap source;
+    for (const auto& value : std::as_const(m_items)) {
+        const auto map = value.toMap();
+        if (map.value("id").toInt() == id) {
+            source = map;
+            break;
+        }
+    }
+    if (source.isEmpty()) {
+        qCWarning(lcClipboard) << "Refusing to pin unknown clipboard entry" << id;
+        emit pinFailed(id);
+        return;
+    }
+
+    if (!QDir().mkpath(m_pinDir)) {
+        qCWarning(lcClipboard) << "Failed to create clipboard pin directory:" << m_pinDir;
+        emit pinFailed(id);
+        return;
+    }
+
+    const bool isImage = source.value("isImage").toBool();
+    const int pinId = m_nextPinId;
+    const auto path = pinFilePath(pinId, isImage);
+    const auto preview = source.value("preview").toString();
+
+    auto* proc = new QProcess(this);
+    proc->setProgram("cliphist");
+    proc->setArguments({ "decode", QString::number(id) });
+
+    connect(proc, &QProcess::finished, this,
+        [this, proc, id, pinId, path, preview, isImage](int exitCode, QProcess::ExitStatus status) {
+            const auto data = proc->readAllStandardOutput();
+            proc->deleteLater();
+
+            if (status == QProcess::CrashExit || exitCode != 0 || data.isEmpty()) {
+                qCWarning(lcClipboard) << "cliphist decode failed while pinning entry" << id;
+                emit pinFailed(id);
+                return;
+            }
+
+            QFile f(path);
+            if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+                qCWarning(lcClipboard) << "Failed to write clipboard pin payload:" << path;
+                emit pinFailed(id);
+                return;
+            }
+            f.write(data);
+            f.close();
+
+            // Only claim the id once the payload is safely on disk.
+            m_nextPinId = pinId + 1;
+            m_pinnedItems.append(QVariantMap{
+                { "pinId",     pinId                     },
+                { "preview",   preview                   },
+                { "isImage",   isImage                   },
+                { "imagePath", isImage ? path : QString() },
+            });
+            savePins();
+            emit pinnedItemsChanged();
+        });
+
+    connect(proc, &QProcess::errorOccurred, this, [this, proc, id](QProcess::ProcessError err) {
+        qCWarning(lcClipboard) << "cliphist decode process error while pinning" << id << ":" << err;
+        if (err == QProcess::FailedToStart) {
+            setAvailable(false);
+            proc->deleteLater();
+            emit pinFailed(id);
+        }
+    });
+
+    proc->start();
+}
+
+void ClipboardManager::unpin(int pinId) {
+    for (int i = 0; i < m_pinnedItems.size(); ++i) {
+        const auto map = m_pinnedItems.at(i).toMap();
+        if (map.value("pinId").toInt() != pinId) {
+            continue;
+        }
+
+        const auto path = pinFilePath(pinId, map.value("isImage").toBool());
+        if (QFileInfo::exists(path) && !QFile::remove(path)) {
+            qCWarning(lcClipboard) << "Failed to remove clipboard pin payload:" << path;
+        }
+
+        m_pinnedItems.removeAt(i);
+        savePins();
+        emit pinnedItemsChanged();
+        return;
+    }
+}
+
+void ClipboardManager::copyPinned(int pinId) {
+    for (const auto& value : std::as_const(m_pinnedItems)) {
+        const auto map = value.toMap();
+        if (map.value("pinId").toInt() != pinId) {
+            continue;
+        }
+
+        const bool isImage = map.value("isImage").toBool();
+        QFile f(pinFilePath(pinId, isImage));
+        if (!f.open(QIODevice::ReadOnly)) {
+            qCWarning(lcClipboard) << "Failed to read clipboard pin payload:" << f.fileName();
+            return;
+        }
+        const auto data = f.readAll();
+        f.close();
+
+        auto* proc = new QProcess(this);
+        proc->setProgram("wl-copy");
+        // wl-copy sniffs the type from stdin, but binary image data is exactly
+        // the case where it guesses wrong, so be explicit.
+        proc->setArguments(isImage ? QStringList{ "--type", "image/png" } : QStringList{});
+
+        connect(proc, &QProcess::finished, proc, &QProcess::deleteLater);
+        connect(proc, &QProcess::errorOccurred, this, [proc](QProcess::ProcessError err) {
+            qCWarning(lcClipboard) << "wl-copy process error:" << err;
+            if (err == QProcess::FailedToStart) {
+                proc->deleteLater();
+            }
+        });
+
+        proc->start();
+        proc->write(data);
+        proc->closeWriteChannel();
+        return;
+    }
+
+    qCWarning(lcClipboard) << "Refusing to copy unknown clipboard pin" << pinId;
 }
 
 void ClipboardManager::reload() {

--- a/shell/plugin/src/Caelestia/Services/clipboardmanager.hpp
+++ b/shell/plugin/src/Caelestia/Services/clipboardmanager.hpp
@@ -28,6 +28,9 @@ class ClipboardManager : public QObject {
     /// False once cliphist has been found to be missing or unusable, so the UI
     /// can say so instead of showing an unexplained empty list.
     Q_PROPERTY(bool available READ available NOTIFY availableChanged)
+    /// Entries kept outside cliphist's rotation. Each is a map of pinId,
+    /// preview, isImage and imagePath, the last only for images.
+    Q_PROPERTY(QVariantList pinnedItems READ pinnedItems NOTIFY pinnedItemsChanged)
 
 public:
     explicit ClipboardManager(QObject* parent = nullptr);
@@ -35,10 +38,19 @@ public:
     [[nodiscard]] QVariantList items() const;
     [[nodiscard]] QString imageCacheDir() const;
     [[nodiscard]] bool available() const;
+    [[nodiscard]] QVariantList pinnedItems() const;
 
     Q_INVOKABLE void reload();
     Q_INVOKABLE void decodeImage(int id, const QString& outPath);
     Q_INVOKABLE void clearHistory();
+
+    /// Decodes the cliphist entry `id` in full and stores its bytes, so the
+    /// entry survives cliphist's rotation and clearHistory().
+    Q_INVOKABLE void pin(int id);
+    Q_INVOKABLE void unpin(int pinId);
+    /// Pinned entries are no longer in cliphist, so `cliphist decode` cannot
+    /// bring them back — the stored bytes go to wl-copy directly.
+    Q_INVOKABLE void copyPinned(int pinId);
 
 signals:
     void itemsChanged();
@@ -47,15 +59,26 @@ signals:
     /// Emitted when clearHistory() completes.
     void clearHistoryFinished(bool success);
     void availableChanged();
+    void pinnedItemsChanged();
+    /// Emitted when pin() fails, so the UI can say the entry was not kept.
+    void pinFailed(int id);
 
 private:
     void setAvailable(bool available);
+
+    void loadPins();
+    void savePins();
+    QString pinFilePath(int pinId, bool isImage) const;
 
     QVariantList m_items;
     bool m_available = true;
     QProcess* m_listProc = nullptr;
     QProcess* m_wipeProc = nullptr;
     QString m_imageCacheDir;
+
+    QVariantList m_pinnedItems;
+    QString m_pinDir;
+    int m_nextPinId = 1;
 };
 
 } // namespace caelestia::services


### PR DESCRIPTION
Closes #273.

The issue asks for pinning. Looking at what is there now, this is really a repair: the existing "favourite" star stores cliphist ids. Those do not survive cliphist rotating an entry out, and they do not survive `clearHistory()` — the starred entry silently vanishes and the dead id stays in `favouriteClips` forever. It marks entries rather than keeping them.

Pinning now stores the entry itself. `ClipboardManager` decodes the full content at pin time and writes the bytes under `$XDG_STATE_HOME/caelestia/clipboard-pins`, with an `index.json` beside them. The state dir matters twice over: pins outlive a reboot, and they are not inside the runtime cache `clearHistory()` wipes.

Decoding at pin time is the point. `preview` is truncated and cannot be pasted, so anything keyed on it would only look right.

Pinned entries are merged into the launcher list ahead of the live ones, carrying a negative id so they never collide with a cliphist id. While an entry is still in the live list it would otherwise appear twice, so live entries matching a pinned preview are dropped in favour of the pinned copy.

Because a pinned entry may no longer exist in cliphist, `cliphist decode` cannot produce it — copying goes through the stored bytes and `wl-copy` directly, with an explicit `image/png` type for images, which is where wl-copy's sniffing would otherwise guess wrong.

`favouriteClips` is migrated on first load: whatever id still resolves in the live list becomes a real pin, then the setting is cleared. Ids that already dangled are dropped, since nothing can be recovered from them.

Tested end to end against stub `cliphist` and `wl-copy` binaries:

| step | result |
| --- | --- |
| after pin | 1 pin |
| after `clearHistory` | live list 0, **pin still there** |
| `copyPinned` | full content, not the truncated preview |
| new manager instance | pin read back from disk |
| unpin, then restart | gone for good |
| image entry | bytes intact, `wl-copy --type image/png` |

Pinning an id that is not in the live list is refused, which I confirmed by accident when a stub listed a different id.
