### PR TITLE
fix: unify runtime path, template desktop Exec, drop title from icon cache

### DIFF
--- a/scripts/10-autostart.sh
+++ b/scripts/10-autostart.sh
@@ -167,8 +167,9 @@ fi
 if [[ -f "$BUNDLE_DIR/assets/org.quickshell.desktop" ]]; then
     echo "  Requesting KWin screencast interface for window previews..."
     mkdir -p "$HOME/.local/share/applications"
-    cp --remove-destination "$BUNDLE_DIR/assets/org.quickshell.desktop" \
-        "$HOME/.local/share/applications/org.quickshell.desktop" 2>/dev/null || true
+    sed "s|^Exec=.*|Exec=$QUICKSHELL_CANONICAL_PATH|" \
+        "$BUNDLE_DIR/assets/org.quickshell.desktop" \
+        > "$HOME/.local/share/applications/org.quickshell.desktop" 2>/dev/null || true
     # KWin reads this through KService, which needs its cache rebuilt.
     kbuildsycoca6 >/dev/null 2>&1 || true
     echo "  [OK]  Window preview interface requested."

--- a/shell/plugin/src/Caelestia/Services/hyprlandstate.cpp
+++ b/shell/plugin/src/Caelestia/Services/hyprlandstate.cpp
@@ -5,7 +5,6 @@
 #include <qloggingcategory.h>
 #include <qfilesystemwatcher.h>
 #include <qfile.h>
-#include <unistd.h>
 
 Q_LOGGING_CATEGORY(lcHyprState, "caelestia.services.hyprlandstate", QtInfoMsg)
 
@@ -22,8 +21,7 @@ HyprlandState::HyprlandState(QObject* parent)
     if (his.isEmpty()) {
         qCWarning(lcHyprState) << "$HYPRLAND_INSTANCE_SIGNATURE is unset. Using KDE fallback bridge.";
         m_kwinWatcher = new QFileSystemWatcher(this);
-        QString fallbackRuntimeDir = QString("/run/user/%1").arg(getuid());
-        QString runtimeDir = qEnvironmentVariable("XDG_RUNTIME_DIR", fallbackRuntimeDir);
+        QString runtimeDir = qEnvironmentVariable("XDG_RUNTIME_DIR", "/tmp");
         QString filePath = runtimeDir + "/qs_kwin_windows.json";
         if (!QFile::exists(filePath)) {
             QFile f(filePath);

--- a/shell/plugin/src/Caelestia/Services/windowicon.cpp
+++ b/shell/plugin/src/Caelestia/Services/windowicon.cpp
@@ -172,7 +172,7 @@ QString WindowIcon::extract(const QString& wmClass, const QString& title) {
     const auto cacheRoot =
         QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + QStringLiteral("/caelestia/winicons");
     const auto key = QString::fromLatin1(
-        QCryptographicHash::hash((wmClass + QStringLiteral("|") + title).toUtf8(), QCryptographicHash::Sha256)
+        QCryptographicHash::hash(wmClass.toUtf8(), QCryptographicHash::Sha256)
             .toHex()
             .left(16));
     const auto path = cacheRoot + QStringLiteral("/") + key + QStringLiteral(".png");


### PR DESCRIPTION
## Summary

Three targeted fixes for well-documented bugs:

| Issue | What | Change |
|-------|------|--------|
| #324 | 3 different fallback paths for qs_kwin_windows.json break the file watcher when XDG_RUNTIME_DIR is unset | Constructor now uses /tmp like the other 2 locations |
| #316 | org.quickshell.desktop hardcodes Exec=/usr/bin/quickshell | sed the Exec= line at deploy time with already-computed QUICKSHELL_CANONICAL_PATH |
| #325 | Icon cache key mixes volatile title with wmClass, causing unbounded cache growth | Drop title from the hash, key on wmClass alone |

## Files changed
- shell/plugin/src/Caelestia/Services/hyprlandstate.cpp — unify fallback path, remove unused getuid include
- shell/plugin/src/Caelestia/Services/windowicon.cpp — 1-line cache key change
- scripts/10-autostart.sh — template Exec instead of cp verbatim