### PR TITLE
feat(arpc): clear the Discord presence while the user is idle

### DIFF
--- a/shell/modules/nexus/pages/services/ArpcPage.qml
+++ b/shell/modules/nexus/pages/services/ArpcPage.qml
@@ -73,11 +73,23 @@ PageBase {
         ToggleRow {
             Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
             Layout.fillWidth: true
-            last: true
             text: qsTr("Broadcast Caelestia info")
             subtext: qsTr("Broadcast shell uptime and system info")
             checked: GlobalConfig.services.arpcCaelestiaInfo
             onToggled: GlobalConfig.services.arpcCaelestiaInfo = checked
+        }
+
+        StepperRow {
+            Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
+            Layout.fillWidth: true
+            last: true
+            label: qsTr("Clear when idle")
+            subtext: GlobalConfig.services.arpcIdleTimeout > 0 ? qsTr("Hide the presence after %1 minutes away").arg(Math.round(GlobalConfig.services.arpcIdleTimeout / 60)) : qsTr("Never hide the presence (minutes)")
+            value: Math.round(GlobalConfig.services.arpcIdleTimeout / 60)
+            from: 0
+            to: 60
+            stepSize: 1
+            onMoved: v => GlobalConfig.services.arpcIdleTimeout = Math.round(v * 60)
         }
 
         SectionHeader {

--- a/shell/plugin/src/Caelestia/Config/serviceconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/serviceconfig.hpp
@@ -50,6 +50,9 @@ class ServiceConfig : public ConfigObject {
     CONFIG_GLOBAL_PROPERTY(QStringList, arpcTargetWindowLabels)
     CONFIG_GLOBAL_PROPERTY(bool, arpcCaelestiaInfo, false)
     CONFIG_GLOBAL_PROPERTY(bool, arpcManualOverride, false)
+    // Seconds of inactivity after which the presence is cleared. 0 disables it,
+    // which keeps the existing always-on behaviour for anyone already using ARPC.
+    CONFIG_GLOBAL_PROPERTY(int, arpcIdleTimeout, 0)
 
 public:
     explicit ServiceConfig(QObject* parent = nullptr)

--- a/shell/services/DiscordRPC.qml
+++ b/shell/services/DiscordRPC.qml
@@ -4,6 +4,7 @@ import QtQuick
 import Caelestia.Config
 import Quickshell
 import Quickshell.Io
+import Quickshell.Wayland
 import Caelestia
 import Caelestia.Services
 import qs.utils
@@ -48,6 +49,35 @@ Item {
     }
 
     property real shellStartTime: Date.now() / 1000
+
+    /// Rich presence is meant to say what you are doing now, not what you were
+    /// doing before you walked away. Uses the Wayland idle protocol rather than
+    /// a focus-change heuristic, so it also covers sitting and reading.
+    readonly property int idleTimeout: GlobalConfig.services.arpcIdleTimeout
+    property bool userIdle: false
+
+    onUserIdleChanged: {
+        if (!root.active || !DiscordIpc.connected)
+            return;
+
+        if (root.userIdle)
+            DiscordIpc.clearActivity();
+        else
+            root.updatePresence();
+    }
+
+    IdleMonitor {
+        // A timeout of 0 means the feature is off, and IdleMonitor would treat
+        // it as "idle immediately".
+        enabled: root.active && root.idleTimeout > 0
+        timeout: root.idleTimeout
+        onIsIdleChanged: root.userIdle = isIdle
+
+        // Turning the feature off while idle must not strand the presence in
+        // the cleared state.
+        onEnabledChanged: if (!enabled)
+            root.userIdle = false
+    }
 
     Connections {
         target: DiscordIpc
@@ -131,6 +161,9 @@ Item {
     function updatePresence() {
         if (!active || !DiscordIpc.connected) return;
         if (fetchingSteam) return; // Prevent loop during async fetch
+        // Any of the triggers below can fire while away; none of them should
+        // put the presence back until the user actually returns.
+        if (userIdle) return;
 
         // Priority 0: Manual Override
         if (GlobalConfig.services.arpcManualOverride && (GlobalConfig.services.arpcAppName || GlobalConfig.services.arpcDetails || GlobalConfig.services.arpcState)) {


### PR DESCRIPTION
Closes #274.

Rich presence is meant to say what you are doing now, not what you were doing before you walked away.

Uses Quickshell's `IdleMonitor`, i.e. the Wayland idle protocol, rather than the "no focus change for N minutes" heuristic the issue offers as a fallback. Focus changes miss the common case of sitting and reading, and the protocol is already available here.

`updatePresence()` returns early while idle. Without that, any of its other triggers — a window list change, a colour scheme change, a Steam fetch completing — would quietly put the presence back a moment after it was cleared.

Turning the feature off while idle resets the flag, so the presence is restored rather than stranded in the cleared state.

The timeout defaults to 0, which disables it. Anyone already using ARPC keeps exactly the behaviour they have now until they opt in from the settings page. The issue notes that most integrations do this by default, so an on-by-default is arguable — I went the other way so nobody's presence quietly disappears after an update. Easy to flip if you disagree.

Walked the state machine through seven steps: presence sent while active, cleared on going idle, skipped for window-list and colour changes while away, sent again on return, and — the one that would otherwise have stranded it — cleared while idle then correctly restored when the timeout is set to 0 from the settings page.
