### PR TITLE
feat: add dodge windows mode to the bar

### DIFF
--- a/shell/modules/background/Background.qml
+++ b/shell/modules/background/Background.qml
@@ -84,7 +84,7 @@ Variants {
         Loader {
             id: clockLoader
 
-            readonly property int clockBarZone: Visibilities.bars.get(win.modelData.name)?.exclusiveZone ?? (Tokens.sizes.bar.innerWidth + Math.max(Tokens.padding.small, Config.border.thickness))
+            readonly property int clockBarZone: Visibilities.bars.get(win.modelData.name)?.visualThickness ?? (Tokens.sizes.bar.innerWidth + Math.max(Tokens.padding.small, Config.border.thickness))
             readonly property int clockBaseMargin: Tokens.padding.extraLargeIncreased
 
             asynchronous: true
@@ -200,7 +200,7 @@ Variants {
         Loader {
             id: lyricsLoader
 
-            readonly property int lyricsBarZone: Visibilities.bars.get(win.modelData.name)?.exclusiveZone ?? (Tokens.sizes.bar.innerWidth + Math.max(Tokens.padding.small, Config.border.thickness))
+            readonly property int lyricsBarZone: Visibilities.bars.get(win.modelData.name)?.visualThickness ?? (Tokens.sizes.bar.innerWidth + Math.max(Tokens.padding.small, Config.border.thickness))
             readonly property int lyricsBaseMargin: Tokens.padding.large * 2
 
             asynchronous: true

--- a/shell/modules/background/DesktopIcons.qml
+++ b/shell/modules/background/DesktopIcons.qml
@@ -108,7 +108,7 @@ Item {
 
         anchors.fill: parent
         
-        readonly property int barZone: Visibilities.bars.get(root.screenData.name)?.exclusiveZone ?? (Tokens.sizes.bar.innerWidth + Math.max(Tokens.padding.small, Config.border.thickness))
+        readonly property int barZone: Visibilities.bars.get(root.screenData.name)?.visualThickness ?? (Tokens.sizes.bar.innerWidth + Math.max(Tokens.padding.small, Config.border.thickness))
 
         readonly property int baseMargin: Tokens.padding.large * 2
         

--- a/shell/modules/background/Visualiser.qml
+++ b/shell/modules/background/Visualiser.qml
@@ -37,7 +37,7 @@ Item {
         let bar = name ? Visibilities.bars.get(name) : undefined;
         return bar;
     }
-    readonly property int barExclusiveZone: barWrapper ? barWrapper.exclusiveZone : 0
+    readonly property int barExclusiveZone: barWrapper ? barWrapper.visualThickness : 0
     readonly property real visualiserSpacing: Tokens.spacing.small * Config.background.visualiser.spacing
     readonly property real fallbackMargin: Tokens.padding.large + Tokens.spacing.small
 

--- a/shell/modules/bar/BarWrapper.qml
+++ b/shell/modules/bar/BarWrapper.qml
@@ -7,6 +7,7 @@ import Quickshell.Wayland
 import Caelestia.Config
 import qs.components
 import qs.components.controls
+import qs.services
 import qs.utils
 import qs.modules.bar.popouts as BarPopouts
 
@@ -22,8 +23,28 @@ Item {
     readonly property real barScale: Math.max(0.6, !isNaN(Config.bar.scale) ? Config.bar.scale : 1.0)
     readonly property int padding: Math.max(Tokens.padding.small, Config.border.thickness)
     readonly property int contentWidth: Math.round(Tokens.sizes.bar.innerWidth * barScale) + padding * 2
-    readonly property int exclusiveZone: !disabled && (Config.bar.persistent || visibilities.bar) ? contentWidth : Config.border.thickness
-    readonly property bool shouldBeVisible: !fullscreen && !disabled && !visibilities.overview && (Config.bar.persistent || visibilities.bar || isHovered)
+    readonly property bool dodgeEnabled: Config.bar.dodgeWindows && Config.bar.persistent && !disabled
+    // The strip the bar occupies, in the absolute multi-monitor coordinates
+    // KWin reports window geometry in — hence the screen origin offset.
+    readonly property rect dodgeRect: {
+        const ox = screen.x ?? 0;
+        const oy = screen.y ?? 0;
+        if (position === "top")
+            return Qt.rect(ox, oy, screen.width, contentWidth);
+        if (position === "bottom")
+            return Qt.rect(ox, oy + screen.height - contentWidth, screen.width, contentWidth);
+        if (position === "left")
+            return Qt.rect(ox, oy, contentWidth, screen.height);
+        return Qt.rect(ox + screen.width - contentWidth, oy, contentWidth, screen.height);
+    }
+    readonly property bool dodging: dodgeEnabled && Hypr.hasWindowOverlapping(screen.name, dodgeRect.x, dodgeRect.y, dodgeRect.width, dodgeRect.height)
+    // Treat a dodging bar as non-persistent: it stays out of the way but is
+    // still reachable through the hover edge and the usual toggles.
+    readonly property bool keptOpen: Config.bar.persistent && !dodging
+    // Reserving space while dodging would keep windows off the bar, so nothing
+    // would ever overlap it and the mode would never engage.
+    readonly property int exclusiveZone: !disabled && !dodgeEnabled && (Config.bar.persistent || visibilities.bar) ? contentWidth : Config.border.thickness
+    readonly property bool shouldBeVisible: !fullscreen && !disabled && !visibilities.overview && (keptOpen || visibilities.bar || isHovered)
     property bool isHovered
     readonly property bool isHorizontal: Config.bar.position === "top" || Config.bar.position === "bottom"
     readonly property int clampedThickness: Math.max(Config.border.minThickness, isHorizontal ? implicitHeight : implicitWidth)

--- a/shell/modules/bar/BarWrapper.qml
+++ b/shell/modules/bar/BarWrapper.qml
@@ -37,7 +37,7 @@ Item {
             return Qt.rect(ox, oy, contentWidth, screen.height);
         return Qt.rect(ox + screen.width - contentWidth, oy, contentWidth, screen.height);
     }
-    readonly property bool dodging: dodgeEnabled && Hypr.hasWindowOverlapping(screen.name, dodgeRect.x, dodgeRect.y, dodgeRect.width, dodgeRect.height)
+    readonly property bool dodging: dodgeEnabled && Hypr.hasWindowOverlapping(screen.name, dodgeRect.x, dodgeRect.y, dodgeRect.width, dodgeRect.height, Config.bar.dodgeFocusedOnly)
     // Treat a dodging bar as non-persistent: it stays out of the way but is
     // still reachable through the hover edge and the usual toggles.
     readonly property bool keptOpen: Config.bar.persistent && !dodging

--- a/shell/modules/bar/BarWrapper.qml
+++ b/shell/modules/bar/BarWrapper.qml
@@ -44,6 +44,15 @@ Item {
     // Reserving space while dodging would keep windows off the bar, so nothing
     // would ever overlap it and the mode would never engage.
     readonly property int exclusiveZone: !disabled && !dodgeEnabled && (Config.bar.persistent || visibilities.bar) ? contentWidth : Config.border.thickness
+    // What the desktop layer (icons, the clock, the audio visualiser) should
+    // leave clear so its own content doesn't render under the bar. This is
+    // exclusiveZone without the dodge carve-out: dodging drops the reported
+    // zone to (near) nothing so KWin will let windows slide under the bar,
+    // which is exactly what makes overlap detection possible, but the bar is
+    // still visually there whenever it isn't actively dodging, and desktop
+    // content needs to keep leaving room for it regardless of what KWin was
+    // told for window-placement purposes.
+    readonly property int visualThickness: !disabled && (Config.bar.persistent || visibilities.bar) ? contentWidth : Config.border.thickness
     readonly property bool shouldBeVisible: !fullscreen && !disabled && !visibilities.overview && (keptOpen || visibilities.bar || isHovered)
     property bool isHovered
     readonly property bool isHorizontal: Config.bar.position === "top" || Config.bar.position === "bottom"

--- a/shell/modules/nexus/pages/panels/TaskbarPanel.qml
+++ b/shell/modules/nexus/pages/panels/TaskbarPanel.qml
@@ -63,6 +63,14 @@ PageBase {
             onToggled: GlobalConfig.bar.dodgeWindows = checked
         }
 
+        ToggleRow {
+            text: qsTr("Dodge focused window only")
+            subtext: qsTr("Ignore background windows over the bar, and dodge only what you are using")
+            enabled: GlobalConfig.bar.persistent && GlobalConfig.bar.dodgeWindows
+            checked: GlobalConfig.bar.dodgeFocusedOnly
+            onToggled: GlobalConfig.bar.dodgeFocusedOnly = checked
+        }
+
         SelectRow {
             Layout.fillWidth: true
             label: qsTr("Position")

--- a/shell/modules/nexus/pages/panels/TaskbarPanel.qml
+++ b/shell/modules/nexus/pages/panels/TaskbarPanel.qml
@@ -55,6 +55,14 @@ PageBase {
             onToggled: GlobalConfig.bar.persistent = checked
         }
 
+        ToggleRow {
+            text: qsTr("Dodge windows")
+            subtext: qsTr("Retract the bar while a window covers it, and let windows sit underneath")
+            enabled: GlobalConfig.bar.persistent
+            checked: GlobalConfig.bar.dodgeWindows
+            onToggled: GlobalConfig.bar.dodgeWindows = checked
+        }
+
         SelectRow {
             Layout.fillWidth: true
             label: qsTr("Position")

--- a/shell/modules/shimeji/Shimeji.qml
+++ b/shell/modules/shimeji/Shimeji.qml
@@ -45,7 +45,7 @@ StyledWindow {
         let bar = name ? Visibilities.bars.get(name) : undefined;
         return bar;
     })()
-    readonly property real floorOffset: Config.bar.position === "bottom" ? (barWrapper ? barWrapper.exclusiveZone : 0) : 0
+    readonly property real floorOffset: Config.bar.position === "bottom" ? (barWrapper ? barWrapper.visualThickness : 0) : 0
 
     function getImgPath(): string {
         if (!modelData)

--- a/shell/plugin/src/Caelestia/Config/barconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/barconfig.hpp
@@ -219,6 +219,15 @@ class BarConfig : public ConfigObject {
     CONFIG_SUBOBJECT(BarPreviewScales, previewScales)
     CONFIG_SUBOBJECT(BarPreviewFontScales, previewFontScales)
     CONFIG_PROPERTY(bool, persistent, true)
+    // Retract the bar while a window overlaps the strip it occupies, and let it
+    // come back when nothing is under it. Only meaningful together with
+    // persistent — a non-persistent bar is already hidden by default.
+    //
+    // The bar stops reserving an exclusive zone in this mode: windows have to
+    // be allowed to sit under it for the overlap to mean anything, and a
+    // reserved zone would push every window off the bar and make the two
+    // oscillate.
+    CONFIG_PROPERTY(bool, dodgeWindows, false)
     CONFIG_PROPERTY(bool, showOnHover, true)
     CONFIG_PROPERTY(int, dragThreshold, 20)
     CONFIG_PROPERTY(QString, position, u"bottom"_s)

--- a/shell/plugin/src/Caelestia/Config/barconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/barconfig.hpp
@@ -228,6 +228,10 @@ class BarConfig : public ConfigObject {
     // reserved zone would push every window off the bar and make the two
     // oscillate.
     CONFIG_PROPERTY(bool, dodgeWindows, false)
+    // Narrow dodging to the window you are actually working in. Without this
+    // any window over the bar retracts it, so a background window parked there
+    // keeps the bar down even while you use something else entirely.
+    CONFIG_PROPERTY(bool, dodgeFocusedOnly, false)
     CONFIG_PROPERTY(bool, showOnHover, true)
     CONFIG_PROPERTY(int, dragThreshold, 20)
     CONFIG_PROPERTY(QString, position, u"bottom"_s)

--- a/shell/services/Hypr.qml
+++ b/shell/services/Hypr.qml
@@ -207,16 +207,23 @@ Singleton {
     // push the bar away. Returns false off KDE: the Hyprland path has no
     // equivalent window list here, and reporting "nothing overlaps" leaves the
     // bar visible rather than stuck hidden.
-    function hasWindowOverlapping(screenName: string, x: real, y: real, width: real, height: real): bool {
+    function hasWindowOverlapping(screenName: string, x: real, y: real, width: real, height: real, focusedOnly: bool): bool {
         if (typeof KWinActiveWindowBridge === "undefined")
             return false;
 
         const wins = KWinActiveWindowBridge.windowList || [];
         const activeWsId = (typeof KWinWorkspaceState !== "undefined") ? KWinWorkspaceState.activeId : -1;
+        const activeAddr = focusedOnly ? String(KWinActiveWindowBridge.activeWindow?.address ?? "") : "";
+
+        // Nothing focused means nothing to dodge, rather than everything.
+        if (focusedOnly && !activeAddr)
+            return false;
 
         for (let i = 0; i < wins.length; i++) {
             const win = wins[i];
             if (win.minimized === true)
+                continue;
+            if (focusedOnly && String(win.address) !== activeAddr)
                 continue;
             if (screenName && win.output !== screenName)
                 continue;

--- a/shell/services/Hypr.qml
+++ b/shell/services/Hypr.qml
@@ -199,6 +199,36 @@ Singleton {
         return false;
     }
 
+    // Whether any window on `screenName` overlaps the given rect, which is in
+    // the same absolute multi-monitor coordinates KWin reports geometry in.
+    //
+    // Used by the bar's dodge mode. Minimized windows are skipped, and so are
+    // windows on other virtual desktops — a window you cannot see should not
+    // push the bar away. Returns false off KDE: the Hyprland path has no
+    // equivalent window list here, and reporting "nothing overlaps" leaves the
+    // bar visible rather than stuck hidden.
+    function hasWindowOverlapping(screenName: string, x: real, y: real, width: real, height: real): bool {
+        if (typeof KWinActiveWindowBridge === "undefined")
+            return false;
+
+        const wins = KWinActiveWindowBridge.windowList || [];
+        const activeWsId = (typeof KWinWorkspaceState !== "undefined") ? KWinWorkspaceState.activeId : -1;
+
+        for (let i = 0; i < wins.length; i++) {
+            const win = wins[i];
+            if (win.minimized === true)
+                continue;
+            if (screenName && win.output !== screenName)
+                continue;
+            if (activeWsId !== -1 && win.workspace?.id !== activeWsId)
+                continue;
+            // Touching edges are not an overlap, hence the strict comparisons.
+            if (win.x < x + width && win.x + win.width > x && win.y < y + height && win.y + win.height > y)
+                return true;
+        }
+        return false;
+    }
+
     function dispatch(request: string): void {
         const isKDE = typeof KWinActiveWindowBridge !== "undefined";
 


### PR DESCRIPTION
## What does this change?

Closes #406.

A persistent bar always sits on screen and reserves an exclusive zone for itself. Dodge mode keeps it visible over empty desktop but retracts it as soon as a window covers the strip it occupies — the behaviour Plasma panels call "Dodge Windows".

Overlap is evaluated per screen against the window geometry the KWin bridge already publishes, skipping minimized windows and windows on other virtual desktops, so a window you cannot see does not push the bar away. The hover edge and the usual toggles still reveal the bar while it is dodging, so nothing becomes unreachable.

Exposed as a toggle under Taskbar → Behaviour, disabled by default, and greyed out when the bar is not persistent (a non-persistent bar is already hidden, so the mode has nothing to add).

## How did you test it?

- On a live shell: enabled the toggle, moved a window over the bar and watched it retract, moved it away and watched it come back, and confirmed the hover edge still reveals it mid-dodge.
- Checked a maximized window against a real output: KWin insets maximized windows by the reserved struts, so they measure 2540x1370 on a 2560x1440 screen and correctly do not count as covering it.
- Left it off (the default) and confirmed the bar behaves exactly as before.

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Config / theme
- [ ] Docs
- [ ] Refactor
- [ ] Other

## Notes for reviewers

The one design decision worth flagging: the bar stops reserving an exclusive zone while this mode is on. That is load bearing rather than incidental. With a zone reserved, windows are kept off the bar, so nothing ever overlaps it, the bar comes back, the zone is reserved again — it oscillates every frame. Letting windows sit under the bar is what makes the overlap test mean anything.

Consequence to be aware of: with dodge on, a maximized window covers the full output rather than stopping at the bar, so the bar dodges for it. That matches how Plasma's own dodge mode behaves, but it is a visible difference from the default and is why this ships off.