### PR TITLE
feat: configurable hover trigger width and border thickness

### DIFF
--- a/shell/modules/drawers/Interactions.qml
+++ b/shell/modules/drawers/Interactions.qml
@@ -52,16 +52,30 @@ CustomMouseArea {
         return false;
     }
 
-    function withinPanelHeight(panel: Item, x: real, y: real): bool {
-        const panelY = panels.topMargin + panel.y;
-        const panelHeight = panel.content ? panel.content.nonAnimHeight : panel.height;
-        return y >= panelY - Config.border.rounding - panels.topMargin && y <= panelY + panelHeight + Config.border.rounding + panels.bottomMargin;
+    // `span` is how much of the panel's own extent along the edge counts, as a
+    // percentage, kept centred on the panel. 100 is the panel's full extent, which
+    // is what every caller wants once the panel is open — the narrowing exists so
+    // that a closed panel is not triggered by crossing the whole edge it spans.
+    function spanBounds(near: real, far: real, span: real): point {
+        if (span >= 100)
+            return Qt.point(near, far);
+        const half = (far - near) * Math.max(0, span) / 200;
+        const centre = (near + far) / 2;
+        return Qt.point(centre - half, centre + half);
     }
 
-    function withinPanelWidth(panel: Item, x: real, y: real): bool {
+    function withinPanelHeight(panel: Item, x: real, y: real, span = 100): bool {
+        const panelY = panels.topMargin + panel.y;
+        const panelHeight = panel.content ? panel.content.nonAnimHeight : panel.height;
+        const b = spanBounds(panelY - Config.border.rounding - panels.topMargin, panelY + panelHeight + Config.border.rounding + panels.bottomMargin, span);
+        return y >= b.x && y <= b.y;
+    }
+
+    function withinPanelWidth(panel: Item, x: real, y: real, span = 100): bool {
         const panelX = panels.leftMargin + panel.x;
         const panelWidth = panel.content ? panel.content.nonAnimWidth : panel.width;
-        return x >= panelX - Config.border.rounding - panels.leftMargin && x <= panelX + panelWidth + Config.border.rounding + panels.rightMargin;
+        const b = spanBounds(panelX - Config.border.rounding - panels.leftMargin, panelX + panelWidth + Config.border.rounding + panels.rightMargin, span);
+        return x >= b.x && x <= b.y;
     }
 
     function inLeftPanel(panel: Item, x: real, y: real): bool {
@@ -79,32 +93,35 @@ CustomMouseArea {
         return false;
     }
 
-    // `edge` is the width of the screen-edge strip that counts as being in the panel while it
-    // is closed; hover call sites pass the owning panel's hoverThickness. 0 keeps the whole
-    // border gap, which is the pre-configurable behaviour. Once the panel is showing, its own
-    // geometry takes over so the full panel stays hoverable wherever it has been pushed to.
-    function inRightPanel(panel: Item, x: real, y: real, edge = 0): bool {
+    // Two independent measurements of the trigger area, both of which used to be
+    // fixed. `edge` is its depth — how far in from the screen edge counts — and
+    // defaults to the border thickness, the pre-configurable behaviour. `span` is
+    // its extent along that edge as a percentage of the panel's own; 100 is the
+    // full extent. Both only apply while the panel is closed: once it is showing,
+    // its whole area has to stay hoverable or the pointer moving into it would
+    // read as leaving.
+    function inRightPanel(panel: Item, x: real, y: real, edge = 0, span = 100): bool {
         const onLeft = Config.bar.position === "right";
         const strip = Math.max(Config.border.minThickness, edge || (onLeft ? panels.leftMargin : panels.rightMargin));
         const closed = (panel.offsetScale ?? 0) >= 1 || panel.width <= 0; // qmllint disable missing-property
 
         if (onLeft) {
             const shown = panels.leftMargin + panel.x + panel.width;
-            return x < (closed ? strip : Math.max(strip, shown)) && withinPanelHeight(panel, x, y);
+            return x < (closed ? strip : Math.max(strip, shown)) && withinPanelHeight(panel, x, y, closed ? span : 100);
         }
 
         const shown = screen.width - (panels.leftMargin + panel.x);
-        return x > screen.width - (closed ? strip : Math.max(strip, shown)) && withinPanelHeight(panel, x, y);
+        return x > screen.width - (closed ? strip : Math.max(strip, shown)) && withinPanelHeight(panel, x, y, closed ? span : 100);
     }
 
-    function inTopPanel(panel: Item, x: real, y: real, edge = Config.border.thickness): bool {
+    function inTopPanel(panel: Item, x: real, y: real, edge = Config.border.thickness, span = 100): bool {
         const panelHeight = panel.height * (1 - (panel.offsetScale ?? 0)); // qmllint disable missing-property
-        return y < Math.max(Config.border.minThickness, edge + panelHeight) && withinPanelWidth(panel, x, y);
+        return y < Math.max(Config.border.minThickness, edge + panelHeight) && withinPanelWidth(panel, x, y, panelHeight > 0 ? 100 : span);
     }
 
-    function inBottomPanel(panel: Item, x: real, y: real, isCorner = false, edge = Config.border.thickness): bool {
+    function inBottomPanel(panel: Item, x: real, y: real, isCorner = false, edge = Config.border.thickness, span = 100): bool {
         const panelHeight = panel.height * (1 - (panel.offsetScale ?? 0)); // qmllint disable missing-property
-        return y > screen.height - Math.max(Config.border.minThickness, edge + panelHeight) - (isCorner ? Config.border.rounding : 0) && withinPanelWidth(panel, x, y);
+        return y > screen.height - Math.max(Config.border.minThickness, edge + panelHeight) - (isCorner ? Config.border.rounding : 0) && withinPanelWidth(panel, x, y, panelHeight > 0 ? 100 : span);
     }
 
     function onWheel(event: WheelEvent): void {
@@ -126,11 +143,11 @@ CustomMouseArea {
             let inside = false;
             
             if (inBarArea(event.x, event.y)) inside = true;
-            else if (visibilities.launcher && inBottomPanel(panels.launcher, event.x, event.y, false, Config.launcher.hoverThickness) && withinPanelWidth(panels.launcher, event.x, event.y)) inside = true;
+            else if (visibilities.launcher && inBottomPanel(panels.launcher, event.x, event.y, false, Config.launcher.hoverThickness, Config.launcher.hoverWidth) && withinPanelWidth(panels.launcher, event.x, event.y)) inside = true;
             else if (visibilities.session && inRightPanel(panels.sessionWrapper, event.x, event.y)) inside = true;
             else if (visibilities.sidebar && inRightPanel(panels.sidebar, event.x, event.y)) inside = true;
-            else if (visibilities.dashboard && inTopPanel(panels.dashboard, event.x, event.y, Config.dashboard.hoverThickness) && withinPanelWidth(panels.dashboard, event.x, event.y)) inside = true;
-            else if (visibilities.utilities && (Config.bar.position === "bottom" ? inTopPanel(panels.utilities, event.x, event.y, Config.utilities.hoverThickness) : inBottomPanel(panels.utilities, event.x, event.y, true, Config.utilities.hoverThickness)) && withinPanelWidth(panels.utilities, event.x, event.y)) inside = true;
+            else if (visibilities.dashboard && inTopPanel(panels.dashboard, event.x, event.y, Config.dashboard.hoverThickness, Config.dashboard.hoverWidth) && withinPanelWidth(panels.dashboard, event.x, event.y)) inside = true;
+            else if (visibilities.utilities && (Config.bar.position === "bottom" ? inTopPanel(panels.utilities, event.x, event.y, Config.utilities.hoverThickness, Config.utilities.hoverWidth) : inBottomPanel(panels.utilities, event.x, event.y, true, Config.utilities.hoverThickness, Config.utilities.hoverWidth)) && withinPanelWidth(panels.utilities, event.x, event.y)) inside = true;
             else if (popouts.hasCurrent && inLeftPanel(panels.popoutsWrapper, event.x, event.y)) inside = true;
 
             if (!inside) {
@@ -172,7 +189,7 @@ CustomMouseArea {
         const dragY = y - dragStart.y;
 
         if (fullscreen) {
-            root.panels.osd.hovered = inRightPanel(panels.osdWrapper, x, y, Config.osd.hoverThickness);
+            root.panels.osd.hovered = inRightPanel(panels.osdWrapper, x, y, Config.osd.hoverThickness, Config.osd.hoverWidth);
             return;
         }
 
@@ -207,7 +224,7 @@ CustomMouseArea {
 
         if (panels.sidebar.offsetScale === 1) {
             // Show osd on hover
-            const showOsd = inRightPanel(panels.osdWrapper, x, y, Config.osd.hoverThickness);
+            const showOsd = inRightPanel(panels.osdWrapper, x, y, Config.osd.hoverThickness, Config.osd.hoverWidth);
 
             // Always update visibility based on hover if not in shortcut mode
             if (!osdShortcutActive) {
@@ -242,7 +259,7 @@ CustomMouseArea {
         } else {
             const outOfSidebar = Config.bar.position === "right" ? x > panels.leftMargin + panels.sidebar.width * (1 - panels.sidebar.offsetScale) : x < screen.width - panels.sidebar.width * (1 - panels.sidebar.offsetScale);
             // Show osd on hover
-            const showOsd = outOfSidebar && inRightPanel(panels.osdWrapper, x, y, Config.osd.hoverThickness);
+            const showOsd = outOfSidebar && inRightPanel(panels.osdWrapper, x, y, Config.osd.hoverThickness, Config.osd.hoverWidth);
 
             // Always update visibility based on hover if not in shortcut mode
             if (!osdShortcutActive) {
@@ -272,9 +289,9 @@ CustomMouseArea {
 
         // Show launcher on hover, or show/hide on drag if hover is disabled
         if (Config.launcher.showOnHover) {
-            if (!visibilities.launcher && inBottomPanel(panels.launcher, x, y, false, Config.launcher.hoverThickness))
+            if (!visibilities.launcher && inBottomPanel(panels.launcher, x, y, false, Config.launcher.hoverThickness, Config.launcher.hoverWidth))
                 visibilities.launcher = true;
-        } else if (pressed && inBottomPanel(panels.launcher, dragStart.x, dragStart.y, false, Config.launcher.hoverThickness) && withinPanelWidth(panels.launcher, x, y)) {
+        } else if (pressed && inBottomPanel(panels.launcher, dragStart.x, dragStart.y, false, Config.launcher.hoverThickness, Config.launcher.hoverWidth) && withinPanelWidth(panels.launcher, x, y)) {
             if (dragY < -Config.launcher.dragThreshold)
                 visibilities.launcher = true;
             else if (dragY > Config.launcher.dragThreshold)
@@ -282,7 +299,7 @@ CustomMouseArea {
         }
 
         // Show dashboard on hover
-        const showDashboard = Config.dashboard.showOnHover && inTopPanel(panels.dashboard, x, y, Config.dashboard.hoverThickness);
+        const showDashboard = Config.dashboard.showOnHover && inTopPanel(panels.dashboard, x, y, Config.dashboard.hoverThickness, Config.dashboard.hoverWidth);
 
         // Always update visibility based on hover if not in shortcut mode
         if (Config.dashboard.showOnHover) {
@@ -295,7 +312,7 @@ CustomMouseArea {
         }
 
         // Show/hide dashboard on drag (for touchscreen devices)
-        if (pressed && inTopPanel(panels.dashboard, dragStart.x, dragStart.y, Config.dashboard.hoverThickness) && withinPanelWidth(panels.dashboard, x, y)) {
+        if (pressed && inTopPanel(panels.dashboard, dragStart.x, dragStart.y, Config.dashboard.hoverThickness, Config.dashboard.hoverWidth) && withinPanelWidth(panels.dashboard, x, y)) {
             if (dragY > Config.dashboard.dragThreshold)
                 visibilities.dashboard = true;
             else if (dragY < -Config.dashboard.dragThreshold)
@@ -322,8 +339,8 @@ CustomMouseArea {
         const inUtilitiesAreaOpen = x >= 0 && x <= screen.width;
         
         const inUtilitiesArea = Config.bar.position === "bottom"
-            ? inTopPanel(panels.utilities, x, y, Config.utilities.hoverThickness) && (root.visibilities.utilities ? inUtilitiesAreaOpen : inUtilitiesAreaClosed)
-            : inBottomPanel(panels.utilities, x, y, true, Config.utilities.hoverThickness) && (root.visibilities.utilities ? inUtilitiesAreaOpen : inUtilitiesAreaClosed);
+            ? inTopPanel(panels.utilities, x, y, Config.utilities.hoverThickness, Config.utilities.hoverWidth) && (root.visibilities.utilities ? inUtilitiesAreaOpen : inUtilitiesAreaClosed)
+            : inBottomPanel(panels.utilities, x, y, true, Config.utilities.hoverThickness, Config.utilities.hoverWidth) && (root.visibilities.utilities ? inUtilitiesAreaOpen : inUtilitiesAreaClosed);
         const showUtilities = Config.utilities.showOnHover && !popouts.hasCurrent && panels.popoutsWrapper.offsetScale > 0.99 && inUtilitiesArea;
 
         // Always update visibility based on hover if not in shortcut mode
@@ -339,8 +356,8 @@ CustomMouseArea {
         // Show/hide utilities on drag
         if (pressed) {
             const inUtilitiesDragStart = Config.bar.position === "bottom"
-                ? inTopPanel(panels.utilities, dragStart.x, dragStart.y, Config.utilities.hoverThickness)
-                : inBottomPanel(panels.utilities, dragStart.x, dragStart.y, true, Config.utilities.hoverThickness);
+                ? inTopPanel(panels.utilities, dragStart.x, dragStart.y, Config.utilities.hoverThickness, Config.utilities.hoverWidth)
+                : inBottomPanel(panels.utilities, dragStart.x, dragStart.y, true, Config.utilities.hoverThickness, Config.utilities.hoverWidth);
 
             if (inUtilitiesDragStart && (Config.bar.position === "bottom" ? withinPanelWidth(panels.utilities, x, y) : withinPanelWidth(panels.utilities, x, y))) {
                 if (Config.bar.position === "bottom") {
@@ -361,7 +378,7 @@ CustomMouseArea {
         // Instead, if it leaves the area, we exit shortcut mode
         if (utilitiesShortcutActive) {
             const inUtilitiesAreaOpen = x >= 0 && x <= screen.width;
-            const stillInUtilitiesArea = Config.bar.position === "bottom" ? inTopPanel(panels.utilities, x, y, Config.utilities.hoverThickness) && inUtilitiesAreaOpen : inBottomPanel(panels.utilities, x, y, true, Config.utilities.hoverThickness) && inUtilitiesAreaOpen;
+            const stillInUtilitiesArea = Config.bar.position === "bottom" ? inTopPanel(panels.utilities, x, y, Config.utilities.hoverThickness, Config.utilities.hoverWidth) && inUtilitiesAreaOpen : inBottomPanel(panels.utilities, x, y, true, Config.utilities.hoverThickness, Config.utilities.hoverWidth) && inUtilitiesAreaOpen;
             if (!stillInUtilitiesArea) {
                 utilitiesShortcutActive = false;
             }
@@ -378,8 +395,8 @@ CustomMouseArea {
                 root.utilitiesShortcutActive = false;
 
                 // Also hide dashboard and OSD if they're not being hovered
-                const inDashboardArea = root.inTopPanel(root.panels.dashboard, root.mouseX, root.mouseY, Config.dashboard.hoverThickness);
-                const inOsdArea = root.inRightPanel(root.panels.osdWrapper, root.mouseX, root.mouseY, Config.osd.hoverThickness);
+                const inDashboardArea = root.inTopPanel(root.panels.dashboard, root.mouseX, root.mouseY, Config.dashboard.hoverThickness, Config.dashboard.hoverWidth);
+                const inOsdArea = root.inRightPanel(root.panels.osdWrapper, root.mouseX, root.mouseY, Config.osd.hoverThickness, Config.osd.hoverWidth);
 
                 if (!inDashboardArea) {
                     root.visibilities.dashboard = false;
@@ -394,7 +411,7 @@ CustomMouseArea {
         function onDashboardChanged() {
             if (root.visibilities.dashboard) {
                 // Dashboard became visible, immediately check if this should be shortcut mode
-                const inDashboardArea = root.inTopPanel(root.panels.dashboard, root.mouseX, root.mouseY, Config.dashboard.hoverThickness);
+                const inDashboardArea = root.inTopPanel(root.panels.dashboard, root.mouseX, root.mouseY, Config.dashboard.hoverThickness, Config.dashboard.hoverWidth);
                 if (!inDashboardArea) {
                     root.dashboardShortcutActive = true;
                 }
@@ -407,7 +424,7 @@ CustomMouseArea {
         function onOsdChanged() {
             if (root.visibilities.osd) {
                 // OSD became visible, immediately check if this should be shortcut mode
-                const inOsdArea = root.inRightPanel(root.panels.osdWrapper, root.mouseX, root.mouseY, Config.osd.hoverThickness);
+                const inOsdArea = root.inRightPanel(root.panels.osdWrapper, root.mouseX, root.mouseY, Config.osd.hoverThickness, Config.osd.hoverWidth);
                 if (!inOsdArea) {
                     root.osdShortcutActive = true;
                 }
@@ -421,7 +438,7 @@ CustomMouseArea {
             if (root.visibilities.utilities) {
                 // Utilities became visible, immediately check if this should be shortcut mode
                 const margin = (root.visibilities.utilities || Config.bar.position !== "bottom") ? 0 : 200;
-                const inUtilitiesArea = Config.bar.position === "bottom" ? root.inTopPanel(root.panels.utilities, root.mouseX, root.mouseY, Config.utilities.hoverThickness) && root.mouseX >= margin && root.mouseX <= screen.width - margin : root.inBottomPanel(root.panels.utilities, root.mouseX, root.mouseY, true, Config.utilities.hoverThickness) && root.mouseX >= margin && root.mouseX <= screen.width - margin;
+                const inUtilitiesArea = Config.bar.position === "bottom" ? root.inTopPanel(root.panels.utilities, root.mouseX, root.mouseY, Config.utilities.hoverThickness, Config.utilities.hoverWidth) && root.mouseX >= margin && root.mouseX <= screen.width - margin : root.inBottomPanel(root.panels.utilities, root.mouseX, root.mouseY, true, Config.utilities.hoverThickness, Config.utilities.hoverWidth) && root.mouseX >= margin && root.mouseX <= screen.width - margin;
                 if (!inUtilitiesArea) {
                     root.utilitiesShortcutActive = true;
                 }

--- a/shell/modules/drawers/Interactions.qml
+++ b/shell/modules/drawers/Interactions.qml
@@ -38,15 +38,17 @@ CustomMouseArea {
 
     readonly property bool isBarHorizontal: Config.bar.position === "top" || Config.bar.position === "bottom"
 
+    // Uses clampedThickness rather than the raw implicit size so the bar stays
+    // reachable when the border thickness is set to 0 (the collapsed bar is 0px wide).
     function inBarArea(x: real, y: real): bool {
         if (Config.bar.position === "left")
-            return x < bar.x + bar.implicitWidth;
+            return x < bar.x + bar.clampedThickness;
         if (Config.bar.position === "right")
-            return x > bar.x;
+            return x > bar.x + bar.width - bar.clampedThickness;
         if (Config.bar.position === "top")
-            return y < bar.y + bar.implicitHeight;
+            return y < bar.y + bar.clampedThickness;
         if (Config.bar.position === "bottom")
-            return y > bar.y;
+            return y > bar.y + bar.height - bar.clampedThickness;
         return false;
     }
 
@@ -77,20 +79,32 @@ CustomMouseArea {
         return false;
     }
 
-    function inRightPanel(panel: Item, x: real, y: real): bool {
-        if (Config.bar.position === "right")
-            return x < Math.max(Config.border.minThickness, panels.leftMargin + panel.x + panel.width) && withinPanelHeight(panel, x, y);
-        return x > Math.min(screen.width - Config.border.minThickness, panels.leftMargin + panel.x) && withinPanelHeight(panel, x, y);
+    // `edge` is the width of the screen-edge strip that counts as being in the panel while it
+    // is closed; hover call sites pass the owning panel's hoverThickness. 0 keeps the whole
+    // border gap, which is the pre-configurable behaviour. Once the panel is showing, its own
+    // geometry takes over so the full panel stays hoverable wherever it has been pushed to.
+    function inRightPanel(panel: Item, x: real, y: real, edge = 0): bool {
+        const onLeft = Config.bar.position === "right";
+        const strip = Math.max(Config.border.minThickness, edge || (onLeft ? panels.leftMargin : panels.rightMargin));
+        const closed = (panel.offsetScale ?? 0) >= 1 || panel.width <= 0; // qmllint disable missing-property
+
+        if (onLeft) {
+            const shown = panels.leftMargin + panel.x + panel.width;
+            return x < (closed ? strip : Math.max(strip, shown)) && withinPanelHeight(panel, x, y);
+        }
+
+        const shown = screen.width - (panels.leftMargin + panel.x);
+        return x > screen.width - (closed ? strip : Math.max(strip, shown)) && withinPanelHeight(panel, x, y);
     }
 
-    function inTopPanel(panel: Item, x: real, y: real): bool {
+    function inTopPanel(panel: Item, x: real, y: real, edge = Config.border.thickness): bool {
         const panelHeight = panel.height * (1 - (panel.offsetScale ?? 0)); // qmllint disable missing-property
-        return y < Math.max(Config.border.minThickness, Config.border.thickness + panelHeight) && withinPanelWidth(panel, x, y);
+        return y < Math.max(Config.border.minThickness, edge + panelHeight) && withinPanelWidth(panel, x, y);
     }
 
-    function inBottomPanel(panel: Item, x: real, y: real, isCorner = false): bool {
+    function inBottomPanel(panel: Item, x: real, y: real, isCorner = false, edge = Config.border.thickness): bool {
         const panelHeight = panel.height * (1 - (panel.offsetScale ?? 0)); // qmllint disable missing-property
-        return y > screen.height - Math.max(Config.border.minThickness, Config.border.thickness + panelHeight) - (isCorner ? Config.border.rounding : 0) && withinPanelWidth(panel, x, y);
+        return y > screen.height - Math.max(Config.border.minThickness, edge + panelHeight) - (isCorner ? Config.border.rounding : 0) && withinPanelWidth(panel, x, y);
     }
 
     function onWheel(event: WheelEvent): void {
@@ -112,11 +126,11 @@ CustomMouseArea {
             let inside = false;
             
             if (inBarArea(event.x, event.y)) inside = true;
-            else if (visibilities.launcher && inBottomPanel(panels.launcher, event.x, event.y) && withinPanelWidth(panels.launcher, event.x, event.y)) inside = true;
+            else if (visibilities.launcher && inBottomPanel(panels.launcher, event.x, event.y, false, Config.launcher.hoverThickness) && withinPanelWidth(panels.launcher, event.x, event.y)) inside = true;
             else if (visibilities.session && inRightPanel(panels.sessionWrapper, event.x, event.y)) inside = true;
             else if (visibilities.sidebar && inRightPanel(panels.sidebar, event.x, event.y)) inside = true;
-            else if (visibilities.dashboard && inTopPanel(panels.dashboard, event.x, event.y) && withinPanelWidth(panels.dashboard, event.x, event.y)) inside = true;
-            else if (visibilities.utilities && (Config.bar.position === "bottom" ? inTopPanel(panels.utilities, event.x, event.y) : inBottomPanel(panels.utilities, event.x, event.y, true)) && withinPanelWidth(panels.utilities, event.x, event.y)) inside = true;
+            else if (visibilities.dashboard && inTopPanel(panels.dashboard, event.x, event.y, Config.dashboard.hoverThickness) && withinPanelWidth(panels.dashboard, event.x, event.y)) inside = true;
+            else if (visibilities.utilities && (Config.bar.position === "bottom" ? inTopPanel(panels.utilities, event.x, event.y, Config.utilities.hoverThickness) : inBottomPanel(panels.utilities, event.x, event.y, true, Config.utilities.hoverThickness)) && withinPanelWidth(panels.utilities, event.x, event.y)) inside = true;
             else if (popouts.hasCurrent && inLeftPanel(panels.popoutsWrapper, event.x, event.y)) inside = true;
 
             if (!inside) {
@@ -158,7 +172,7 @@ CustomMouseArea {
         const dragY = y - dragStart.y;
 
         if (fullscreen) {
-            root.panels.osd.hovered = inRightPanel(panels.osdWrapper, x, y);
+            root.panels.osd.hovered = inRightPanel(panels.osdWrapper, x, y, Config.osd.hoverThickness);
             return;
         }
 
@@ -193,7 +207,7 @@ CustomMouseArea {
 
         if (panels.sidebar.offsetScale === 1) {
             // Show osd on hover
-            const showOsd = inRightPanel(panels.osdWrapper, x, y);
+            const showOsd = inRightPanel(panels.osdWrapper, x, y, Config.osd.hoverThickness);
 
             // Always update visibility based on hover if not in shortcut mode
             if (!osdShortcutActive) {
@@ -228,7 +242,7 @@ CustomMouseArea {
         } else {
             const outOfSidebar = Config.bar.position === "right" ? x > panels.leftMargin + panels.sidebar.width * (1 - panels.sidebar.offsetScale) : x < screen.width - panels.sidebar.width * (1 - panels.sidebar.offsetScale);
             // Show osd on hover
-            const showOsd = outOfSidebar && inRightPanel(panels.osdWrapper, x, y);
+            const showOsd = outOfSidebar && inRightPanel(panels.osdWrapper, x, y, Config.osd.hoverThickness);
 
             // Always update visibility based on hover if not in shortcut mode
             if (!osdShortcutActive) {
@@ -258,9 +272,9 @@ CustomMouseArea {
 
         // Show launcher on hover, or show/hide on drag if hover is disabled
         if (Config.launcher.showOnHover) {
-            if (!visibilities.launcher && inBottomPanel(panels.launcher, x, y))
+            if (!visibilities.launcher && inBottomPanel(panels.launcher, x, y, false, Config.launcher.hoverThickness))
                 visibilities.launcher = true;
-        } else if (pressed && inBottomPanel(panels.launcher, dragStart.x, dragStart.y) && withinPanelWidth(panels.launcher, x, y)) {
+        } else if (pressed && inBottomPanel(panels.launcher, dragStart.x, dragStart.y, false, Config.launcher.hoverThickness) && withinPanelWidth(panels.launcher, x, y)) {
             if (dragY < -Config.launcher.dragThreshold)
                 visibilities.launcher = true;
             else if (dragY > Config.launcher.dragThreshold)
@@ -268,7 +282,7 @@ CustomMouseArea {
         }
 
         // Show dashboard on hover
-        const showDashboard = Config.dashboard.showOnHover && inTopPanel(panels.dashboard, x, y);
+        const showDashboard = Config.dashboard.showOnHover && inTopPanel(panels.dashboard, x, y, Config.dashboard.hoverThickness);
 
         // Always update visibility based on hover if not in shortcut mode
         if (Config.dashboard.showOnHover) {
@@ -281,7 +295,7 @@ CustomMouseArea {
         }
 
         // Show/hide dashboard on drag (for touchscreen devices)
-        if (pressed && inTopPanel(panels.dashboard, dragStart.x, dragStart.y) && withinPanelWidth(panels.dashboard, x, y)) {
+        if (pressed && inTopPanel(panels.dashboard, dragStart.x, dragStart.y, Config.dashboard.hoverThickness) && withinPanelWidth(panels.dashboard, x, y)) {
             if (dragY > Config.dashboard.dragThreshold)
                 visibilities.dashboard = true;
             else if (dragY < -Config.dashboard.dragThreshold)
@@ -307,9 +321,9 @@ CustomMouseArea {
         const inUtilitiesAreaClosed = isUtilitiesOnLeft ? x <= (screen.width / 2) : (x >= (screen.width / 2) && (Config.bar.position === "bottom" ? x <= (screen.width - 200) : true));
         const inUtilitiesAreaOpen = x >= 0 && x <= screen.width;
         
-        const inUtilitiesArea = Config.bar.position === "bottom" 
-            ? inTopPanel(panels.utilities, x, y) && (root.visibilities.utilities ? inUtilitiesAreaOpen : inUtilitiesAreaClosed)
-            : inBottomPanel(panels.utilities, x, y, true) && (root.visibilities.utilities ? inUtilitiesAreaOpen : inUtilitiesAreaClosed);
+        const inUtilitiesArea = Config.bar.position === "bottom"
+            ? inTopPanel(panels.utilities, x, y, Config.utilities.hoverThickness) && (root.visibilities.utilities ? inUtilitiesAreaOpen : inUtilitiesAreaClosed)
+            : inBottomPanel(panels.utilities, x, y, true, Config.utilities.hoverThickness) && (root.visibilities.utilities ? inUtilitiesAreaOpen : inUtilitiesAreaClosed);
         const showUtilities = Config.utilities.showOnHover && !popouts.hasCurrent && panels.popoutsWrapper.offsetScale > 0.99 && inUtilitiesArea;
 
         // Always update visibility based on hover if not in shortcut mode
@@ -324,9 +338,9 @@ CustomMouseArea {
 
         // Show/hide utilities on drag
         if (pressed) {
-            const inUtilitiesDragStart = Config.bar.position === "bottom" 
-                ? inTopPanel(panels.utilities, dragStart.x, dragStart.y) 
-                : inBottomPanel(panels.utilities, dragStart.x, dragStart.y, true);
+            const inUtilitiesDragStart = Config.bar.position === "bottom"
+                ? inTopPanel(panels.utilities, dragStart.x, dragStart.y, Config.utilities.hoverThickness)
+                : inBottomPanel(panels.utilities, dragStart.x, dragStart.y, true, Config.utilities.hoverThickness);
 
             if (inUtilitiesDragStart && (Config.bar.position === "bottom" ? withinPanelWidth(panels.utilities, x, y) : withinPanelWidth(panels.utilities, x, y))) {
                 if (Config.bar.position === "bottom") {
@@ -347,7 +361,7 @@ CustomMouseArea {
         // Instead, if it leaves the area, we exit shortcut mode
         if (utilitiesShortcutActive) {
             const inUtilitiesAreaOpen = x >= 0 && x <= screen.width;
-            const stillInUtilitiesArea = Config.bar.position === "bottom" ? inTopPanel(panels.utilities, x, y) && inUtilitiesAreaOpen : inBottomPanel(panels.utilities, x, y, true) && inUtilitiesAreaOpen;
+            const stillInUtilitiesArea = Config.bar.position === "bottom" ? inTopPanel(panels.utilities, x, y, Config.utilities.hoverThickness) && inUtilitiesAreaOpen : inBottomPanel(panels.utilities, x, y, true, Config.utilities.hoverThickness) && inUtilitiesAreaOpen;
             if (!stillInUtilitiesArea) {
                 utilitiesShortcutActive = false;
             }
@@ -364,8 +378,8 @@ CustomMouseArea {
                 root.utilitiesShortcutActive = false;
 
                 // Also hide dashboard and OSD if they're not being hovered
-                const inDashboardArea = root.inTopPanel(root.panels.dashboard, root.mouseX, root.mouseY);
-                const inOsdArea = root.inRightPanel(root.panels.osdWrapper, root.mouseX, root.mouseY);
+                const inDashboardArea = root.inTopPanel(root.panels.dashboard, root.mouseX, root.mouseY, Config.dashboard.hoverThickness);
+                const inOsdArea = root.inRightPanel(root.panels.osdWrapper, root.mouseX, root.mouseY, Config.osd.hoverThickness);
 
                 if (!inDashboardArea) {
                     root.visibilities.dashboard = false;
@@ -380,7 +394,7 @@ CustomMouseArea {
         function onDashboardChanged() {
             if (root.visibilities.dashboard) {
                 // Dashboard became visible, immediately check if this should be shortcut mode
-                const inDashboardArea = root.inTopPanel(root.panels.dashboard, root.mouseX, root.mouseY);
+                const inDashboardArea = root.inTopPanel(root.panels.dashboard, root.mouseX, root.mouseY, Config.dashboard.hoverThickness);
                 if (!inDashboardArea) {
                     root.dashboardShortcutActive = true;
                 }
@@ -393,7 +407,7 @@ CustomMouseArea {
         function onOsdChanged() {
             if (root.visibilities.osd) {
                 // OSD became visible, immediately check if this should be shortcut mode
-                const inOsdArea = root.inRightPanel(root.panels.osdWrapper, root.mouseX, root.mouseY);
+                const inOsdArea = root.inRightPanel(root.panels.osdWrapper, root.mouseX, root.mouseY, Config.osd.hoverThickness);
                 if (!inOsdArea) {
                     root.osdShortcutActive = true;
                 }
@@ -407,7 +421,7 @@ CustomMouseArea {
             if (root.visibilities.utilities) {
                 // Utilities became visible, immediately check if this should be shortcut mode
                 const margin = (root.visibilities.utilities || Config.bar.position !== "bottom") ? 0 : 200;
-                const inUtilitiesArea = Config.bar.position === "bottom" ? root.inTopPanel(root.panels.utilities, root.mouseX, root.mouseY) && root.mouseX >= margin && root.mouseX <= screen.width - margin : root.inBottomPanel(root.panels.utilities, root.mouseX, root.mouseY, true) && root.mouseX >= margin && root.mouseX <= screen.width - margin;
+                const inUtilitiesArea = Config.bar.position === "bottom" ? root.inTopPanel(root.panels.utilities, root.mouseX, root.mouseY, Config.utilities.hoverThickness) && root.mouseX >= margin && root.mouseX <= screen.width - margin : root.inBottomPanel(root.panels.utilities, root.mouseX, root.mouseY, true, Config.utilities.hoverThickness) && root.mouseX >= margin && root.mouseX <= screen.width - margin;
                 if (!inUtilitiesArea) {
                     root.utilitiesShortcutActive = true;
                 }

--- a/shell/modules/drawers/Regions.qml
+++ b/shell/modules/drawers/Regions.qml
@@ -17,6 +17,12 @@ Region {
     readonly property real borderThickness: Config.border.thickness
     readonly property real clampedThickness: Config.border.clampedThickness
 
+    // A closed panel's input region must be at least as deep as its hover trigger,
+    // otherwise the pointer never reaches the area Interactions tests against.
+    function edgeExtent(hoverThickness: real): real {
+        return Math.max(borderThickness, hoverThickness);
+    }
+
     readonly property real barLeftWidth: Config.bar.position === "left" ? bar.clampedThickness : clampedThickness
     readonly property real barRightWidth: Config.bar.position === "right" ? bar.clampedThickness : clampedThickness
     readonly property real barTopHeight: Config.bar.position === "top" ? bar.clampedThickness : clampedThickness
@@ -31,13 +37,13 @@ Region {
     R {
         panel: root.panels.dashboard
         y: 0
-        height: panel.height * (1 - root.panels.dashboard.offsetScale) + root.borderThickness
+        height: panel.height * (1 - root.panels.dashboard.offsetScale) + root.edgeExtent(root.Config.dashboard.hoverThickness)
     }
 
     R {
         panel: root.panels.launcher
         y: root.win.height - height
-        height: panel.height * (1 - root.panels.launcher.offsetScale) + root.borderThickness
+        height: panel.height * (1 - root.panels.launcher.offsetScale) + root.edgeExtent(root.Config.launcher.hoverThickness)
     }
 
     R {
@@ -61,7 +67,7 @@ Region {
 
         panel: root.panels.osdWrapper
         x: root.Config.bar.position === "right" ? 0 : root.win.width - osdRegion.width
-        width: panel.width * (1 - root.panels.osd.offsetScale) + root.borderThickness + sessionRegion.width
+        width: panel.width * (1 - root.panels.osd.offsetScale) + root.edgeExtent(root.Config.osd.hoverThickness) + sessionRegion.width
     }
 
     R {
@@ -73,7 +79,7 @@ Region {
     R {
         panel: root.panels.utilities
         y: root.Config.bar.position === "bottom" ? 0 : root.win.height - height
-        height: panel.height * (1 - root.panels.utilities.offsetScale) + root.borderThickness
+        height: panel.height * (1 - root.panels.utilities.offsetScale) + root.edgeExtent(root.Config.utilities.hoverThickness)
     }
 
     R {

--- a/shell/modules/nexus/pages/UtilitiesPage.qml
+++ b/shell/modules/nexus/pages/UtilitiesPage.qml
@@ -91,14 +91,24 @@ PageBase {
         }
 
         StepperRow {
-            last: true
-            label: qsTr("Hover trigger width")
-            subtext: qsTr("Width of the screen edge strip that opens the OSD sliders")
+            label: qsTr("Hover trigger depth")
+            subtext: qsTr("Distance in from the screen edge that opens the OSD sliders")
             value: Config.osd.hoverThickness
             from: 1
             to: 100
             stepSize: 1
             onMoved: v => GlobalConfig.osd.hoverThickness = v
+        }
+
+        StepperRow {
+            last: true
+            label: qsTr("Hover trigger height")
+            subtext: qsTr("How much of the side edge opens the OSD sliders, as a percentage of their height")
+            value: Config.osd.hoverWidth
+            from: 10
+            to: 100
+            stepSize: 5
+            onMoved: v => GlobalConfig.osd.hoverWidth = v
         }
 
         SectionHeader {

--- a/shell/modules/nexus/pages/UtilitiesPage.qml
+++ b/shell/modules/nexus/pages/UtilitiesPage.qml
@@ -84,11 +84,21 @@ PageBase {
         }
 
         ToggleRow {
-            last: true
             text: qsTr("Brightness slider")
             subtext: qsTr("Show the brightness OSD slider")
             checked: Config.osd.enableBrightness
             onToggled: GlobalConfig.osd.enableBrightness = checked
+        }
+
+        StepperRow {
+            last: true
+            label: qsTr("Hover trigger width")
+            subtext: qsTr("Width of the screen edge strip that opens the OSD sliders")
+            value: Config.osd.hoverThickness
+            from: 1
+            to: 100
+            stepSize: 1
+            onMoved: v => GlobalConfig.osd.hoverThickness = v
         }
 
         SectionHeader {

--- a/shell/modules/nexus/pages/panels/DashboardPanel.qml
+++ b/shell/modules/nexus/pages/panels/DashboardPanel.qml
@@ -314,6 +314,16 @@ PageBase {
 
         StepperRow {
             first: true
+            label: qsTr("Hover trigger width")
+            subtext: qsTr("Width of the screen edge strip that opens the dashboard")
+            value: Config.dashboard.hoverThickness
+            from: 1
+            to: 100
+            stepSize: 1
+            onMoved: v => GlobalConfig.dashboard.hoverThickness = v
+        }
+
+        StepperRow {
             last: true
             label: qsTr("Drag threshold")
             subtext: qsTr("Pixels dragged before the dashboard opens")

--- a/shell/modules/nexus/pages/panels/DashboardPanel.qml
+++ b/shell/modules/nexus/pages/panels/DashboardPanel.qml
@@ -314,13 +314,23 @@ PageBase {
 
         StepperRow {
             first: true
-            label: qsTr("Hover trigger width")
-            subtext: qsTr("Width of the screen edge strip that opens the dashboard")
+            label: qsTr("Hover trigger depth")
+            subtext: qsTr("Distance in from the screen edge that opens the dashboard")
             value: Config.dashboard.hoverThickness
             from: 1
             to: 100
             stepSize: 1
             onMoved: v => GlobalConfig.dashboard.hoverThickness = v
+        }
+
+        StepperRow {
+            label: qsTr("Hover trigger width")
+            subtext: qsTr("How much of the top edge opens the dashboard, as a percentage of its width")
+            value: Config.dashboard.hoverWidth
+            from: 10
+            to: 100
+            stepSize: 5
+            onMoved: v => GlobalConfig.dashboard.hoverWidth = v
         }
 
         StepperRow {

--- a/shell/modules/nexus/pages/panels/LauncherPanel.qml
+++ b/shell/modules/nexus/pages/panels/LauncherPanel.qml
@@ -65,13 +65,23 @@ PageBase {
         }
 
         StepperRow {
-            label: qsTr("Hover trigger width")
-            subtext: qsTr("Width of the screen edge strip that opens the launcher")
+            label: qsTr("Hover trigger depth")
+            subtext: qsTr("Distance in from the screen edge that opens the launcher")
             value: Config.launcher.hoverThickness
             from: 1
             to: 100
             stepSize: 1
             onMoved: v => GlobalConfig.launcher.hoverThickness = v
+        }
+
+        StepperRow {
+            label: qsTr("Hover trigger width")
+            subtext: qsTr("How much of the bottom edge opens the launcher, as a percentage of its width")
+            value: Config.launcher.hoverWidth
+            from: 10
+            to: 100
+            stepSize: 5
+            onMoved: v => GlobalConfig.launcher.hoverWidth = v
         }
 
         StepperRow {

--- a/shell/modules/nexus/pages/panels/LauncherPanel.qml
+++ b/shell/modules/nexus/pages/panels/LauncherPanel.qml
@@ -65,6 +65,16 @@ PageBase {
         }
 
         StepperRow {
+            label: qsTr("Hover trigger width")
+            subtext: qsTr("Width of the screen edge strip that opens the launcher")
+            value: Config.launcher.hoverThickness
+            from: 1
+            to: 100
+            stepSize: 1
+            onMoved: v => GlobalConfig.launcher.hoverThickness = v
+        }
+
+        StepperRow {
             last: true
             label: qsTr("Drag threshold")
             subtext: qsTr("Pixels dragged before the launcher opens")

--- a/shell/modules/nexus/pages/panels/UtilitiesPanel.qml
+++ b/shell/modules/nexus/pages/panels/UtilitiesPanel.qml
@@ -44,13 +44,25 @@ PageBase {
         StepperRow {
             Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
             Layout.fillWidth: true
-            label: qsTr("Hover trigger width")
-            subtext: qsTr("Width of the screen edge strip that opens the quick toggles")
+            label: qsTr("Hover trigger depth")
+            subtext: qsTr("Distance in from the screen edge that opens the quick toggles")
             value: Config.utilities.hoverThickness
             from: 1
             to: 100
             stepSize: 1
             onMoved: v => GlobalConfig.utilities.hoverThickness = v
+        }
+
+        StepperRow {
+            Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
+            Layout.fillWidth: true
+            label: qsTr("Hover trigger width")
+            subtext: qsTr("How much of that edge opens the quick toggles, as a percentage of their width")
+            value: Config.utilities.hoverWidth
+            from: 10
+            to: 100
+            stepSize: 5
+            onMoved: v => GlobalConfig.utilities.hoverWidth = v
         }
 
         StepperRow {

--- a/shell/modules/nexus/pages/panels/UtilitiesPanel.qml
+++ b/shell/modules/nexus/pages/panels/UtilitiesPanel.qml
@@ -44,6 +44,18 @@ PageBase {
         StepperRow {
             Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
             Layout.fillWidth: true
+            label: qsTr("Hover trigger width")
+            subtext: qsTr("Width of the screen edge strip that opens the quick toggles")
+            value: Config.utilities.hoverThickness
+            from: 1
+            to: 100
+            stepSize: 1
+            onMoved: v => GlobalConfig.utilities.hoverThickness = v
+        }
+
+        StepperRow {
+            Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
+            Layout.fillWidth: true
             last: true
             label: qsTr("Drag threshold")
             subtext: qsTr("Pixels dragged before the quick toggle opens")

--- a/shell/modules/nexus/pages/wallandstyle/AppearancePage.qml
+++ b/shell/modules/nexus/pages/wallandstyle/AppearancePage.qml
@@ -65,6 +65,17 @@ PageBase {
                 onToggled: GlobalConfig.appearance.islands = checked
             }
 
+            StepperRow {
+                Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
+                label: qsTr("Border thickness")
+                subtext: qsTr("Thickness of the shell border in pixels. Set to 0 for a borderless look")
+                value: GlobalConfig.border.thickness
+                from: 0
+                to: 50
+                stepSize: 1
+                onMoved: v => GlobalConfig.border.thickness = v
+            }
+
             ToggleRow {
                 Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
                 Layout.fillWidth: true

--- a/shell/plugin/src/Caelestia/Config/dashboardconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/dashboardconfig.hpp
@@ -40,6 +40,7 @@ class DashboardConfig : public ConfigObject {
     CONFIG_GLOBAL_PROPERTY(int, mediaUpdateInterval, 500)
     CONFIG_GLOBAL_PROPERTY(int, resourceUpdateInterval, 1000)
     CONFIG_PROPERTY(int, dragThreshold, 50)
+    CONFIG_PROPERTY(int, hoverThickness, 5)
     CONFIG_SUBOBJECT(DashboardPerformance, performance)
 
 public:

--- a/shell/plugin/src/Caelestia/Config/dashboardconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/dashboardconfig.hpp
@@ -41,6 +41,7 @@ class DashboardConfig : public ConfigObject {
     CONFIG_GLOBAL_PROPERTY(int, resourceUpdateInterval, 1000)
     CONFIG_PROPERTY(int, dragThreshold, 50)
     CONFIG_PROPERTY(int, hoverThickness, 5)
+    CONFIG_PROPERTY(int, hoverWidth, 50)
     CONFIG_SUBOBJECT(DashboardPerformance, performance)
 
 public:

--- a/shell/plugin/src/Caelestia/Config/launcherconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/launcherconfig.hpp
@@ -40,6 +40,7 @@ class LauncherConfig : public ConfigObject {
     CONFIG_GLOBAL_PROPERTY(QString, actionPrefix, u">"_s)
     CONFIG_GLOBAL_PROPERTY(bool, enableDangerousActions, false)
     CONFIG_PROPERTY(int, dragThreshold, 50)
+    CONFIG_PROPERTY(int, hoverThickness, 5)
     CONFIG_GLOBAL_PROPERTY(bool, vimKeybinds, false)
     CONFIG_GLOBAL_PROPERTY(bool, confirmClearClipboard, true)
     CONFIG_GLOBAL_PROPERTY(QStringList, favouriteApps, QStringList({ u"firefox"_s, u"org.kde.dolphin"_s }))

--- a/shell/plugin/src/Caelestia/Config/launcherconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/launcherconfig.hpp
@@ -41,6 +41,7 @@ class LauncherConfig : public ConfigObject {
     CONFIG_GLOBAL_PROPERTY(bool, enableDangerousActions, false)
     CONFIG_PROPERTY(int, dragThreshold, 50)
     CONFIG_PROPERTY(int, hoverThickness, 5)
+    CONFIG_PROPERTY(int, hoverWidth, 50)
     CONFIG_GLOBAL_PROPERTY(bool, vimKeybinds, false)
     CONFIG_GLOBAL_PROPERTY(bool, confirmClearClipboard, true)
     CONFIG_GLOBAL_PROPERTY(QStringList, favouriteApps, QStringList({ u"firefox"_s, u"org.kde.dolphin"_s }))

--- a/shell/plugin/src/Caelestia/Config/osdconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/osdconfig.hpp
@@ -11,6 +11,7 @@ class OsdConfig : public ConfigObject {
     CONFIG_PROPERTY(bool, enabled, true)
     CONFIG_PROPERTY(int, hideDelay, 2000)
     CONFIG_PROPERTY(int, hoverThickness, 5)
+    CONFIG_PROPERTY(int, hoverWidth, 50)
     CONFIG_PROPERTY(bool, enableBrightness, true)
     CONFIG_PROPERTY(bool, enableMicrophone, false)
     CONFIG_PROPERTY(bool, enableVolume, true)

--- a/shell/plugin/src/Caelestia/Config/osdconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/osdconfig.hpp
@@ -10,6 +10,7 @@ class OsdConfig : public ConfigObject {
 
     CONFIG_PROPERTY(bool, enabled, true)
     CONFIG_PROPERTY(int, hideDelay, 2000)
+    CONFIG_PROPERTY(int, hoverThickness, 5)
     CONFIG_PROPERTY(bool, enableBrightness, true)
     CONFIG_PROPERTY(bool, enableMicrophone, false)
     CONFIG_PROPERTY(bool, enableVolume, true)

--- a/shell/plugin/src/Caelestia/Config/utilitiesconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/utilitiesconfig.hpp
@@ -76,6 +76,7 @@ class UtilitiesConfig : public ConfigObject {
     CONFIG_PROPERTY(bool, enabled, true)
     CONFIG_PROPERTY(bool, showOnHover, true)
     CONFIG_PROPERTY(int, dragThreshold, 50)
+    CONFIG_PROPERTY(int, hoverThickness, 5)
     CONFIG_PROPERTY(int, maxToasts, 4)
     CONFIG_SUBOBJECT(UtilitiesToasts, toasts)
     CONFIG_SUBOBJECT(UtilitiesVpn, vpn)

--- a/shell/plugin/src/Caelestia/Config/utilitiesconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/utilitiesconfig.hpp
@@ -77,6 +77,7 @@ class UtilitiesConfig : public ConfigObject {
     CONFIG_PROPERTY(bool, showOnHover, true)
     CONFIG_PROPERTY(int, dragThreshold, 50)
     CONFIG_PROPERTY(int, hoverThickness, 5)
+    CONFIG_PROPERTY(int, hoverWidth, 50)
     CONFIG_PROPERTY(int, maxToasts, 4)
     CONFIG_SUBOBJECT(UtilitiesToasts, toasts)
     CONFIG_SUBOBJECT(UtilitiesVpn, vpn)


### PR DESCRIPTION
Closes #320, closes #319.

## #320 - hover trigger area

Two measurements of the trigger area, both of which were fixed before.

**Depth** - how far in from the screen edge counts - was hardcoded to the border thickness, so the only way to shrink it was to make the border thinner. Now a `hoverThickness` option on the dashboard, launcher, utilities and osd configs, default 5, down from the previous effective 10.

**Extent along the edge** is the one the reporter meant (see the screenshot in the issue). For the dashboard it was the panel's own width plus the corner rounding and the margins - roughly 914px of a 1920px screen - so crossing the middle of the top edge at all opened it. Now a `hoverWidth` option, as a percentage of the panel's extent kept centred on it, default 50.

Both narrow only while the panel is closed. Once one is showing, its whole area has to keep counting as hovered, or moving the pointer into the part outside the narrowed band would read as leaving and close it again.

`inTopPanel`, `inBottomPanel` and `inRightPanel` take the two as optional arguments, defaulting to what those expressions used before, so the drag call sites are unaffected.

`inRightPanel` needed rewriting beyond that: it derived its strip from `panels.rightMargin`, which is the border gap, so a smaller value had no effect there. It now uses the configured strip while the panel is closed and the panel's own geometry once it is showing, so the panel stays hoverable wherever the sidebar or session have pushed it to.

The drawer input regions in `Regions.qml` grow with the hover thickness too. Without that, a `hoverThickness` larger than the border thickness does nothing, because the pointer never reaches the area `Interactions` tests against.

In Nexus the two are named apart - "Hover trigger depth" in pixels and "Hover trigger width" as a percentage - since one of them being called width is what caused the confusion in the first place. On the OSD the second one is vertical and called height.

## #319 - border thickness

Settable from Nexus under Theme & Effects, 0 to 50.

Making 0 actually usable needed one fix: `inBarArea` measured against the bar's raw implicit size, and at thickness 0 the collapsed bar is 0px wide, so a non-persistent bar could never be revealed on hover. It now measures against `clampedThickness`, which keeps the existing 2px floor the input regions already use.

This also answers the follow-up on #320 asking for the dashboard and sidebar to keep working at border thickness 0 - the trigger depth no longer derives from the border thickness, so it holds its own value whatever the border is set to.

## Testing

On KDE Plasma 6.7 / kwin_wayland: hover thresholds on all four panels, hover thickness above and below the border thickness, the narrowed extent while closed and the full extent once open, and border thickness 0 with the bar in hover mode.