### PR TITLE
fix: stop games borrowing each other's taskbar icon

### DIFF
--- a/shell/modules/bar/components/Dock.qml
+++ b/shell/modules/bar/components/Dock.qml
@@ -450,7 +450,7 @@ Item {
 
                         anchors.centerIn: parent
                         implicitSize: Math.round(((delegateItem.width || 0) * 0.7) / 2) * 2 || 0
-                        source: modelData ? WinIcons.sourceFor(modelData.entry, modelData.appClass, modelData.iconName) : ""
+                        source: modelData ? WinIcons.sourceFor(modelData.entry, modelData.appClass, modelData.iconName, modelData.pid ?? 0) : ""
                         asynchronous: true
                         visible: !(Config.bar.dock.recolourIcons ?? false)
                         
@@ -588,7 +588,8 @@ Item {
                             entry: entry,
                             toplevels: [],
                             appClass: entry.id.replace(".desktop", ""),
-                            iconName: entry.id
+                            iconName: entry.id,
+                            pid: 0
                         });
                     }
                 }
@@ -651,9 +652,12 @@ Item {
                         iconName = appClass.toLowerCase().split(/[^a-z0-9]/)[0] || appClass;
                 }
 
-                // No desktop entry — pull the icon straight from the window (_NET_WM_ICON).
+                // No desktop entry — pull the icon straight from the window
+                // (_NET_WM_ICON), keyed on the pid: appClass is not unique for
+                // these (every unmapped Proton title is "steam_app_default").
+                const pid = ipc.pid || 0;
                 if (!entry)
-                    WinIcons.request(appClass, ipc.title || "");
+                    WinIcons.request(appClass, ipc.title || "", pid);
 
                 apps.push({
                     id: appClass,
@@ -661,7 +665,8 @@ Item {
                     entry: entry,
                     toplevels: [toplevel],
                     appClass: appClass,
-                    iconName: iconName
+                    iconName: iconName,
+                    pid: pid
                 });
             }
         }

