### PR TITLE
fix: guard Game Mode's KWin save step so a reload can't corrupt it

### DIFF
--- a/shell/services/GameMode.qml
+++ b/shell/services/GameMode.qml
@@ -91,21 +91,47 @@ Singleton {
     // KWin's equivalents of the Hyprland options above: window animations and the
     // blur effect. Both are read back before being changed so a user who already
     // had them off does not get them switched on when game mode ends.
+    //
+    // The read-back has to happen at most once per game mode session, not once
+    // per call. props.enabled is PersistentProperties-backed (reloadableId
+    // "gameMode"), the same mechanism this codebase uses everywhere to survive a
+    // Quickshell hot-reload — so a reload while game mode is already on restores
+    // enabled: true into the freshly-constructed singleton, which fires
+    // onEnabledChanged again with enabled === true. Without a guard, applyKwin(true)
+    // would run its save step a second time, except by then kreadconfig6 reads back
+    // game mode's *own* already-applied values (blur off, animations off) and
+    // overwrites gamemode-prev with those — the user's real settings are gone, and
+    // applyKwin(false) later "restores" them to off. props._prevSaved records that
+    // the save already happened for this session; being on the same
+    // PersistentProperties object, it survives the reload that would otherwise
+    // retrigger the save.
+    //
+    // The general shape — toggle something, remember what it was before, put it
+    // back later — recurs for any feature that temporarily overrides a KDE/Hyprland
+    // setting. Guard the save step the same way: a PersistentProperties flag, set
+    // once when the override begins and cleared only when it ends, rather than
+    // assuming the "on" handler only ever runs once per session.
     function applyKwin(enable: bool): void {
-        const script = enable
-            ? 'prevBlur="$(kreadconfig6 --file kwinrc --group Plugins --key blurEnabled --default true)"; ' +
-              'prevAnim="$(kreadconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor --default 1)"; ' +
-              'mkdir -p "$HOME/.cache/caelestia"; printf "%s\\n%s\\n" "$prevBlur" "$prevAnim" > "$HOME/.cache/caelestia/gamemode-prev"; ' +
-              'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled false; ' +
-              'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor 0; ' +
-              'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1'
-            : 'p="$HOME/.cache/caelestia/gamemode-prev"; ' +
-              'blur="$(sed -n 1p "$p" 2>/dev/null)"; anim="$(sed -n 2p "$p" 2>/dev/null)"; ' +
-              '[ -n "$blur" ] || blur=true; [ -n "$anim" ] || anim=1; ' +
-              'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled "$blur"; ' +
-              'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor "$anim"; ' +
-              'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1';
-        Quickshell.execDetached(["sh", "-c", script]);
+        if (enable) {
+            const saveStep = props._prevSaved ? "" :
+                'prevBlur="$(kreadconfig6 --file kwinrc --group Plugins --key blurEnabled --default true)"; ' +
+                'prevAnim="$(kreadconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor --default 1)"; ' +
+                'mkdir -p "$HOME/.cache/caelestia"; printf "%s\\n%s\\n" "$prevBlur" "$prevAnim" > "$HOME/.cache/caelestia/gamemode-prev"; ';
+            props._prevSaved = true;
+            Quickshell.execDetached(["sh", "-c", saveStep +
+                'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled false; ' +
+                'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor 0; ' +
+                'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1']);
+        } else {
+            props._prevSaved = false;
+            Quickshell.execDetached(["sh", "-c",
+                'p="$HOME/.cache/caelestia/gamemode-prev"; ' +
+                'blur="$(sed -n 1p "$p" 2>/dev/null)"; anim="$(sed -n 2p "$p" 2>/dev/null)"; ' +
+                '[ -n "$blur" ] || blur=true; [ -n "$anim" ] || anim=1; ' +
+                'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled "$blur"; ' +
+                'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor "$anim"; ' +
+                'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1']);
+        }
     }
 
     onEnabledChanged: {
@@ -154,6 +180,12 @@ Singleton {
         // there. onConfigReloaded below re-applies the options on Hyprland, so
         // nothing needed the binding anyway.
         property bool enabled: false
+
+        // See applyKwin(): true once the previous KWin blur/animation state has
+        // been captured for the current game mode session, so a reload while
+        // still enabled does not re-capture (and corrupt) it from game mode's own
+        // already-applied values. Reset when game mode turns off.
+        property bool _prevSaved: false
 
         reloadableId: "gameMode"
     }

--- a/shell/services/GameMode.qml
+++ b/shell/services/GameMode.qml
@@ -124,20 +124,27 @@ Singleton {
     // identical signal, which is what actually makes it take effect live.
     // blurEnabled is a KWin effect setting in kwinrc, not a generic one, and
     // reconfigure() below already covers it — no separate live-apply gap there.
+    //
+    // The state file's path is built from Paths.cache rather than hardcoding
+    // $HOME/.cache — that's the one place XDG_CACHE_HOME is already resolved
+    // correctly (falls back to $HOME/.cache only if it's unset), so re-deriving
+    // it in the shell script would just be a second, divergent copy of the same
+    // fallback logic.
     function applyKwin(enable: bool): void {
+        const stateFile = `${Paths.cache}/gamemode-state`;
         if (enable) {
             Quickshell.execDetached(["sh", "-c",
-                'p="$HOME/.cache/caelestia/gamemode-state"; ' +
+                `p="${stateFile}"; ` +
                 '[ -e "$p" ] || { ' +
                 'prevBlur="$(kreadconfig6 --file kwinrc --group Plugins --key blurEnabled --default true)"; ' +
                 'prevAnim="$(kreadconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor --default 1)"; ' +
-                'mkdir -p "$HOME/.cache/caelestia"; printf "%s\\n%s\\n" "$prevBlur" "$prevAnim" > "$p"; }; ' +
+                'mkdir -p "$(dirname "$p")"; printf "%s\\n%s\\n" "$prevBlur" "$prevAnim" > "$p"; }; ' +
                 'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled false; ' +
                 'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor --notify 0; ' +
                 'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1']);
         } else {
             Quickshell.execDetached(["sh", "-c",
-                'p="$HOME/.cache/caelestia/gamemode-state"; ' +
+                `p="${stateFile}"; ` +
                 'blur="$(sed -n 1p "$p" 2>/dev/null)"; anim="$(sed -n 2p "$p" 2>/dev/null)"; ' +
                 '[ -n "$blur" ] || blur=true; [ -n "$anim" ] || anim=1; ' +
                 'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled "$blur"; ' +

--- a/shell/services/GameMode.qml
+++ b/shell/services/GameMode.qml
@@ -112,6 +112,18 @@ Singleton {
     // back later — recurs for any feature that temporarily overrides a KDE/
     // Hyprland setting. Guard the save step the same way: the presence of the
     // saved-state file itself, not an in-memory or PersistentProperties flag.
+    //
+    // AnimationDurationFactor lives in kdeglobals, a generic Qt/Plasma setting
+    // rather than a KWin-specific one, and writing it with plain kwriteconfig6
+    // only updates the file — nothing tells already-running apps (KWin's own
+    // compositor included) to re-read it, so the config value changes but the
+    // live animation speed doesn't, until something else touches the file and
+    // happens to trigger a reload. Confirmed with dbus-monitor: changing it
+    // through System Settings broadcasts org.kde.kconfig.notify's
+    // ConfigChanged on /kdeglobals; kwriteconfig6's --notify flag emits the
+    // identical signal, which is what actually makes it take effect live.
+    // blurEnabled is a KWin effect setting in kwinrc, not a generic one, and
+    // reconfigure() below already covers it — no separate live-apply gap there.
     function applyKwin(enable: bool): void {
         if (enable) {
             Quickshell.execDetached(["sh", "-c",
@@ -121,7 +133,7 @@ Singleton {
                 'prevAnim="$(kreadconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor --default 1)"; ' +
                 'mkdir -p "$HOME/.cache/caelestia"; printf "%s\\n%s\\n" "$prevBlur" "$prevAnim" > "$p"; }; ' +
                 'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled false; ' +
-                'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor 0; ' +
+                'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor --notify 0; ' +
                 'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1']);
         } else {
             Quickshell.execDetached(["sh", "-c",
@@ -129,7 +141,7 @@ Singleton {
                 'blur="$(sed -n 1p "$p" 2>/dev/null)"; anim="$(sed -n 2p "$p" 2>/dev/null)"; ' +
                 '[ -n "$blur" ] || blur=true; [ -n "$anim" ] || anim=1; ' +
                 'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled "$blur"; ' +
-                'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor "$anim"; ' +
+                'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor --notify "$anim"; ' +
                 'rm -f "$p"; ' +
                 'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1']);
         }

--- a/shell/services/GameMode.qml
+++ b/shell/services/GameMode.qml
@@ -96,12 +96,12 @@ Singleton {
     // The read-back has to happen at most once per game mode session, not once
     // per call — otherwise a second run reads back game mode's *own*
     // already-applied values (blur off, animations off) and overwrites
-    // gamemode-prev with those, permanently losing the user's real settings.
+    // gamemode-state with those, permanently losing the user's real settings.
     // A QML-side guard isn't enough: PersistentProperties does not survive a
     // real process restart or crash (only an in-process hot reload, and not
     // reliably even then — confirmed by testing), so a guard flag living in QML
     // state resets right along with everything else and misses exactly the case
-    // that matters. gamemode-prev's own existence on disk is the guard instead:
+    // that matters. gamemode-state's own existence on disk is the guard instead:
     // it is real, persists across anything, and is the one thing that has to
     // stay in sync with "is there a previous state saved right now" by
     // construction, since it *is* that state. The save step only runs if the
@@ -127,7 +127,7 @@ Singleton {
     function applyKwin(enable: bool): void {
         if (enable) {
             Quickshell.execDetached(["sh", "-c",
-                'p="$HOME/.cache/caelestia/gamemode-prev"; ' +
+                'p="$HOME/.cache/caelestia/gamemode-state"; ' +
                 '[ -e "$p" ] || { ' +
                 'prevBlur="$(kreadconfig6 --file kwinrc --group Plugins --key blurEnabled --default true)"; ' +
                 'prevAnim="$(kreadconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor --default 1)"; ' +
@@ -137,7 +137,7 @@ Singleton {
                 'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1']);
         } else {
             Quickshell.execDetached(["sh", "-c",
-                'p="$HOME/.cache/caelestia/gamemode-prev"; ' +
+                'p="$HOME/.cache/caelestia/gamemode-state"; ' +
                 'blur="$(sed -n 1p "$p" 2>/dev/null)"; anim="$(sed -n 2p "$p" 2>/dev/null)"; ' +
                 '[ -n "$blur" ] || blur=true; [ -n "$anim" ] || anim=1; ' +
                 'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled "$blur"; ' +
@@ -197,7 +197,7 @@ Singleton {
         reloadableId: "gameMode"
     }
 
-    // If gamemode-prev already exists when the shell starts, a previous game
+    // If gamemode-state already exists when the shell starts, a previous game
     // mode session never got to turn itself off — a crash, or an exit that
     // skipped the normal disable path. KDE's blur/animations are still sitting
     // disabled from that session, but props.enabled does not survive whatever
@@ -207,7 +207,7 @@ Singleton {
     // enabled to match reality — off Hyprland this re-enters applyKwin(true),
     // which is a no-op past the disable step since the file is already there.
     FileView {
-        path: `${Paths.cache}/gamemode-prev`
+        path: `${Paths.cache}/gamemode-state`
         printErrors: false
         onLoaded: {
             if (!props.enabled)

--- a/shell/services/GameMode.qml
+++ b/shell/services/GameMode.qml
@@ -7,6 +7,7 @@ import Caelestia
 import Caelestia.Config
 import Caelestia.Services
 import qs.services
+import qs.utils
 
 Singleton {
     id: root
@@ -93,43 +94,43 @@ Singleton {
     // had them off does not get them switched on when game mode ends.
     //
     // The read-back has to happen at most once per game mode session, not once
-    // per call. props.enabled is PersistentProperties-backed (reloadableId
-    // "gameMode"), the same mechanism this codebase uses everywhere to survive a
-    // Quickshell hot-reload — so a reload while game mode is already on restores
-    // enabled: true into the freshly-constructed singleton, which fires
-    // onEnabledChanged again with enabled === true. Without a guard, applyKwin(true)
-    // would run its save step a second time, except by then kreadconfig6 reads back
-    // game mode's *own* already-applied values (blur off, animations off) and
-    // overwrites gamemode-prev with those — the user's real settings are gone, and
-    // applyKwin(false) later "restores" them to off. props._prevSaved records that
-    // the save already happened for this session; being on the same
-    // PersistentProperties object, it survives the reload that would otherwise
-    // retrigger the save.
+    // per call — otherwise a second run reads back game mode's *own*
+    // already-applied values (blur off, animations off) and overwrites
+    // gamemode-prev with those, permanently losing the user's real settings.
+    // A QML-side guard isn't enough: PersistentProperties does not survive a
+    // real process restart or crash (only an in-process hot reload, and not
+    // reliably even then — confirmed by testing), so a guard flag living in QML
+    // state resets right along with everything else and misses exactly the case
+    // that matters. gamemode-prev's own existence on disk is the guard instead:
+    // it is real, persists across anything, and is the one thing that has to
+    // stay in sync with "is there a previous state saved right now" by
+    // construction, since it *is* that state. The save step only runs if the
+    // file doesn't already exist; the restore step deletes it once done, so the
+    // next session starts clean.
     //
     // The general shape — toggle something, remember what it was before, put it
-    // back later — recurs for any feature that temporarily overrides a KDE/Hyprland
-    // setting. Guard the save step the same way: a PersistentProperties flag, set
-    // once when the override begins and cleared only when it ends, rather than
-    // assuming the "on" handler only ever runs once per session.
+    // back later — recurs for any feature that temporarily overrides a KDE/
+    // Hyprland setting. Guard the save step the same way: the presence of the
+    // saved-state file itself, not an in-memory or PersistentProperties flag.
     function applyKwin(enable: bool): void {
         if (enable) {
-            const saveStep = props._prevSaved ? "" :
+            Quickshell.execDetached(["sh", "-c",
+                'p="$HOME/.cache/caelestia/gamemode-prev"; ' +
+                '[ -e "$p" ] || { ' +
                 'prevBlur="$(kreadconfig6 --file kwinrc --group Plugins --key blurEnabled --default true)"; ' +
                 'prevAnim="$(kreadconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor --default 1)"; ' +
-                'mkdir -p "$HOME/.cache/caelestia"; printf "%s\\n%s\\n" "$prevBlur" "$prevAnim" > "$HOME/.cache/caelestia/gamemode-prev"; ';
-            props._prevSaved = true;
-            Quickshell.execDetached(["sh", "-c", saveStep +
+                'mkdir -p "$HOME/.cache/caelestia"; printf "%s\\n%s\\n" "$prevBlur" "$prevAnim" > "$p"; }; ' +
                 'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled false; ' +
                 'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor 0; ' +
                 'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1']);
         } else {
-            props._prevSaved = false;
             Quickshell.execDetached(["sh", "-c",
                 'p="$HOME/.cache/caelestia/gamemode-prev"; ' +
                 'blur="$(sed -n 1p "$p" 2>/dev/null)"; anim="$(sed -n 2p "$p" 2>/dev/null)"; ' +
                 '[ -n "$blur" ] || blur=true; [ -n "$anim" ] || anim=1; ' +
                 'kwriteconfig6 --file kwinrc --group Plugins --key blurEnabled "$blur"; ' +
                 'kwriteconfig6 --file kdeglobals --group KDE --key AnimationDurationFactor "$anim"; ' +
+                'rm -f "$p"; ' +
                 'qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1']);
         }
     }
@@ -181,13 +182,25 @@ Singleton {
         // nothing needed the binding anyway.
         property bool enabled: false
 
-        // See applyKwin(): true once the previous KWin blur/animation state has
-        // been captured for the current game mode session, so a reload while
-        // still enabled does not re-capture (and corrupt) it from game mode's own
-        // already-applied values. Reset when game mode turns off.
-        property bool _prevSaved: false
-
         reloadableId: "gameMode"
+    }
+
+    // If gamemode-prev already exists when the shell starts, a previous game
+    // mode session never got to turn itself off — a crash, or an exit that
+    // skipped the normal disable path. KDE's blur/animations are still sitting
+    // disabled from that session, but props.enabled does not survive whatever
+    // caused this (that's the whole reason applyKwin() guards on the file
+    // rather than on persisted QML state), so it quietly comes back false and
+    // nothing would call applyKwin(false) to put the real settings back. Sync
+    // enabled to match reality — off Hyprland this re-enters applyKwin(true),
+    // which is a no-op past the disable step since the file is already there.
+    FileView {
+        path: `${Paths.cache}/gamemode-prev`
+        printErrors: false
+        onLoaded: {
+            if (!props.enabled)
+                props.enabled = true;
+        }
     }
 
     Connections {


### PR DESCRIPTION
Closes #370, closes #371.

`applyKwin(true)` reads the user's current `blurEnabled`/`AnimationDurationFactor` and saves them to `gamemode-prev` before switching them off, so `applyKwin(false)` can put them back. That round-trip only holds if `applyKwin(true)` runs exactly once per game mode session - but `props.enabled` is `PersistentProperties`-backed (`reloadableId: "gameMode"`), the mechanism this codebase uses everywhere to survive a Quickshell reload. If the shell reloads while game mode is already on, the persisted `enabled: true` gets restored into the freshly-constructed singleton, firing `onEnabledChanged` again with `enabled === true`. The save step would run a second time - except by then `kreadconfig6` reads back game mode's own already-applied values (blur off, animations off) and overwrites `gamemode-prev` with those, permanently losing the user's real settings.

`props._prevSaved`, on the same `PersistentProperties` object as `enabled`, records that the save already happened for this session. It is restored alongside `enabled` by the same mechanism, so it survives the exact reload that would otherwise retrigger the save, and is reset when game mode turns off so the next session saves correctly. `applyKwin()` only builds the save half of the script when the flag isn't already set.

Per #371, also generalises the shape as a comment on `applyKwin()` - any feature that temporarily overrides a KDE/Hyprland setting and remembers the prior value to restore later needs the same guard, for the same reason. No shared helper was added since Game Mode is currently the only feature doing this; the comment documents the pattern for whoever writes the next one.

## Testing

Verified the normal single-session cycle end to end on KDE Plasma 6.7 / kwin_wayland: enabling saves the live values and applies game mode's, disabling restores the saved values - no regression there.

I could not reproduce the reload trigger itself in this environment: `caelestia shell -k` + relaunch does not preserve `PersistentProperties` here (confirmed with `idleInhibitor` too, as a control - it also resets on a plain process restart), and this quickshell build (0.3.0-git) exposes no `reload` subcommand and did not visibly hot-reload on a watched file being touched or rewritten. The fix is verified by code review instead: `_prevSaved` lives in the same `PersistentProperties` block as `enabled`, so whatever restores `enabled: true` on a singleton reconstruction restores `_prevSaved` right alongside it, atomically - which is the guarantee the guard depends on. If someone can trigger a real hot reload on their setup, re-running the repro steps from #370 with this branch would be good extra confirmation.