### PR TITLE
fix: restore the AI Assistant entry in the nexus nav

### DIFF
--- a/shell/modules/nexus/PageDictionary.qml
+++ b/shell/modules/nexus/PageDictionary.qml
@@ -193,6 +193,21 @@ QtObject {
                 { label: qsTr("Device Info"), keywords: ["hardware", "specs", "cpu", "ram"] },
                 { label: qsTr("OS Version"), keywords: ["caelestia", "quickshell", "release"] }
             ]
+        },
+
+        // AI
+        // Last, to stay aligned with PageCompRegistry.pageComps — this list is
+        // indexed by position, so entries cannot be reordered independently.
+        {
+            label: qsTr("AI Assistant"),
+            icon: "smart_toy",
+            description: qsTr("Claude Code, accounts, providers"),
+            category: "controls",
+            settings: [
+                { label: qsTr("Claude Code"), keywords: ["claude", "cli", "subscription", "login"] },
+                { label: qsTr("Accounts"), keywords: ["claude", "account", "login", "switch"] },
+                { label: qsTr("Providers"), keywords: ["ollama", "openai", "chatgpt", "gemini", "openrouter", "api key"] }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Moving the nexus page list from `PageRegistry` into `PageDictionary` in 115ad61e dropped the "AI Assistant" entry. The page component is still registered as the last entry of `PageCompRegistry.pageComps`, but the nav is built from `PageDictionary.pages`, so with nothing at that index the page became unreachable - including the provider toggles and the API key fields, which have no other entry point.

The two lists are indexed by position, so the entry goes back at the end, where `AiSettingsPage` sits. After this both lists are 17 long and line up: 0 Appearance -> WallpaperAndStyle, ... 15 About System -> AboutPage, 16 AI Assistant -> AiSettingsPage.

The `settings` sub-entries are new - the old `PageRegistry` entry predates that field - so the page also turns up in search for "claude", "api key", "ollama" and so on.

Tested on KDE Plasma 6.7 / kwin_wayland: the entry is back in the nav and the page opens.