### PR TITLE
fix: plugins placeholder, update-checker timeouts, dynamic python path, distro-aware news

### DIFF
--- a/shell/modules/nexus/pages/PluginsPage.qml
+++ b/shell/modules/nexus/pages/PluginsPage.qml
@@ -1,6 +1,9 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.components
 import qs.modules.nexus.common
 
 PageBase {
@@ -8,8 +11,33 @@ PageBase {
     
     title: qsTr("Plugins")
 
-    Item {
-        anchors.fill: parent
-        // Placeholder — plugin menu is not yet implemented
+    ColumnLayout {
+        anchors.centerIn: parent
+        spacing: Tokens.spacing.medium
+
+        StyledText {
+            Layout.alignment: Qt.AlignHCenter
+            text: "🧩"
+            font: Tokens.font.icon.extraExtraLarge
+            color: Colours.palette.m3onSurfaceVariant
+            animate: true
+        }
+
+        StyledText {
+            Layout.alignment: Qt.AlignHCenter
+            text: qsTr("Plugins are coming soon")
+            font: Tokens.font.headline.small
+            color: Colours.palette.m3onSurface
+            animate: true
+        }
+
+        StyledText {
+            Layout.alignment: Qt.AlignHCenter
+            text: qsTr("A plugin framework is planned for v2.3.0.\nStay tuned for the ability to extend your shell with community plugins.")
+            font: Tokens.font.body.medium
+            color: Colours.palette.m3onSurfaceVariant
+            horizontalAlignment: Text.AlignHCenter
+            animate: true
+        }
     }
 }

--- a/shell/modules/sidebar/News.qml
+++ b/shell/modules/sidebar/News.qml
@@ -23,13 +23,68 @@ Item {
 
     Component.onCompleted: fetchNews()
 
+    // ── Distro-aware news feed ────────────────────────────────────
+    // The feed URL is chosen based on the running distribution so Fedora
+    // users see Fedora news rather than an irrelevant Arch Linux feed.
+
+    function newsFeedUrl() {
+        var process = Qt.createQmlObject(
+            'import QtQuick\n' +
+            'import Quickshell.Io\n' +
+            'Process {\n' +
+            '    id: p\n' +
+            '    command: ["sh", "-c", \'. /etc/os-release 2>/dev/null && echo "$ID"\']\n' +
+            '    stdout: StdioCollector { onStreamFinished: p.destroy(); }\n' +
+            '}', root, "osReleaseProc");
+        return process;
+    }
+
+    property string _distroId: ""
+
     function fetchNews() {
         if (isFetching) return;
         isFetching = true;
         errorMessage = "";
         
+        // Default to Arch; re-read /etc/os-release to decide at fetch time
+        // so the feed is correct even if the shell was started before the OS
+        // release file was updated.
+        var feedUrl = "https://archlinux.org/feeds/news/";
+        if (_distroId === "") {
+            var proc = newsFeedUrl();
+            if (proc && proc.stdout) {
+                proc.stdout.onStreamFinished = function() {
+                    var id = (proc.stdout.text || "").trim();
+                    _distroId = id;
+                    doFetch(id);
+                    if (proc) proc.destroy();
+                };
+                proc.running = true;
+                return;
+            }
+        }
+        doFetch(_distroId);
+    }
+
+    function doFetch(distroId) {
+        var feedUrl = "https://archlinux.org/feeds/news/";
+        // Map known distro IDs to their news/blog feeds. Falls back to
+        // Arch Linux news for unrecognised distributions.
+        var feedMap = {
+            "fedora": "https://fedoramagazine.org/feed/",
+            "arch": "https://archlinux.org/feeds/news/",
+            "cachyos": "https://archlinux.org/feeds/news/",
+            "endeavouros": "https://archlinux.org/feeds/news/",
+            "manjaro": "https://archlinux.org/feeds/news/",
+            "ubuntu": "https://ubuntu.com/blog/feed",
+            "debian": "https://www.debian.org/News/news.en.rss",
+            "opensuse": "https://news.opensuse.org/feed/",
+        };
+        if (feedMap[distroId])
+            feedUrl = feedMap[distroId];
+
         var xhr = new XMLHttpRequest();
-        xhr.open("GET", "https://archlinux.org/feeds/news/");
+        xhr.open("GET", feedUrl);
         xhr.onreadystatechange = function() {
             if (xhr.readyState === XMLHttpRequest.DONE) {
                 isFetching = false;

--- a/shell/plugin/src/Caelestia/Services/emojidb.cpp
+++ b/shell/plugin/src/Caelestia/Services/emojidb.cpp
@@ -3,13 +3,14 @@
 
 #include <algorithm>
 
+#include <qdir.h>
+#include <qdiriterator.h>
 #include <qfile.h>
 #include <qjsondocument.h>
 #include <qjsonobject.h>
 #include <qloggingcategory.h>
 #include <qstandardpaths.h>
 #include <qtextstream.h>
-#include <QDir>
 
 Q_LOGGING_CATEGORY(lcEmojiDb, "caelestia.services.emojidb", QtInfoMsg)
 
@@ -17,18 +18,19 @@ namespace caelestia::services {
 
 EmojiDb::EmojiDb(QObject* parent)
     : QObject(parent) {
-    // Find the emojis.txt — same path used by Emojis.qml
-    // Prefer user-local override, fall back to system package path
-    const auto sysPath = QStringLiteral("/usr/lib/python3.14/site-packages/caelestia/data/emojis.txt");
-    // Also try versioned python paths
-    const QStringList candidates = {
-        sysPath,
-        QStringLiteral("/usr/lib/python3.13/site-packages/caelestia/data/emojis.txt"),
-        QStringLiteral("/usr/lib/python3.12/site-packages/caelestia/data/emojis.txt"),
+    // Find the emojis.txt — same path used by Emojis.qml.
+    // Prefer user-local override, fall back to dynamic system package search.
+    // Scanning the python site-packages tree avoids hardcoding version numbers
+    // and handles both /usr/lib (Arch) and /usr/lib64 (Fedora) layouts.
+    const QStringList searchRoots = {
+        QStringLiteral("/usr/lib"),
+        QStringLiteral("/usr/lib64"),
     };
-    for (const auto& path : candidates) {
-        if (QFile::exists(path)) {
-            m_emojiPath = path;
+    for (const auto& root : searchRoots) {
+        QDirIterator it(root, {QStringLiteral("*/site-packages/caelestia/data/emojis.txt")},
+                        QDir::Files, QDirIterator::Subdirectories);
+        if (it.hasNext()) {
+            m_emojiPath = it.next();
             break;
         }
     }

--- a/src/bin/caelestia-check-updates
+++ b/src/bin/caelestia-check-updates
@@ -24,7 +24,12 @@ if [ "$BRANCH" != "main" ] && [ "$BRANCH" != "dev" ]; then
     BRANCH="main"
 fi
 
-if ! git ls-remote --exit-code --heads https://github.com/ladybug-me/caelestia-dots-kde.git "$BRANCH" >/dev/null 2>&1; then
+# Prevent git from blocking indefinitely on a hung network by setting a timeout
+# and disabling interactive prompts that could stall the script.
+export GIT_TERMINAL_PROMPT=0
+GIT_TIMEOUT=30
+
+if ! timeout ${GIT_TIMEOUT} git ls-remote --exit-code --heads https://github.com/ladybug-me/caelestia-dots-kde.git "$BRANCH" >/dev/null 2>&1; then
     BRANCH="main"
     mkdir -p "$HOME/.config/quickshell/caelestia"
     echo "$BRANCH" > "$HOME/.config/quickshell/caelestia/.update_branch"
@@ -35,9 +40,9 @@ CAELESTIA_PENDING=0
 
 if [ -n "$_localCommit" ]; then
     if [ ! -d "$REPO" ]; then
-        git clone --bare --filter=blob:none https://github.com/ladybug-me/caelestia-dots-kde.git "$REPO" >/dev/null 2>&1
+        timeout ${GIT_TIMEOUT} git clone --bare --filter=blob:none https://github.com/ladybug-me/caelestia-dots-kde.git "$REPO" >/dev/null 2>&1 || true
     else
-        git -C "$REPO" fetch --force origin "$BRANCH:$BRANCH" >/dev/null 2>&1
+        timeout ${GIT_TIMEOUT} git -C "$REPO" fetch --force origin "$BRANCH:$BRANCH" >/dev/null 2>&1 || true
     fi
 
     LOCAL_DATE=$(git -C "$REPO" show -s --format=%cI ${_localCommit} 2>/dev/null)


### PR DESCRIPTION
## P1: UX Improvements and Resilience

### 1. Plugins page placeholder
**File:** `shell/modules/nexus/pages/PluginsPage.qml`

Replaced the empty 15-line stub with a proper "Coming Soon" page showing an icon, title ("Plugins are coming soon"), and description ("A plugin framework is planned for v2.3.0").

### 2. Update checker network timeouts
**File:** `src/bin/caelestia-check-updates`

Added `GIT_TERMINAL_PROMPT=0` and 30-second `timeout` to all `git ls-remote`, `clone`, and `fetch` calls. Previously a hung network or unreachable GitHub would block the 30-minute systemd timer indefinitely, accumulating stuck processes.

### 3. Dynamic Python path in emojidb
**File:** `shell/plugin/src/Caelestia/Services/emojidb.cpp`

Replaced hardcoded `python3.14/3.13/3.12` paths with `QDirIterator` over `/usr/lib` and `/usr/lib64`. This handles Fedora's lib64 layout and future Python versions without code changes.

### 4. Distro-aware news feed
**File:** `shell/modules/sidebar/News.qml`

The sidebar News feed now detects `/etc/os-release` at fetch time and maps known distros (Fedora, Ubuntu, Debian, openSUSE) to their RSS feeds instead of always showing Arch Linux news.
