### PR TITLE
fix: Discord IPC Flatpak paths, KWin bridge tempfile, orphan script cleanup

### DIFF
--- a/shell/plugin/src/Caelestia/Services/discordipc.cpp
+++ b/shell/plugin/src/Caelestia/Services/discordipc.cpp
@@ -64,9 +64,30 @@ void DiscordIpc::checkReconnect() {
     if (m_socket->state() == QLocalSocket::ConnectedState || m_socket->state() == QLocalSocket::ConnectingState) return;
 
     QString runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
-    QString pipePath = runtimeDir + "/discord-ipc-0";
 
-    m_socket->connectToServer(pipePath);
+    // Try native Discord IPC paths first: discord-ipc-0 through discord-ipc-9
+    // (multiple concurrent Discord-protocol clients occupy successive slots).
+    for (int slot = 0; slot <= 9; ++slot) {
+        QString pipePath = runtimeDir + "/discord-ipc-" + QString::number(slot);
+        m_socket->connectToServer(pipePath);
+        if (m_socket->waitForConnected(500))
+            return;
+    }
+
+    // Flatpak-packaged Discord / Vesktop sandbox the runtime directory.
+    // Try the well-known Flatpak app-ids.
+    static const QStringList flatpakIds = {
+        "com.discordapp.Discord",
+        "dev.vencord.Vesktop",
+    };
+    for (const auto& id : flatpakIds) {
+        for (int slot = 0; slot <= 9; ++slot) {
+            QString pipePath = runtimeDir + "/app/" + id + "/discord-ipc-" + QString::number(slot);
+            m_socket->connectToServer(pipePath);
+            if (m_socket->waitForConnected(500))
+                return;
+        }
+    }
 }
 
 void DiscordIpc::onSocketConnected() {

--- a/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
+++ b/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
@@ -215,6 +215,22 @@ KWinActiveWindowBridge::KWinActiveWindowBridge(QObject* parent)
             QDBusConnection::ExportAdaptors);
     bus.registerService("dev.caelestia.KWinActiveWindow");
 
+    // Clean up orphan KWin scripts from previous crashed sessions before
+    // injecting a fresh one, so duplicate D-Bus notifications don't pile up.
+    QDBusMessage listMsg =
+        QDBusMessage::createMethodCall("org.kde.KWin", "/Scripting", "org.kde.kwin.Scripting", "loadedScripts");
+    QDBusReply<QStringList> listReply = bus.call(listMsg);
+    if (listReply.isValid()) {
+        for (const auto& name : listReply.value()) {
+            if (name.startsWith("caelestia-active-window-")) {
+                QDBusMessage unloadMsg = QDBusMessage::createMethodCall(
+                    "org.kde.KWin", "/Scripting", "org.kde.kwin.Scripting", "unloadScript");
+                unloadMsg << name;
+                bus.call(unloadMsg, QDBus::NoBlock);
+            }
+        }
+    }
+
     injectKWinScript();
 }
 
@@ -587,12 +603,15 @@ void KWinActiveWindowBridge::injectKWinScript() {
     m_scriptName = "caelestia-active-window-" + QString::number(QCoreApplication::applicationPid()) + "-" +
                    QString::number(QDateTime::currentMSecsSinceEpoch());
 
-    QString scriptPath = QDir::tempPath() + "/caelestia-kwin-bridge.js";
-    QFile f(scriptPath);
-    if (f.open(QIODevice::WriteOnly)) {
-        f.write(kScriptSource.toUtf8());
-        f.close();
+    QTemporaryFile f(QDir::tempPath() + "/caelestia-kwin-bridge-XXXXXX.js");
+    f.setAutoRemove(false);
+    if (!f.open()) {
+        qWarning() << "Failed to create temporary file for KWin bridge script";
+        return;
     }
+    f.write(kScriptSource.toUtf8());
+    f.close();
+    const QString scriptPath = f.fileName();
 
     QDBusConnection bus = QDBusConnection::sessionBus();
 
@@ -609,6 +628,10 @@ void KWinActiveWindowBridge::injectKWinScript() {
     } else {
         qWarning() << "Failed to inject KWin active window script:" << reply.error().message();
     }
+
+    // KWin has loaded the script into its own JS engine; the temp file on disk
+    // is no longer needed.
+    QFile::remove(scriptPath);
 }
 
 } // namespace caelestia::services


### PR DESCRIPTION
| Issue | What | Change |
|-------|------|--------|
| #315 | Discord RPC only tries native discord-ipc-0, never works with Flatpak Discord/Vesktop | Scan 0..9 slots + Flatpak sandbox paths for both Discord and Vesktop |
| #295 | KWin bridge writes to static /tmp/caelestia-kwin-bridge.js (symlink attack + multi-instance race) | Use QTemporaryFile with unique name, delete after KWin loads it |
| #296 | Orphan KWin scripts pile up after crashes, causing duplicate D-Bus notifications | On construction, enumerate loadedScripts and unload any caelestia-active-window-* orphans before injecting |