### PR TITLE
fix: stop the shell crashing as it exits

### DIFF
--- a/shell/plugin/src/Caelestia/Services/windowscreencast.cpp
+++ b/shell/plugin/src/Caelestia/Services/windowscreencast.cpp
@@ -45,8 +45,14 @@ WindowScreencastGlobal::WindowScreencastGlobal()
 }
 
 WindowScreencastGlobal* WindowScreencastGlobal::instance() {
-    static WindowScreencastGlobal s_instance;
-    return &s_instance;
+    // Deliberately never destroyed. Releasing a Wayland proxy is itself a
+    // request, and a function-local static is torn down from an exit handler,
+    // long after Qt has closed the display — marshalling there writes into
+    // freed memory and takes the shell down with a SIGSEGV as it quits. The
+    // process is ending either way, so leaking the global is the cheap fix;
+    // the kernel reclaims it.
+    static auto* s_instance = new WindowScreencastGlobal();
+    return s_instance;
 }
 
 WindowScreencastGlobal::~WindowScreencastGlobal() {


### PR DESCRIPTION
## What does this change?

`WindowScreencastGlobal` is a function-local static whose destructor calls `destroy()`. Releasing a Wayland proxy is itself a request, and a function-local static is torn down from an exit handler — long after Qt has closed the display — so that marshals into freed memory and the shell dies with a SIGSEGV on its way out.

That turns an ordinary quit into a crash, and a crash is not a clean stop: restarting the shell leaves it down instead of coming back up, because nothing relaunches the process once it has died this way. It looks exactly like "I restarted the shell and it never came back".

The fix is to leak the global. The process is ending regardless and the kernel reclaims it; there is nothing to gain by releasing a proxy at a point where the connection no longer exists.

## How did you test it?

- Caught it in a coredump: `SIGSEGV` in `wl_proxy_marshal_array_flags`, called from `libcaelestia-services.so`, with `exit()` and the C++ exit-handler machinery below it in the stack — i.e. teardown, not startup.
- Confirmed the process that crashed had a build of the plugin mapped whose only static Wayland object is this one.
- After the fix, restarting the shell exits cleanly and comes back on its own; no new coredumps.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Config / theme
- [ ] Docs
- [ ] Refactor
- [ ] Other

## Notes for reviewers

Worth knowing this pattern is a trap in general: any `QWaylandClientExtension` (or proxy wrapper) kept in a function-local static will release itself at exit, after the display is gone. Anything longer-lived than a request should either be owned by an object destroyed while the connection is up, or deliberately leaked like this.