### PR TITLE
feat: anchor minimize animations to the dock

### DIFF
--- a/shell/modules/bar/components/Dock.qml
+++ b/shell/modules/bar/components/Dock.qml
@@ -36,6 +36,20 @@ Item {
 
     HoverHandler { id: dockHover }
 
+    // Drives the icon-geometry publishing below. A tile's rect on screen moves
+    // for reasons no single binding can watch — the bar sliding in and out, the
+    // dock list scrolling, a drag reordering tiles — and mapToItem() is a plain
+    // call that never re-runs on its own. Re-reading a handful of rects twice a
+    // second covers all of it, and MinimizeGeometry drops rects that have not
+    // actually changed, so a steady dock sends nothing over the wire.
+    Timer {
+        id: minimizeGeometryTicker
+
+        interval: 500
+        repeat: true
+        running: root.visible
+    }
+
     ListModel { id: dockModel }
 
     function saveNewOrder(): void {
@@ -273,6 +287,32 @@ Item {
                     Drag.source: delegateItem
                     Drag.hotSpot.x: width / 2
                     Drag.hotSpot.y: height / 2
+                    Component.onCompleted: minimizeTarget.publish()
+
+                    // Tell KWin this tile is where the app's windows live in the
+                    // taskbar, so minimize/restore effects animate into it. With
+                    // nothing published, Magic Lamp has no icon geometry to aim
+                    // at and falls back to following the cursor.
+                    QtObject {
+                        id: minimizeTarget
+
+                        function publish(): void {
+                            const tops = modelData?.toplevels ?? [];
+                            for (let i = 0; i < tops.length; i++) {
+                                const address = tops[i]?.address;
+                                if (address)
+                                    MinimizeGeometry.setGeometry(delegateItem, String(address));
+                            }
+                        }
+                    }
+
+                    Connections {
+                        function onTriggered(): void {
+                            minimizeTarget.publish();
+                        }
+
+                        target: minimizeGeometryTicker
+                    }
 
                     StateLayer {
                         id: stateLayer

--- a/shell/plugin/src/Caelestia/Services/CMakeLists.txt
+++ b/shell/plugin/src/Caelestia/Services/CMakeLists.txt
@@ -1,5 +1,9 @@
 find_package(KF6GlobalAccel REQUIRED)
 find_package(X11 REQUIRED)
+# For QPlatformNativeInterface, the only way to reach a QWindow's wl_surface:
+# Qt exposes no public native interface for it. Ships with qt6-base on Arch and
+# with qt6-qtbase-private-devel on Fedora, both already installed by setup.
+find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
 qml_module(caelestia-services
     URI Caelestia.Services
     SOURCES
@@ -53,9 +57,13 @@ qml_module(caelestia-services
         windowscreencast.cpp
         windowscreencast.hpp
         windowicon.hpp
+        minimizegeometry.cpp
+        minimizegeometry.hpp
     LIBRARIES
         Qt::DBus
         Qt::Gui
+        Qt::Quick
+        Qt::GuiPrivate
         Qt::WaylandClient
         KF6::GlobalAccel
         X11::X11
@@ -72,8 +80,10 @@ qml_module(caelestia-services
 
 qt6_generate_wayland_protocol_client_sources(caelestia-services FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../protocols/zkde-screencast-unstable-v1.xml
+    ${CMAKE_CURRENT_SOURCE_DIR}/../protocols/plasma-window-management.xml
 )
 set_source_files_properties(
     ${CMAKE_CURRENT_BINARY_DIR}/wayland-zkde-screencast-unstable-v1-protocol.c
+    ${CMAKE_CURRENT_BINARY_DIR}/wayland-plasma-window-management-protocol.c
     PROPERTIES SKIP_PRECOMPILE_HEADERS ON
 )

--- a/shell/plugin/src/Caelestia/Services/minimizegeometry.cpp
+++ b/shell/plugin/src/Caelestia/Services/minimizegeometry.cpp
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-3.0-only
+#include "minimizegeometry.hpp"
+
+#include <QCoreApplication>
+#include <QGuiApplication>
+#include <QLoggingCategory>
+#include <QUuid>
+#include <QQuickWindow>
+#include <QWindow>
+
+#include <qpa/qplatformnativeinterface.h>
+
+namespace caelestia::services {
+
+namespace {
+
+Q_LOGGING_CATEGORY(logMinimizeGeometry, "caelestia.services.minimizegeometry");
+
+// get_window_by_uuid, which is what lets us address a window without mirroring
+// KWin's entire window list.
+constexpr int kRequiredVersion = 12;
+
+// Set once the Wayland connection is on its way out. Releasing a proxy is
+// itself a request, so doing it after the connection is gone marshals onto
+// freed memory and takes the whole shell down with a SIGSEGV — which is
+// exactly what happened before this existed. Everything is released up front
+// from aboutToQuit, while the connection is still live; anything that survives
+// past that point must let its proxy leak rather than touch it.
+bool s_connectionGone = false;
+
+/// The wl_surface backing a QWindow, or nullptr before it has been shown.
+wl_surface* surfaceFor(QWindow* window) {
+    if (!window || !window->handle()) {
+        return nullptr;
+    }
+
+    auto* native = QGuiApplication::platformNativeInterface();
+    if (!native) {
+        return nullptr;
+    }
+    return static_cast<wl_surface*>(native->nativeResourceForWindow(QByteArrayLiteral("surface"), window));
+}
+
+/// KWin hands out window ids as QUuid::toString(), i.e. brace-wrapped. Callers
+/// pass those through from the KWin bridge, but normalise anyway: a uuid that
+/// differs only in its braces resolves to a window that is immediately
+/// unmapped, which looks exactly like the protocol silently doing nothing.
+QString normaliseUuid(const QString& uuid) {
+    const auto parsed = QUuid::fromString(uuid);
+    return parsed.isNull() ? uuid : parsed.toString(QUuid::WithBraces);
+}
+
+} // namespace
+
+PlasmaWindowHandle::PlasmaWindowHandle(::org_kde_plasma_window* window)
+    : QtWayland::org_kde_plasma_window(window) {}
+
+PlasmaWindowHandle::~PlasmaWindowHandle() {
+    if (!s_connectionGone && isInitialized()) {
+        destroy();
+    }
+}
+
+void PlasmaWindowHandle::org_kde_plasma_window_unmapped() {
+    emit unmapped();
+}
+
+PlasmaWindowManagement::PlasmaWindowManagement(QObject* parent)
+    : QWaylandClientExtensionTemplate<PlasmaWindowManagement>(kRequiredVersion) {
+    setParent(parent);
+    initialize();
+    if (!isInitialized() || !isActive()) {
+        qCWarning(logMinimizeGeometry)
+            << "org_kde_plasma_window_management is not available (isInitialized:" << isInitialized()
+            << ", isActive:" << isActive() << "). Minimize animations will fall back to the cursor."
+            << "The compositor may not support it at version" << kRequiredVersion
+            << "or this app is missing org_kde_plasma_window_management from"
+               " X-KDE-Wayland-Interfaces in its desktop file.";
+    }
+}
+
+// org_kde_plasma_window_management has no destructor request, so there is
+// nothing to release here beyond the base class teardown.
+PlasmaWindowManagement::~PlasmaWindowManagement() = default;
+
+MinimizeGeometry::MinimizeGeometry(QObject* parent)
+    : QObject(parent) {
+    // Tear down while the connection is still usable. QML singletons outlive
+    // the Wayland display on the way out, so waiting for the destructor is too
+    // late to release anything.
+    if (auto* app = QCoreApplication::instance()) {
+        connect(app, &QCoreApplication::aboutToQuit, this, &MinimizeGeometry::shutdown);
+    }
+}
+
+void MinimizeGeometry::shutdown() {
+    if (s_connectionGone) {
+        return;
+    }
+
+    const auto uuids = m_handles.keys();
+    for (const auto& uuid : uuids) {
+        delete m_handles.take(uuid);
+    }
+    m_published.clear();
+
+    delete m_management;
+    m_management = nullptr;
+
+    s_connectionGone = true;
+}
+
+PlasmaWindowHandle* MinimizeGeometry::handleFor(const QString& uuid) {
+    if (s_connectionGone) {
+        return nullptr;
+    }
+    if (const auto it = m_handles.constFind(uuid); it != m_handles.constEnd()) {
+        return *it;
+    }
+
+    if (!m_management) {
+        m_management = new PlasmaWindowManagement(this);
+    }
+    if (!m_management->isActive()) {
+        return nullptr;
+    }
+
+    auto* handle = new PlasmaWindowHandle(m_management->get_window_by_uuid(uuid));
+    handle->setParent(this);
+    // The compositor answers an unknown uuid with an immediately unmapped
+    // window rather than an error, so this doubles as the "no such window"
+    // path: drop it and let the next call ask again.
+    connect(handle, &PlasmaWindowHandle::unmapped, this, [this, uuid]() { forget(uuid); });
+    m_handles.insert(uuid, handle);
+    return handle;
+}
+
+void MinimizeGeometry::forget(const QString& uuid) {
+    if (auto* handle = m_handles.take(uuid)) {
+        handle->deleteLater();
+    }
+    m_published.remove(uuid);
+}
+
+void MinimizeGeometry::setGeometry(QQuickItem* tile, const QString& uuid) {
+    if (!tile || uuid.isEmpty() || tile->width() <= 0 || tile->height() <= 0) {
+        return;
+    }
+
+    auto* surface = surfaceFor(tile->window());
+    if (!surface) {
+        return;
+    }
+
+    // Scene coordinates are surface coordinates: the item's window is the
+    // surface the rect is declared against.
+    const auto topLeft = tile->mapToScene(QPointF(0, 0));
+    const QRect rect(qRound(topLeft.x()), qRound(topLeft.y()), qRound(tile->width()), qRound(tile->height()));
+
+    const auto key = normaliseUuid(uuid);
+    if (m_published.value(key) == rect) {
+        return;
+    }
+
+    auto* handle = handleFor(key);
+    if (!handle) {
+        return;
+    }
+
+    // The protocol takes unsigned coordinates, so a tile scrolled or animated
+    // off the surface's top/left would wrap into a huge positive number.
+    handle->set_minimized_geometry(surface, static_cast<uint32_t>(std::max(0, rect.x())),
+        static_cast<uint32_t>(std::max(0, rect.y())), static_cast<uint32_t>(rect.width()),
+        static_cast<uint32_t>(rect.height()));
+    m_published.insert(key, rect);
+}
+
+void MinimizeGeometry::clearGeometry(QQuickItem* tile, const QString& uuid) {
+    if (uuid.isEmpty()) {
+        return;
+    }
+
+    const auto key = normaliseUuid(uuid);
+    if (!m_published.contains(key)) {
+        return;
+    }
+
+    if (auto* surface = tile ? surfaceFor(tile->window()) : nullptr) {
+        if (const auto it = m_handles.constFind(key); it != m_handles.constEnd()) {
+            (*it)->unset_minimized_geometry(surface);
+        }
+    }
+    forget(key);
+}
+
+} // namespace caelestia::services

--- a/shell/plugin/src/Caelestia/Services/minimizegeometry.hpp
+++ b/shell/plugin/src/Caelestia/Services/minimizegeometry.hpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-only
+#pragma once
+
+// Tells KWin where each taskbar entry sits, so minimize/restore effects have
+// something to animate towards.
+//
+// KWin's Magic Lamp effect animates a window into its "icon geometry" — the
+// rect the taskbar occupies for that window. Nothing publishes that here: the
+// dock is a Quickshell surface, not a Plasma panel, so KWin has no icon
+// geometry for any window and the effect falls back to guessing from the
+// cursor. That is why the animation follows the pointer around, and why
+// putting a real Plasma panel underneath the dock "fixes" it.
+//
+// The taskbar side of the plasma-window-management protocol is what Plasma's
+// own Task Manager uses for this (libtaskmanager sets it from the task
+// delegate's rect). The shell already requests org_kde_plasma_window_management
+// in its desktop file for window metadata, so no new privilege is involved.
+
+#include <QHash>
+#include <QObject>
+#include <QQmlEngine>
+#include <QRect>
+// Full definition, not a forward declaration: moc needs it to register the
+// Q_INVOKABLE pointer argument below as a metatype.
+#include <QQuickItem>
+#include <QtWaylandClient/QWaylandClientExtension>
+
+#include "qwayland-plasma-window-management.h"
+
+namespace caelestia::services {
+
+/// One org_kde_plasma_window handle, held for as long as the shell has a
+/// taskbar rect to publish for that window.
+class PlasmaWindowHandle : public QObject, public QtWayland::org_kde_plasma_window {
+    Q_OBJECT
+
+public:
+    explicit PlasmaWindowHandle(::org_kde_plasma_window* window);
+    ~PlasmaWindowHandle() override;
+
+signals:
+    /// The compositor dropped the window; the handle is spent after this.
+    void unmapped();
+
+protected:
+    void org_kde_plasma_window_unmapped() override;
+};
+
+class PlasmaWindowManagement : public QWaylandClientExtensionTemplate<PlasmaWindowManagement>,
+                               public QtWayland::org_kde_plasma_window_management {
+    Q_OBJECT
+
+public:
+    explicit PlasmaWindowManagement(QObject* parent = nullptr);
+    ~PlasmaWindowManagement() override;
+};
+
+class MinimizeGeometry : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+public:
+    explicit MinimizeGeometry(QObject* parent = nullptr);
+
+    /**
+     * Publish @p tile as the taskbar rect for @p uuid, which is KWin's internal
+     * window id — the same value the KWin bridge reports as a window's address.
+     *
+     * Takes the item rather than a window and a rect: the protocol wants
+     * surface-relative coordinates, which is exactly what mapping the item into
+     * its own scene gives, and QML cannot hand a QWindow across to C++ anyway.
+     *
+     * Repeat calls with an unchanged rect are dropped, because the QML side
+     * drives this from layout bindings that fire far more often than the
+     * geometry actually moves.
+     */
+    Q_INVOKABLE void setGeometry(QQuickItem* tile, const QString& uuid);
+
+    /// Withdraw a rect published earlier, e.g. when its tile goes away.
+    Q_INVOKABLE void clearGeometry(QQuickItem* tile, const QString& uuid);
+
+private:
+    PlasmaWindowHandle* handleFor(const QString& uuid);
+    void forget(const QString& uuid);
+    /// Release every proxy while the connection is still up. See the .cpp.
+    void shutdown();
+
+    // Bound lazily and owned here rather than through a function-local static.
+    // A static is torn down from an exit handler, long after Qt has closed the
+    // Wayland connection.
+    PlasmaWindowManagement* m_management = nullptr;
+    // Parented to this, so they also go away with the service. Raw pointers
+    // rather than unique_ptr because QHash requires a copyable value type.
+    QHash<QString, PlasmaWindowHandle*> m_handles;
+    QHash<QString, QRect> m_published;
+};
+
+} // namespace caelestia::services

--- a/shell/plugin/src/Caelestia/protocols/plasma-window-management.xml
+++ b/shell/plugin/src/Caelestia/protocols/plasma-window-management.xml
@@ -1,0 +1,476 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="plasma_window_management">
+  <copyright><![CDATA[
+    SPDX-FileCopyrightText: 2013-2014 Pier Luigi Fiorini
+
+    SPDX-License-Identifier: LGPL-2.1-or-later
+  ]]></copyright>
+
+  <interface name="org_kde_plasma_window_management" version="20">
+    <description summary="application windows management">
+      This interface manages application windows.
+      It provides requests to show and hide the desktop and emits
+      an event every time a window is created so that the client can
+      use it to manage the window.
+
+      Only one client can bind this interface at a time.
+
+      Warning! The protocol described in this file is a desktop environment
+      implementation detail. Regular clients must not use this protocol.
+      Backward incompatible changes may be added without bumping the major
+      version of the extension.
+    </description>
+
+    <enum name="state">
+      <entry name="active" value="0x1"/>
+      <entry name="minimized" value="0x2"/>
+      <entry name="maximized" value="0x4"/>
+      <entry name="fullscreen" value="0x8"/>
+      <entry name="keep_above" value="0x10"/>
+      <entry name="keep_below" value="0x20"/>
+      <entry name="on_all_desktops" value="0x40"/>
+      <entry name="demands_attention" value="0x80"/>
+      <entry name="closeable" value="0x100"/>
+      <entry name="minimizable" value="0x200"/>
+      <entry name="maximizable" value="0x400"/>
+      <entry name="fullscreenable" value="0x800"/>
+      <entry name="skiptaskbar" value="0x1000" since="2"/>
+      <entry name="shadeable" value="0x2000" since="3"/>
+      <entry name="shaded" value="0x4000" since="3"/>
+      <entry name="movable" value="0x8000" since="3"/>
+      <entry name="resizable" value="0x10000" since="3"/>
+      <entry name="virtual_desktop_changeable" value="0x20000" since="3"/>
+      <entry name="skipswitcher" value="0x40000" since="9"/>
+      <entry name="no_border" value="0x80000" since="19"/>
+      <entry name="can_set_no_border" value="0x100000" since="19"/>
+      <entry name="exclude_from_capture" value="0x200000" since="20"/>
+    </enum>
+
+    <enum name="show_desktop">
+        <entry name="disabled" value="0"/>
+        <entry name="enabled" value="1"/>
+    </enum>
+
+    <request name="show_desktop">
+      <description summary="show/hide the desktop">
+        Tell the compositor to show/hide the desktop.
+      </description>
+      <arg name="state" type="uint" summary="requested state"/>
+    </request>
+
+    <request name="get_window">
+        <description summary="deprecated">Deprecated: use get_window_by_uuid</description>
+        <arg name="id" type="new_id" interface="org_kde_plasma_window"/>
+        <arg name="internal_window_id" type="uint" summary="The internal window id of the window to create"/>
+    </request>
+
+    <request name="get_window_by_uuid" since="12">
+        <arg name="id" type="new_id" interface="org_kde_plasma_window"/>
+        <arg name="internal_window_uuid" type="string" summary="The internal window uuiid of the window to create"/>
+    </request>
+
+    <event name="show_desktop_changed">
+        <description summary="notify the client when the show desktop mode is entered/left">
+            This event will be sent whenever the show desktop mode changes. E.g. when it is entered
+            or left.
+
+            On binding the interface the current state is sent.
+        </description>
+      <arg name="state" type="uint" summary="new state"/>
+    </event>
+
+    <event name="window">
+      <description summary="notify the client that a window was mapped">
+        This event will be sent immediately after a window is mapped.
+      </description>
+      <arg name="id" type="uint" summary="Deprecated: internal window Id"/>
+    </event>
+
+    <event name="stacking_order_changed" since="11">
+      <description summary="notify the client when stacking order changed">
+        This event will be sent when stacking order changed and on bind.
+
+        With version 17 this event is deprecated and will no longer be sent.
+      </description>
+      <arg name="ids" type="array" summary="internal windows id array"/>
+    </event>
+
+    <event name="stacking_order_uuid_changed" since="12">
+      <description summary="notify the client when stacking order changed">
+        This event will be sent when stacking order changed and on bind.
+
+        With version 17 this event is deprecated and will no longer be sent.
+      </description>
+      <arg name="uuids" type="string" summary="internal windows id ;-separated"/>
+    </event>
+
+    <event name="window_with_uuid" since="13">
+      <description summary="notify the client that a window was mapped">
+        This event will be sent immediately after a window is mapped.
+      </description>
+      <arg name="id" type="uint" summary="Deprecated: internal window Id"/>
+      <arg name="uuid" type="string" summary="internal window uuid"/>
+    </event>
+
+    <event name="stacking_order_changed_2" since="17">
+      <description summary="notify the client when stacking order changed">
+        This event will be sent when stacking order changed.
+      </description>
+    </event>
+
+    <request name="get_stacking_order" since="17">
+      <description summary="get the stacking order"/>
+      <arg name="stacking_order" type="new_id" interface="org_kde_plasma_stacking_order"/>
+    </request>
+  </interface>
+
+  <interface name="org_kde_plasma_window" version="20">
+    <description summary="interface to control application windows">
+      Manages and control an application window.
+
+      Only one client can bind this interface at a time.
+    </description>
+
+    <request name="set_state">
+      <description summary="set window state">
+        Set window state.
+
+        Values for state argument are described by org_kde_plasma_window_management.state
+        and can be used together in a bitfield. The flags bitfield describes which flags are
+        supposed to be set, the state bitfield the value for the set flags
+      </description>
+      <arg name="flags" type="uint" summary="bitfield of set state flags"/>
+      <arg name="state" type="uint" summary="bitfield of state flags"/>
+    </request>
+
+    <request name="set_virtual_desktop">
+      <description summary="map window on a virtual desktop">
+          Deprecated: use enter_virtual_desktop
+        Maps the window to a different virtual desktop.
+
+        To show the window on all virtual desktops, call the
+        org_kde_plasma_window.set_state request and specify a on_all_desktops
+        state in the bitfield.
+      </description>
+      <arg name="number" type="uint" summary="zero based virtual desktop number"/>
+    </request>
+
+    <request name="set_minimized_geometry">
+      <description summary="set the geometry for a taskbar entry">
+        Sets the geometry of the taskbar entry for this window.
+        The geometry is relative to a panel in particular.
+      </description>
+      <arg name="panel" type="object" interface="wl_surface"/>
+      <arg name="x" type="uint"/>
+      <arg name="y" type="uint"/>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </request>
+
+    <request name="unset_minimized_geometry">
+      <description summary="set the geometry for a taskbar entry">
+        Remove the task geometry information for a particular panel.
+      </description>
+      <arg name="panel" type="object" interface="wl_surface"/>
+    </request>
+
+  <!--
+    <request name="highlight">
+      <description summary="highlight the window">
+        Tell the compositor to highlight this window.
+      </description>
+    </request>
+  -->
+
+    <request name="close">
+      <description summary="close window">
+        Close this window.
+      </description>
+    </request>
+
+    <request name="request_move" since="3">
+      <description summary="request move">
+        Request an interactive move for this window.
+      </description>
+    </request>
+
+    <request name="request_resize" since="3">
+      <description summary="request resize">
+        Request an interactive resize for this window.
+      </description>
+    </request>
+
+    <request name="destroy" type="destructor" since="4">
+      <description summary="remove resource for the org_kde_plasma_window">
+        Removes the resource bound for this org_kde_plasma_window.
+      </description>
+    </request>
+
+    <request name="get_icon" since="7">
+      <description summary="Requests to get the window icon">
+        The compositor will write the window icon into the provided file descriptor.
+        The data is a serialized QIcon with QDataStream.
+      </description>
+      <arg name="fd" type="fd" summary="file descriptor for the icon"/>
+    </request>
+
+    <event name="title_changed">
+      <description summary="window title has been changed">
+        This event will be sent as soon as the window title is changed.
+      </description>
+      <arg name="title" type="string" summary="window title"/>
+    </event>
+
+    <event name="app_id_changed">
+      <description summary="application identifier has been changed">
+        This event will be sent as soon as the application
+        identifier is changed.
+      </description>
+      <arg name="app_id" type="string"/>
+    </event>
+
+    <event name="state_changed">
+      <description summary="window state has been changed">
+        This event will be sent as soon as the window state changes.
+
+        Values for state argument are described by org_kde_plasma_window_management.state.
+      </description>
+      <arg name="flags" type="uint" summary="bitfield of state flags"/>
+    </event>
+
+    <event name="virtual_desktop_changed">
+      <description summary="window was moved to another workspace">
+          DEPRECATED: use virtual_desktop_entered and virtual_desktop_left instead
+        This event will be sent when a window is moved to another
+        virtual desktop.
+
+        It is not sent if it becomes visible on all virtual desktops though.
+      </description>
+      <arg name="number" type="int" summary="zero based virtual desktop number"/>
+    </event>
+
+    <event name="themed_icon_name_changed">
+        <description summary="window's icon name changed">
+            This event will be sent whenever the themed icon name changes. May be null.
+        </description>
+        <arg name="name" type="string" summary="the new themed icon name"/>
+    </event>
+
+    <event name="unmapped">
+      <description summary="window's surface was unmapped">
+        This event will be sent immediately after the window is closed
+        and its surface is unmapped.
+      </description>
+    </event>
+
+    <event name="initial_state" since="4">
+        <description summary="All initial known state is submitted">
+            This event will be sent immediately after all initial state been sent to the client.
+            If the Plasma window is already unmapped, the unmapped event will be sent before the
+            initial_state event.
+        </description>
+    </event>
+
+    <event name="parent_window" since="5">
+        <description summary="The parent window changed">
+            This event will be sent whenever the parent window of this org_kde_plasma_window changes.
+            The passed parent is another org_kde_plasma_window and this org_kde_plasma_window is a
+            transient window to the parent window. If the parent argument is null, this
+            org_kde_plasma_window does not have a parent window.
+        </description>
+        <arg name="parent" type="object" interface="org_kde_plasma_window" summary="The parent window" allow-null="true"/>
+    </event>
+
+    <event name="geometry" since="6">
+        <description summary="The geometry of this window in absolute coordinates">
+            This event will be sent whenever the window geometry of this org_kde_plasma_window changes.
+            The coordinates are in absolute coordinates of the windowing system.
+        </description>
+        <arg name="x" type="int" summary="x position of the org_kde_plasma_window"/>
+        <arg name="y" type="int" summary="y position of the org_kde_plasma_window"/>
+        <arg name="width" type="uint" summary="width of the org_kde_plasma_window"/>
+        <arg name="height" type="uint" summary="height of the org_kde_plasma_window"/>
+    </event>
+
+    <event name="icon_changed" since="7">
+        <description summary="The icon of the window changed">
+            This event will be sent whenever the icon of the window changes, but there is no themed
+            icon name. Common examples are Xwayland windows which have a pixmap based icon.
+
+            The client can request the icon using get_icon.
+        </description>
+    </event>
+
+    <event name="pid_changed">
+      <description summary="process id of application owning the window has changed">
+        This event will be sent when the compositor has set the process id this window belongs to.
+        This should be set once before the initial_state is sent.
+      </description>
+      <arg name="pid" type="uint" summary="process id"/>
+    </event>
+
+
+
+
+    <request name="request_enter_virtual_desktop" since="8">
+      <description summary="map window on a virtual desktop">
+        Make the window enter a virtual desktop. A window can enter more
+        than one virtual desktop. if the id is empty or invalid, no action will be performed.
+      </description>
+      <arg name="id" type="string" summary="desktop id"/>
+    </request>
+
+    <request name="request_enter_new_virtual_desktop" since="8">
+      <description summary="map window on a virtual desktop">RFC: do this with an empty id to request_enter_virtual_desktop?
+        Make the window enter a new virtual desktop. If the server consents the request,
+        it will create a new virtual desktop and assign the window to it.
+      </description>
+    </request>
+
+    <request name="request_leave_virtual_desktop" since="8">
+      <description summary="remove a window from a virtual desktop">
+        Make the window exit a virtual desktop. If it exits all desktops it will be considered on all of them.
+      </description>
+      <arg name="id" type="string" summary="desktop id"/>
+    </request>
+
+    <event name="virtual_desktop_entered" since="8">
+      <description summary="the window entered a new virtual desktop">
+          This event will be sent when the window has entered a new virtual desktop. The window can be on more than one desktop, or none: then is considered on all of them.
+      </description>
+      <arg name="id" type="string" summary="desktop id"/>
+    </event>
+
+    <event name="virtual_desktop_left" since="8">
+      <description summary="the window left a virtual desktop">
+          This event will be sent when the window left a virtual desktop. If the window leaves all desktops, it can be considered on all.
+          If the window gets manually added on all desktops, the server has to send virtual_desktop_left for every previous desktop it was in for the window to be really considered on all desktops.
+      </description>
+      <arg name="is" type="string" summary="desktop id"/>
+    </event>
+
+    <!-- Version 10 additions -->
+
+    <event name="application_menu" since="10">
+      <description summary="notify the client that the current appmenu changed">
+          This event will be sent after the application menu
+          for the window has changed.
+      </description>
+      <arg name="service_name" type="string" />
+      <arg name="object_path" type="string" />
+    </event>
+
+    <request name="request_enter_activity" since="14">
+      <description summary="map window on an activity">
+        Make the window enter an activity. A window can enter more activity. If the id is empty or invalid, no action will be performed.
+      </description>
+      <arg name="id" type="string" summary="activity id"/>
+    </request>
+
+    <request name="request_leave_activity" since="14">
+      <description summary="remove a window from an activity">
+        Make the window exit a an activity. If it exits all activities it will be considered on all of them.
+      </description>
+      <arg name="id" type="string" summary="activity id"/>
+    </request>
+
+    <event name="activity_entered" since="14">
+      <description summary="the window entered an activity">
+        This event will be sent when the window has entered an activity. The window can be on more than one activity, or none: then is considered on all of them.
+      </description>
+      <arg name="id" type="string" summary="activity id"/>
+    </event>
+
+    <event name="activity_left" since="14">
+      <description summary="the window left an activity">
+        This event will be sent when the window left an activity. If the window leaves all activities, it will be considered on all.
+        If the window gets manually added on all activities, the server has to send activity_left for every previous activity it was in for the window to be really considered on all activities.
+      </description>
+      <arg name="id" type="string" summary="activity id"/>
+    </event>
+
+    <request name="send_to_output" since="15">
+     <description summary="send window to specified output">
+        Requests this window to be displayed in a specific output.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <event name="resource_name_changed" since="16">
+      <description summary="X11 resource name has changed">
+        This event will be sent when the X11 resource name of the window has changed.
+        This is only set for XWayland windows.
+      </description>
+      <arg name="resource_name" type="string" summary="resource name"/>
+    </event>
+
+    <event name="client_geometry" since="18">
+      <description summary="The client geometry (i.e. without decorations etc) of this window in absolute coordinates">
+        This event will be sent whenever the window geometry of this org_kde_plasma_window changes.
+        The coordinates are in absolute coordinates of the windowing system.
+      </description>
+      <arg name="x" type="int" summary="x position of the org_kde_plasma_window"/>
+      <arg name="y" type="int" summary="y position of the org_kde_plasma_window"/>
+      <arg name="width" type="uint" summary="width of the org_kde_plasma_window"/>
+      <arg name="height" type="uint" summary="height of the org_kde_plasma_window"/>
+    </event>
+  </interface>
+
+  <interface name="org_kde_plasma_activation_feedback" version="1">
+    <description summary="activation feedback">
+      The activation manager interface provides a way to get notified
+      when an application is about to be activated.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the activation manager object">
+        Destroy the activation manager object. The activation objects introduced
+        by this manager object will be unaffected.
+      </description>
+    </request>
+
+    <event name="activation">
+      <description summary="notify that an app is starting">
+        Will be issued when an app is set to be activated. It offers
+        an instance of org_kde_plasma_activation that will tell us the app_id
+        and the extent of the activation.
+      </description>
+      <arg name="id" type="new_id" interface="org_kde_plasma_activation"/>
+    </event>
+  </interface>
+
+  <interface name="org_kde_plasma_activation" version="1">
+    <request name="destroy" type="destructor">
+      <description summary="destroy the org_kde_plasma_activation object">
+        Notify the compositor that the org_kde_plasma_activation object will no
+        longer be used.
+      </description>
+    </request>
+
+    <event name="app_id">
+      <description summary="Offers the app_id"></description>
+      <arg name="app_id" type="string" summary="application id, as described in xdg_activation_v1"/>
+    </event>
+
+    <event name="finished">
+        <description summary="Notifies about activation finished, either by activation or because it got invalidated"></description>
+    </event>
+  </interface>
+
+  <interface name="org_kde_plasma_stacking_order" version="17">
+    <description summary="helper object for sending the stacking order">
+      When this object is created, the compositor sends a window event for
+      each window in the stacking order, and afterwards sends the done event
+      and destroys this object.
+    </description>
+
+    <event name="window">
+      <description summary="a window in the stacking order list"/>
+      <arg name="uuid" type="string" summary="window uuid"/>
+    </event>
+
+    <event name="done" type="destructor">
+      <description summary="marks the end of the list"/>
+    </event>
+  </interface>
+</protocol>


### PR DESCRIPTION
## What does this change?

Closes #355.

KWin's Magic Lamp animates a window into its icon geometry — the rect its taskbar entry occupies. Nothing was publishing one: the dock is a Quickshell surface rather than a Plasma panel, so every window had an invalid icon geometry and the effect fell back to guessing from the pointer. That is why the animation chased the cursor, and why putting a real Plasma panel under the dock worked around it, at the cost of that panel still reserving space.

Each dock tile's rect is now published through the taskbar side of plasma-window-management, the same mechanism Plasma's own Task Manager uses.

Cost of the change is small:

- The protocol XML is vendored next to the two already in `shell/plugin/src/Caelestia/protocols`, so this adds **no** runtime or packaging dependency.
- The shell's desktop file already requests `org_kde_plasma_window_management`, so it adds **no** new privilege.
- `Qt::GuiPrivate` comes along for `QPlatformNativeInterface`, which is the only way to reach a `QWindow`'s `wl_surface` — Qt exposes no public native interface for it. It ships with `qt6-base` on Arch and `qt6-qtbase-private-devel` on Fedora, both of which setup already installs.

## How did you test it?

Measured rather than eyeballed, since "the animation looks right" is hard to argue about:

- Queried `iconGeometry` for every window through the KWin scripting API. Before: `0,0 0x0` on every window, i.e. invalid, which is exactly the condition that makes Magic Lamp fall back to the cursor. After: each window reports a distinct real rect on the bar strip (`1066,1394 32x32`, `978,1394 32x32`, ...), matching its own dock tile.
- Confirmed visually that minimize now animates into the window's own tile, including when the pointer is parked over a different tile — that is the case where the old behaviour was obvious.
- Exercised the protocol in an isolated second Quickshell instance before letting it near a real session, checking that the extension binds, that a valid and a bogus uuid both behave, and that the process exits cleanly with no coredump.
- Running in a live shell since.

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Config / theme
- [ ] Docs
- [ ] Refactor
- [ ] Other

## Notes for reviewers

Three things the protocol forced, each with a reason that is not obvious from the diff:

**Proxies are released from `aboutToQuit`, not from destructors.** Releasing a Wayland proxy is itself a request, so it has to happen while the connection is up. A QML singleton's children are destroyed from an exit handler, long after Qt has closed the display, and marshalling there segfaults the shell as it quits. A latched flag makes anything destroyed later leak its proxy rather than touch it. Same reason the management global is owned by the singleton instead of living in a function-local static. (#426 fixes a pre-existing instance of this same trap in the screencast code; the two are independent.)

**`setGeometry` takes the tile item, not a window and a rect.** The protocol wants surface-relative coordinates, which is exactly what mapping the item into its own scene gives — and QML cannot pass a `QWindow` to C++ at all, it throws before the call is made.

**Rects are re-read on a slow timer rather than from bindings.** A tile moves for reasons no single binding can watch: the bar sliding in and out, the dock list scrolling, a drag reordering tiles. `mapToScene` is a plain call that never re-runs by itself. Unchanged rects are dropped before they reach the wire, so a dock at rest sends nothing; if you would rather see this driven by explicit change signals I am happy to try, but I could not find a set that covers all three cases.

This touches `Dock.qml`, as does #424 — different regions, and merging both locally was conflict-free, but flagging it in case order matters to you.