--- a/shell/modules/bar/popouts/DockHover.qml
+++ b/shell/modules/bar/popouts/DockHover.qml
@@ -17,7 +17,7 @@ StyledRect {
     property var model: popouts.dockModel
     // Resolved through the same helper the taskbar tile uses, so the hover popup
     // can never disagree with the tile it belongs to.
-    readonly property string iconSource: model ? WinIcons.sourceFor(model.entry, model.appClass, model.iconName) : ""
+    readonly property string iconSource: model ? WinIcons.sourceFor(model.entry, model.appClass, model.iconName, model.pid ?? 0) : ""
     property MprisPlayer player: {
         if (!model) return null;
         return Players.list.find(p => p.identity.toLowerCase().includes(model.appClass.toLowerCase()) || (model.id && p.identity.toLowerCase().includes(model.id.toLowerCase().replace(".desktop", "")))) || null;

--- a/shell/modules/launcher/items/WindowSwitcherItem.qml
+++ b/shell/modules/launcher/items/WindowSwitcherItem.qml
@@ -44,7 +44,7 @@ Item {
         opacity = 1;
 
         if (root.modelData) {
-            WinIcons.request(root.modelData.class, root.modelData.title);
+            WinIcons.request(root.modelData.class, root.modelData.title, root.modelData.pid ?? 0);
         }
 
         Qt.callLater(() => {
@@ -135,7 +135,7 @@ Item {
             implicitSize: previewBox.height * 0.5
             asynchronous: true
             visible: previewBox.serial === 0
-            source: root.modelData ? WinIcons.sourceFor(null, root.modelData.class, root.modelData.iconName) : ""
+            source: root.modelData ? WinIcons.sourceFor(null, root.modelData.class, root.modelData.iconName, root.modelData.pid ?? 0) : ""
         }
 
         Pipewire.PipeWireSourceItem {

--- a/shell/plugin/src/Caelestia/Services/windowicon.cpp
+++ b/shell/plugin/src/Caelestia/Services/windowicon.cpp
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 #include "windowicon.hpp"
 
+#include <qbuffer.h>
 #include <qcryptographichash.h>
 #include <qdir.h>
 #include <qfile.h>
 #include <qimage.h>
+#include <qlist.h>
 #include <qloggingcategory.h>
 #include <qstandardpaths.h>
 
@@ -89,26 +91,42 @@ QString windowTitle(Display* dpy, Window win) {
     return QString();
 }
 
-bool matchesWindow(Display* dpy, Window win, const QString& wmClass, const QString& title) {
+/// The client's _NET_WM_PID, or -1 when the window does not advertise one.
+qint64 windowPid(Display* dpy, Window win) {
+    const Atom netWmPid = XInternAtom(dpy, "_NET_WM_PID", True);
+    if (netWmPid == None) {
+        return -1;
+    }
+
+    unsigned long count = 0;
+    auto* data = fetchProperty(dpy, win, netWmPid, XA_CARDINAL, &count);
+    if (!data) {
+        return -1;
+    }
+    // XGetWindowProperty hands back 32-bit CARDINALs widened to long.
+    const auto pid = static_cast<qint64>(*reinterpret_cast<const unsigned long*>(data) & 0xffffffff);
+    XFree(data);
+    return pid > 0 ? pid : -1;
+}
+
+bool matchesClass(Display* dpy, Window win, const QString& wmClass) {
     XClassHint hint {};
-    bool classMatches = false;
-
-    if (XGetClassHint(dpy, win, &hint)) {
-        const auto name = QString::fromUtf8(hint.res_name ? hint.res_name : "");
-        const auto cls = QString::fromUtf8(hint.res_class ? hint.res_class : "");
-        if (hint.res_name) {
-            XFree(hint.res_name);
-        }
-        if (hint.res_class) {
-            XFree(hint.res_class);
-        }
-        classMatches = name.compare(wmClass, Qt::CaseInsensitive) == 0 || cls.compare(wmClass, Qt::CaseInsensitive) == 0;
+    if (!XGetClassHint(dpy, win, &hint)) {
+        return false;
     }
 
-    if (classMatches) {
-        return true;
+    const auto name = QString::fromUtf8(hint.res_name ? hint.res_name : "");
+    const auto cls = QString::fromUtf8(hint.res_class ? hint.res_class : "");
+    if (hint.res_name) {
+        XFree(hint.res_name);
     }
+    if (hint.res_class) {
+        XFree(hint.res_class);
+    }
+    return name.compare(wmClass, Qt::CaseInsensitive) == 0 || cls.compare(wmClass, Qt::CaseInsensitive) == 0;
+}
 
+bool matchesTitle(Display* dpy, Window win, const QString& wmClass, const QString& title) {
     // KWin often reports the title as the "class" for these windows (Minecraft
     // shows up as "Minecraft* 1.21.11"), so fall back to matching on it.
     const auto actual = windowTitle(dpy, win);
@@ -164,23 +182,12 @@ QImage decodeLargest(const unsigned long* data, unsigned long count) {
 WindowIcon::WindowIcon(QObject* parent)
     : QObject(parent) {}
 
-QString WindowIcon::extract(const QString& wmClass, const QString& title) {
-    if (wmClass.isEmpty()) {
+QString WindowIcon::extract(const QString& wmClass, const QString& title, qint64 pid) {
+    if (wmClass.isEmpty() && pid <= 0) {
         return QString();
     }
 
-    const auto cacheRoot =
-        QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + QStringLiteral("/caelestia/winicons");
-    const auto key = QString::fromLatin1(
-        QCryptographicHash::hash(wmClass.toUtf8(), QCryptographicHash::Sha256)
-            .toHex()
-            .left(16));
-    const auto path = cacheRoot + QStringLiteral("/") + key + QStringLiteral(".png");
-
-    if (QFile::exists(path)) {
-        emit extracted(wmClass, path);
-        return path;
-    }
+    const QString key = pid > 0 ? QString::number(pid) : wmClass;
 
     XDisplay display;
     if (!display.isValid()) {
@@ -202,14 +209,30 @@ QString WindowIcon::extract(const QString& wmClass, const QString& title) {
     }
     const auto* windows = reinterpret_cast<const Window*>(rawWindows);
 
-    QImage icon;
+    // Rank candidates rather than taking the first hit: the pid identifies
+    // exactly one client, while the class can name a dozen unrelated games.
+    // A pid match therefore suppresses the weaker matches outright — falling
+    // back to them is how a game ends up wearing another game's icon.
+    QList<Window> candidates;
+    bool havePidMatch = false;
     for (unsigned long i = 0; i < windowCount; ++i) {
-        if (!matchesWindow(dpy, windows[i], wmClass, title)) {
-            continue;
+        if (pid > 0 && windowPid(dpy, windows[i]) == pid) {
+            if (!havePidMatch) {
+                havePidMatch = true;
+                candidates.clear();
+            }
+            candidates.append(windows[i]);
+        } else if (!havePidMatch && !wmClass.isEmpty() &&
+                   (matchesClass(dpy, windows[i], wmClass) || matchesTitle(dpy, windows[i], wmClass, title))) {
+            candidates.append(windows[i]);
         }
+    }
+    XFree(rawWindows);
 
+    QImage icon;
+    for (const auto win : candidates) {
         unsigned long iconCount = 0;
-        auto* rawIcon = fetchProperty(dpy, windows[i], netWmIcon, XA_CARDINAL, &iconCount);
+        auto* rawIcon = fetchProperty(dpy, win, netWmIcon, XA_CARDINAL, &iconCount);
         if (!rawIcon) {
             continue;
         }
@@ -220,18 +243,40 @@ QString WindowIcon::extract(const QString& wmClass, const QString& title) {
             break;
         }
     }
-    XFree(rawWindows);
 
     if (icon.isNull()) {
         return QString();
     }
 
-    if (!QDir().mkpath(cacheRoot) || !icon.save(path, "PNG")) {
-        qCWarning(logWindowIcon) << "could not write icon cache for" << wmClass << "to" << path;
+    // Name the file after the icon's own bytes. Keying on the window class was
+    // the other half of the wrong-icon bug: "steam_app_default" hashes to one
+    // path, so whichever game ran first owned that file forever. Content
+    // addressing also collapses the duplicates a class-per-version window
+    // (Minecraft) used to leave behind.
+    QByteArray png;
+    QBuffer buffer(&png);
+    buffer.open(QIODevice::WriteOnly);
+    if (!icon.save(&buffer, "PNG")) {
+        qCWarning(logWindowIcon) << "could not encode icon for" << key;
         return QString();
     }
+    buffer.close();
 
-    emit extracted(wmClass, path);
+    const auto cacheRoot =
+        QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + QStringLiteral("/caelestia/winicons");
+    const auto digest =
+        QString::fromLatin1(QCryptographicHash::hash(png, QCryptographicHash::Sha256).toHex().left(16));
+    const auto path = cacheRoot + QStringLiteral("/") + digest + QStringLiteral(".png");
+
+    if (!QFile::exists(path)) {
+        QFile file(path);
+        if (!QDir().mkpath(cacheRoot) || !file.open(QIODevice::WriteOnly) || file.write(png) != png.size()) {
+            qCWarning(logWindowIcon) << "could not write icon cache for" << key << "to" << path;
+            return QString();
+        }
+    }
+
+    emit extracted(key, path);
     return path;
 }
 

--- a/shell/plugin/src/Caelestia/Services/windowicon.hpp
+++ b/shell/plugin/src/Caelestia/Services/windowicon.hpp
@@ -29,17 +29,27 @@ public:
     explicit WindowIcon(QObject* parent = nullptr);
 
     /**
-     * Extract the icon for the window matching @p wmClass (and optionally
-     * @p title), caching it under ~/.cache/caelestia/winicons.
+     * Extract the icon for a window, caching it under ~/.cache/caelestia/winicons.
      *
-     * Returns the cached path immediately when it already exists, so a repeat
-     * call costs nothing. Returns an empty string when no window matches or the
-     * window carries no icon; extracted() is emitted on success either way.
+     * @p pid is the strongest identifier and is tried first against
+     * _NET_WM_PID: the window class is not unique for the very windows this
+     * exists to serve — every Proton title Steam cannot map to an appid is
+     * reported as "steam_app_default" — so matching on class alone hands one
+     * game's icon to the next. @p wmClass and @p title are only consulted when
+     * no window carries the pid (native Wayland clients, or a launcher that
+     * never set the property).
+     *
+     * Cache files are named after the icon's own content hash, so a class that
+     * covers several games can never resolve to a previously cached stranger.
+     *
+     * Returns an empty string when no window matches or it carries no icon;
+     * extracted() is emitted on success, keyed the same way as the return.
      */
-    Q_INVOKABLE QString extract(const QString& wmClass, const QString& title = QString());
+    Q_INVOKABLE QString extract(const QString& wmClass, const QString& title = QString(), qint64 pid = 0);
 
 signals:
-    void extracted(const QString& wmClass, const QString& path);
+    /// @p key is the pid as a string when one was given, else the window class.
+    void extracted(const QString& key, const QString& path);
 };
 
 } // namespace caelestia::services

--- a/shell/services/WinIcons.qml
+++ b/shell/services/WinIcons.qml
@@ -17,55 +17,65 @@ import Caelestia.Services
 Singleton {
     id: root
 
-    // appClass -> extracted png path
+    // key -> extracted png path
     property var paths: ({})
 
-    // appClass -> extraction already attempted (don't re-spawn the helper)
+    // key -> extraction already attempted (don't re-spawn the helper)
     property var tried: ({})
 
-    // Ask the plugin for the icon, at most once per class. The extraction is a
+    // Icons are tracked per window, not per class. Steam reports every Proton
+    // title it cannot map to an appid as "steam_app_default", so a class-keyed
+    // map served whichever of those games happened to be extracted first to all
+    // the others. The pid is unique per running window and is what the plugin
+    // matches on; the class is only a fallback for windows that have no pid.
+    function keyFor(appClass: string, pid: int): string {
+        return pid > 0 ? String(pid) : (appClass || "");
+    }
+
+    // Ask the plugin for the icon, at most once per window. The extraction is a
     // direct XGetWindowProperty read on _NET_WM_ICON — no helper process, and no
     // python-xlib/Pillow to have installed.
-    function request(appClass: string, title: string): void {
-        if (!appClass || root.tried[appClass])
+    function request(appClass: string, title: string, pid: int): void {
+        const key = root.keyFor(appClass, pid ?? 0);
+        if (!key || root.tried[key])
             return;
 
         const t = root.tried;
-        t[appClass] = true;
+        t[key] = true;
         root.tried = t;
 
-        const path = WindowIcon.extract(appClass, title || "");
+        const path = WindowIcon.extract(appClass || "", title || "", pid ?? 0);
         if (path)
-            root.register(appClass, path);
+            root.register(key, path);
     }
 
-    // Cached hits come straight back from extract(), but a window that only
-    // appears later still reports through the signal.
+    // extract() returns the path directly; the signal carries the same result
+    // for any caller that did not go through request().
     Connections {
         target: WindowIcon
 
-        function onExtracted(appClass: string, path: string): void {
-            root.register(appClass, path);
+        function onExtracted(key: string, path: string): void {
+            root.register(key, path);
         }
     }
 
     // Record a freshly extracted icon. Reassigning a copy is what notifies the
     // bindings that read paths[...] — mutating in place would not.
-    function register(appClass: string, path: string): void {
-        if (!path || path === "" || root.paths[appClass] === path)
+    function register(key: string, path: string): void {
+        if (!path || path === "" || root.paths[key] === path)
             return;
         const m = root.paths;
-        m[appClass] = path;
+        m[key] = path;
         root.paths = Object.assign({}, m);
     }
 
     // Resolve an icon for a dock entry, in the order the taskbar tile and the
     // hover popup must agree on: desktop entry icon, then extracted window
     // icon, then the window class as a themed-icon name.
-    function sourceFor(entry: var, appClass: string, iconName: string): string {
+    function sourceFor(entry: var, appClass: string, iconName: string, pid: int): string {
         if (entry && entry.icon)
             return Quickshell.iconPath(entry.icon, "application-x-executable");
-        const wp = root.paths[appClass];
+        const wp = root.paths[root.keyFor(appClass, pid ?? 0)];
         if (wp)
             return "file://" + wp;
         return Quickshell.iconPath(iconName, "application-x-executable");


### PR DESCRIPTION
## What does this change?

Steam reports every Proton title it cannot map to an appid under the same window class, `steam_app_default`, and the extracted-icon cache was keyed on that class alone. Whichever such game ran first owned the cache file forever, and every later one wore its icon.

Windows are now matched by `_NET_WM_PID`, which identifies exactly one client. Once a pid match exists the class and title fallbacks are suppressed outright — falling through to them is what mixed the games up in the first place. Cache files are named after the icon's own content hash instead of the class, so a shared class can no longer resolve to a previously cached stranger. The QML-side maps are keyed on the pid to match.

The class/title matching is kept for windows that carry no pid (native Wayland clients, or launcher-spawned windows that never set the property).

## How did you test it?

On a live session with a Proton game running (Watch_Dogs 2, reported as `steam_app_default`):

- Before: `~/.cache/caelestia/winicons` held an icon for `steam_app_default` belonging to a completely different game, and that is what the dock drew. Four more entries were byte-identical duplicates of one Minecraft icon, cached under different class strings.
- Verified `_NET_WM_PID` on the game's X window matched the pid KWin reports for it.
- Ran the extractor against the live window through a small harness linked to the built plugin: with the pid it produced the game's actual icon; the same call keyed only on the class had previously returned the stranger.
- Cleared the cache and confirmed the shell re-extracted exactly one content-addressed file, matching the icon the harness produced.
- Running in a live shell since.

Not covered: native Wayland game windows. `_NET_WM_ICON` is an X property, so a game launched with `PROTON_ENABLE_WAYLAND=1` has nothing to extract and falls back to the themed icon, as before.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Config / theme
- [ ] Docs
- [ ] Refactor
- [ ] Other

## Notes for reviewers

Dropping the class-keyed cache path means the on-disk lookup no longer short-circuits the X read. That read is one `XGetWindowProperty` round trip and still happens at most once per window per session, so the cost is negligible next to the class of bug it removes. Existing cache files under the old naming are simply never consulted again.