### PR TITLE
fix: close taskbar preview thumbnails when their window closes

### DIFF
--- a/shell/modules/bar/popouts/DockHover.qml
+++ b/shell/modules/bar/popouts/DockHover.qml
@@ -36,6 +36,35 @@ StyledRect {
         ? Math.round(previewWidth * 0.55)
         : previewWidth
 
+    // root.model is a snapshot taken when the popout opened, not a live binding, so
+    // it never learns a window closed on its own — that card's screencast dies
+    // (KWin has nothing left to stream) and falls back to the app icon instead of
+    // the card disappearing. Closing a window here therefore also has to patch the
+    // snapshot by hand: drop the closed toplevel, and if none are left, close the
+    // popout outright unless the app is pinned, in which case the empty-state
+    // fallback below is the correct thing to show.
+    function closeToplevel(address: string): void {
+        if (typeof KWinActiveWindowBridge !== "undefined" && KWinActiveWindowBridge.windowList) {
+            KWinActiveWindowBridge.closeWindow(address);
+        } else {
+            Hypr.dispatch(Hypr.usingLua ? `hl.dsp.window.close({ window = "address:0x${address}" })` : `closewindow address:0x${address}`);
+        }
+
+        if (!root.model || !root.model.toplevels)
+            return;
+
+        const remaining = root.model.toplevels.filter(t => String(t.address) !== String(address));
+        if (remaining.length === root.model.toplevels.length)
+            return;
+
+        if (remaining.length === 0 && !root.model.isPinned) {
+            root.popouts.hasCurrent = false;
+            return;
+        }
+
+        root.popouts.dockModel = Object.assign({}, root.model, { toplevels: remaining });
+    }
+
     radius: Tokens.rounding.medium
     color: Colours.tPalette.m3surfaceContainer
     clip: true
@@ -220,13 +249,8 @@ StyledRect {
                                     anchors.fill: parent
                                     radius: Tokens.rounding.small
                                     onClicked: {
-                                        if (card.modelData.address) {
-                                            if (typeof KWinActiveWindowBridge !== "undefined" && KWinActiveWindowBridge.windowList) {
-                                                KWinActiveWindowBridge.closeWindow(card.modelData.address);
-                                            } else {
-                                                Hypr.dispatch(Hypr.usingLua ? `hl.dsp.window.close({ window = "address:0x${card.modelData.address}" })` : `closewindow address:0x${card.modelData.address}`);
-                                            }
-                                        }
+                                        if (card.modelData.address)
+                                            root.closeToplevel(card.modelData.address);
                                     }
                                 }
 


### PR DESCRIPTION
Hovering a dock icon snapshots that app's data into `popouts.dockModel` once, when the popout opens (`Dock.qml`). It is not a live binding, so if you close a window from the preview, the popout never learns - the closed window's card stays in the list, its PipeWire screencast dies because KWin has nothing left to stream, and it falls back to the app icon. The live thumbnail is replaced by a static logo that just sits there instead of the card disappearing.

For an app with a single window this made the whole popout look stuck open on a broken thumbnail. For an app with multiple windows (e.g. Prism Launcher + its console window) it was worse: closing one window left its card showing the icon fallback while the other window's card kept working fine, so half the popout looked dead.

The close button now patches the snapshot instead of just closing the window: the closed toplevel is dropped from the array and `popouts.dockModel` is reassigned to a new object so the `model:` binding downstream actually refreshes. If nothing is left to preview and the app isn't pinned to the dock, the popout closes outright rather than show a stale or empty card. A pinned app with no windows left still falls through to the existing "click to launch" empty state, which is correct there.

## Testing

Verified interactively on KDE Plasma 6.7 / kwin_wayland with an app that opens two windows (Prism Launcher + its console window): closing the console window now removes just that card immediately with no icon flash, and the remaining window's preview stays intact. Closing the last window closes the popout.