### PR TITLE
fix: sync the extracted first-frame thumbnail to Plasma for video wallpapers

### DIFF
--- a/shell/services/Wallpapers.qml
+++ b/shell/services/Wallpapers.qml
@@ -123,7 +123,17 @@ Searcher {
 
     function setWallpaper(path: string): void {
         actualCurrent = path;
-        Quickshell.execDetached(["caelestia", "wallpaper", "-f", path, ...smartArg]);
+        if (Images.isVideo(path)) {
+            const thumb = thumbFor(path);
+            if (thumb !== "") {
+                const script = 'caelestia wallpaper -f "$1" ' + root.smartArg.join(" ") + '; printf "%s" "$2" > "$3"';
+                Quickshell.execDetached(["sh", "-c", script, "--", thumb, path, root.currentNamePath]);
+            } else {
+                Quickshell.execDetached(["sh", "-c", 'printf "%s" "$1" > "$2"', "--", path, root.currentNamePath]);
+            }
+        } else {
+            Quickshell.execDetached(["caelestia", "wallpaper", "-f", path, ...smartArg]);
+        }
     }
 
     function preview(path: string): void {
@@ -200,6 +210,10 @@ Searcher {
             const m = root.videoThumbs;
             m[path] = out;
             root.videoThumbs = Object.assign({}, m);   // a copy, so bindings re-run
+            if (path === root.actualCurrent) {
+                const script = 'caelestia wallpaper -f "$1" ' + root.smartArg.join(" ") + '; printf "%s" "$2" > "$3"';
+                Quickshell.execDetached(["sh", "-c", script, "--", out, path, root.currentNamePath]);
+            }
         }
         const pending = root.videoThumbsPending;
         delete pending[path];
@@ -246,6 +260,9 @@ Searcher {
             if (!wall) {
                 wall = root.fallback;
                 Quickshell.execDetached(["caelestia", "wallpaper", "-f", root.fallback, ...root.smartArg]);
+            }
+            if (Images.isVideo(root.actualCurrent) && wall === root.getThumbnailPath(root.actualCurrent)) {
+                return;
             }
             root.actualCurrent = wall;
             root.previewColourLock = false;

--- a/shell/services/Wallpapers.qml
+++ b/shell/services/Wallpapers.qml
@@ -23,9 +23,36 @@ Searcher {
     property bool previewColourLock
     property bool pendingPreviewClear
 
-    onActualCurrentChanged: {
-        // Sync KDE Plasma wallpaper
-        Quickshell.execDetached(["sh", "-c", 'qdbus6 org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "var allDesktops = desktops();for (i=0;i<allDesktops.length;i++) {d = allDesktops[i];d.wallpaperPlugin = \\"org.kde.image\\";d.currentConfigGroup = Array(\\"Wallpaper\\", \\"org.kde.image\\", \\"General\\");d.writeConfig(\\"Image\\", \\"file://$1\\")}"', "--", actualCurrent]);
+    onActualCurrentChanged: root.syncPlasmaWallpaper()
+
+    // videoThumbs landing (a fresh extraction, or discovering a frame already
+    // cached from a previous session) can complete after onActualCurrentChanged
+    // already ran with nothing to show yet — re-sync so it still lands.
+    onVideoThumbsChanged: root.syncPlasmaWallpaper()
+
+    // Plasma's own desktop wallpaper layer can only render still images
+    // (org.kde.image); a video wallpaper's raw path there just shows up
+    // blank/broken. That's invisible under normal operation since Caelestia's own
+    // background layer draws over the real desktop, but it's exactly what's
+    // exposed the moment that's not true — a crash, a manual `qs -c caelestia`
+    // exit, or someone temporarily switching back to stock Plasma to
+    // troubleshoot. Sync the same first-frame still the pickers already use
+    // instead of a path org.kde.image can't decode at all.
+    function syncPlasmaWallpaper(): void {
+        const path = root.actualCurrent;
+        if (path === "")
+            return;
+
+        // thumbFor() is the same "video path in, still frame out" resolution the
+        // pickers use: returns the cached frame, or "" while kicking off the
+        // extraction — in which case Plasma's previous (still valid) wallpaper is
+        // left alone rather than pointed at a video, and onVideoThumbsChanged
+        // retries once the frame lands.
+        const target = root.thumbFor(path);
+        if (target === "")
+            return;
+
+        Quickshell.execDetached(["sh", "-c", 'qdbus6 org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "var allDesktops = desktops();for (i=0;i<allDesktops.length;i++) {d = allDesktops[i];d.wallpaperPlugin = \\"org.kde.image\\";d.currentConfigGroup = Array(\\"Wallpaper\\", \\"org.kde.image\\", \\"General\\");d.writeConfig(\\"Image\\", \\"file://$1\\")}"', "--", target]);
     }
 
     readonly property var categories: {


### PR DESCRIPTION
Closes #379, closes #380.

`onActualCurrentChanged` pushed whatever the current wallpaper's raw path was straight into Plasma's real desktop config over D-Bus, hardcoded to `org.kde.image` - the static-image renderer. For a video wallpaper that path can't be decoded at all, so the actual Plasma desktop layer underneath ends up blank/broken. This is invisible under normal operation since Caelestia's own background layer draws over the real desktop, but it's exactly what's exposed the moment that's not true: a crash, a manual `qs -c caelestia` exit, or switching back to stock Plasma to troubleshoot.

`thumbFor()` already does the "video path in, still frame out" resolution the wallpaper pickers (`WallpaperItem.qml`, `WallItem.qml`) use - it returns the cached first-frame extraction if one exists, or `""` while kicking off the ffmpeg extraction if it doesn't. The Plasma sync now goes through that same function instead of writing the raw path unconditionally, and a new `onVideoThumbsChanged` handler re-syncs once a pending extraction lands. While nothing is ready yet, Plasma's previous (still valid) wallpaper is left alone rather than actively pointed at something it can't render - strictly better than the alternative of writing a path that's guaranteed broken.

## Testing

Live end to end on KDE Plasma 6.7 / kwin_wayland, reading Plasma's `Image` config directly via `qdbus6` after each step:

- **Image wallpaper**: unaffected, syncs immediately as before.
- **Video wallpaper, cold cache** (fresh shell process, no prior extraction): Plasma keeps showing the previous wallpaper for the ~1s the ffmpeg extraction takes, then picks up the finished still frame once it lands - the raw `.mp4` path never reaches Plasma's config at any point in between.
- **Video wallpaper, warm cache** (frame already extracted from an earlier session): syncs to the cached still immediately.