### PR TITLE
feat: resolve icons for Wayland windows through the compositor

### DIFF
--- a/shell/modules/bar/components/Dock.qml
+++ b/shell/modules/bar/components/Dock.qml
@@ -697,7 +697,7 @@ Item {
                 // these (every unmapped Proton title is "steam_app_default").
                 const pid = ipc.pid || 0;
                 if (!entry)
-                    WinIcons.request(appClass, ipc.title || "", pid);
+                    WinIcons.request(appClass, ipc.title || "", pid, ipc.address ? String(ipc.address) : "");
 
                 apps.push({
                     id: appClass,

--- a/shell/modules/launcher/items/WindowSwitcherItem.qml
+++ b/shell/modules/launcher/items/WindowSwitcherItem.qml
@@ -44,7 +44,7 @@ Item {
         opacity = 1;
 
         if (root.modelData) {
-            WinIcons.request(root.modelData.class, root.modelData.title, root.modelData.pid ?? 0);
+            WinIcons.request(root.modelData.class, root.modelData.title, root.modelData.pid ?? 0, root.modelData.address ? String(root.modelData.address) : "");
         }
 
         Qt.callLater(() => {

--- a/shell/plugin/src/Caelestia/Services/CMakeLists.txt
+++ b/shell/plugin/src/Caelestia/Services/CMakeLists.txt
@@ -59,6 +59,10 @@ qml_module(caelestia-services
         windowicon.hpp
         minimizegeometry.cpp
         minimizegeometry.hpp
+        plasmawindows.cpp
+        plasmawindows.hpp
+        plasmawindowicon.cpp
+        plasmawindowicon.hpp
     LIBRARIES
         Qt::DBus
         Qt::Gui

--- a/shell/plugin/src/Caelestia/Services/minimizegeometry.cpp
+++ b/shell/plugin/src/Caelestia/Services/minimizegeometry.cpp
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 #include "minimizegeometry.hpp"
 
-#include <QCoreApplication>
+#include "plasmawindows.hpp"
+
 #include <QGuiApplication>
-#include <QLoggingCategory>
-#include <QUuid>
 #include <QQuickWindow>
 #include <QWindow>
 
@@ -13,20 +12,6 @@
 namespace caelestia::services {
 
 namespace {
-
-Q_LOGGING_CATEGORY(logMinimizeGeometry, "caelestia.services.minimizegeometry");
-
-// get_window_by_uuid, which is what lets us address a window without mirroring
-// KWin's entire window list.
-constexpr int kRequiredVersion = 12;
-
-// Set once the Wayland connection is on its way out. Releasing a proxy is
-// itself a request, so doing it after the connection is gone marshals onto
-// freed memory and takes the whole shell down with a SIGSEGV — which is
-// exactly what happened before this existed. Everything is released up front
-// from aboutToQuit, while the connection is still live; anything that survives
-// past that point must let its proxy leak rather than touch it.
-bool s_connectionGone = false;
 
 /// The wl_surface backing a QWindow, or nullptr before it has been shown.
 wl_surface* surfaceFor(QWindow* window) {
@@ -41,105 +26,14 @@ wl_surface* surfaceFor(QWindow* window) {
     return static_cast<wl_surface*>(native->nativeResourceForWindow(QByteArrayLiteral("surface"), window));
 }
 
-/// KWin hands out window ids as QUuid::toString(), i.e. brace-wrapped. Callers
-/// pass those through from the KWin bridge, but normalise anyway: a uuid that
-/// differs only in its braces resolves to a window that is immediately
-/// unmapped, which looks exactly like the protocol silently doing nothing.
-QString normaliseUuid(const QString& uuid) {
-    const auto parsed = QUuid::fromString(uuid);
-    return parsed.isNull() ? uuid : parsed.toString(QUuid::WithBraces);
-}
-
 } // namespace
-
-PlasmaWindowHandle::PlasmaWindowHandle(::org_kde_plasma_window* window)
-    : QtWayland::org_kde_plasma_window(window) {}
-
-PlasmaWindowHandle::~PlasmaWindowHandle() {
-    if (!s_connectionGone && isInitialized()) {
-        destroy();
-    }
-}
-
-void PlasmaWindowHandle::org_kde_plasma_window_unmapped() {
-    emit unmapped();
-}
-
-PlasmaWindowManagement::PlasmaWindowManagement(QObject* parent)
-    : QWaylandClientExtensionTemplate<PlasmaWindowManagement>(kRequiredVersion) {
-    setParent(parent);
-    initialize();
-    if (!isInitialized() || !isActive()) {
-        qCWarning(logMinimizeGeometry)
-            << "org_kde_plasma_window_management is not available (isInitialized:" << isInitialized()
-            << ", isActive:" << isActive() << "). Minimize animations will fall back to the cursor."
-            << "The compositor may not support it at version" << kRequiredVersion
-            << "or this app is missing org_kde_plasma_window_management from"
-               " X-KDE-Wayland-Interfaces in its desktop file.";
-    }
-}
-
-// org_kde_plasma_window_management has no destructor request, so there is
-// nothing to release here beyond the base class teardown.
-PlasmaWindowManagement::~PlasmaWindowManagement() = default;
 
 MinimizeGeometry::MinimizeGeometry(QObject* parent)
     : QObject(parent) {
-    // Tear down while the connection is still usable. QML singletons outlive
-    // the Wayland display on the way out, so waiting for the destructor is too
-    // late to release anything.
-    if (auto* app = QCoreApplication::instance()) {
-        connect(app, &QCoreApplication::aboutToQuit, this, &MinimizeGeometry::shutdown);
-    }
-}
-
-void MinimizeGeometry::shutdown() {
-    if (s_connectionGone) {
-        return;
-    }
-
-    const auto uuids = m_handles.keys();
-    for (const auto& uuid : uuids) {
-        delete m_handles.take(uuid);
-    }
-    m_published.clear();
-
-    delete m_management;
-    m_management = nullptr;
-
-    s_connectionGone = true;
-}
-
-PlasmaWindowHandle* MinimizeGeometry::handleFor(const QString& uuid) {
-    if (s_connectionGone) {
-        return nullptr;
-    }
-    if (const auto it = m_handles.constFind(uuid); it != m_handles.constEnd()) {
-        return *it;
-    }
-
-    if (!m_management) {
-        m_management = new PlasmaWindowManagement(this);
-    }
-    if (!m_management->isActive()) {
-        return nullptr;
-    }
-
-    auto* handle = new PlasmaWindowHandle(m_management->get_window_by_uuid(uuid));
-    handle->setParent(this);
-    // The compositor answers an unknown uuid with an immediately unmapped
-    // window rather than an error, so this doubles as the "no such window"
-    // path: drop it and let the next call ask again.
-    connect(handle, &PlasmaWindowHandle::unmapped, this, [this, uuid]() { forget(uuid); });
-    m_handles.insert(uuid, handle);
-    return handle;
-}
-
-void MinimizeGeometry::forget(const QString& uuid) {
-    if (auto* handle = m_handles.take(uuid)) {
-        handle->deleteLater();
-    }
-    m_published.remove(uuid);
+    // A handle that goes away takes the published rect with it, so the next
+    // call has to send afresh rather than dedupe against a stale value.
+    connect(PlasmaWindows::instance(), &PlasmaWindows::handleLost, this,
+        [this](const QString& uuid) { m_published.remove(uuid); });
 }
 
 void MinimizeGeometry::setGeometry(QQuickItem* tile, const QString& uuid) {
@@ -157,12 +51,12 @@ void MinimizeGeometry::setGeometry(QQuickItem* tile, const QString& uuid) {
     const auto topLeft = tile->mapToScene(QPointF(0, 0));
     const QRect rect(qRound(topLeft.x()), qRound(topLeft.y()), qRound(tile->width()), qRound(tile->height()));
 
-    const auto key = normaliseUuid(uuid);
+    const auto key = PlasmaWindows::normaliseUuid(uuid);
     if (m_published.value(key) == rect) {
         return;
     }
 
-    auto* handle = handleFor(key);
+    auto* handle = PlasmaWindows::instance()->handleFor(key);
     if (!handle) {
         return;
     }
@@ -180,17 +74,17 @@ void MinimizeGeometry::clearGeometry(QQuickItem* tile, const QString& uuid) {
         return;
     }
 
-    const auto key = normaliseUuid(uuid);
+    const auto key = PlasmaWindows::normaliseUuid(uuid);
     if (!m_published.contains(key)) {
         return;
     }
 
     if (auto* surface = tile ? surfaceFor(tile->window()) : nullptr) {
-        if (const auto it = m_handles.constFind(key); it != m_handles.constEnd()) {
-            (*it)->unset_minimized_geometry(surface);
+        if (auto* handle = PlasmaWindows::instance()->handleFor(key)) {
+            handle->unset_minimized_geometry(surface);
         }
     }
-    forget(key);
+    m_published.remove(key);
 }
 
 } // namespace caelestia::services

--- a/shell/plugin/src/Caelestia/Services/minimizegeometry.hpp
+++ b/shell/plugin/src/Caelestia/Services/minimizegeometry.hpp
@@ -13,47 +13,17 @@
 //
 // The taskbar side of the plasma-window-management protocol is what Plasma's
 // own Task Manager uses for this (libtaskmanager sets it from the task
-// delegate's rect). The shell already requests org_kde_plasma_window_management
-// in its desktop file for window metadata, so no new privilege is involved.
+// delegate's rect).
 
 #include <QHash>
 #include <QObject>
 #include <QQmlEngine>
-#include <QRect>
 // Full definition, not a forward declaration: moc needs it to register the
 // Q_INVOKABLE pointer argument below as a metatype.
 #include <QQuickItem>
-#include <QtWaylandClient/QWaylandClientExtension>
-
-#include "qwayland-plasma-window-management.h"
+#include <QRect>
 
 namespace caelestia::services {
-
-/// One org_kde_plasma_window handle, held for as long as the shell has a
-/// taskbar rect to publish for that window.
-class PlasmaWindowHandle : public QObject, public QtWayland::org_kde_plasma_window {
-    Q_OBJECT
-
-public:
-    explicit PlasmaWindowHandle(::org_kde_plasma_window* window);
-    ~PlasmaWindowHandle() override;
-
-signals:
-    /// The compositor dropped the window; the handle is spent after this.
-    void unmapped();
-
-protected:
-    void org_kde_plasma_window_unmapped() override;
-};
-
-class PlasmaWindowManagement : public QWaylandClientExtensionTemplate<PlasmaWindowManagement>,
-                               public QtWayland::org_kde_plasma_window_management {
-    Q_OBJECT
-
-public:
-    explicit PlasmaWindowManagement(QObject* parent = nullptr);
-    ~PlasmaWindowManagement() override;
-};
 
 class MinimizeGeometry : public QObject {
     Q_OBJECT
@@ -81,18 +51,6 @@ public:
     Q_INVOKABLE void clearGeometry(QQuickItem* tile, const QString& uuid);
 
 private:
-    PlasmaWindowHandle* handleFor(const QString& uuid);
-    void forget(const QString& uuid);
-    /// Release every proxy while the connection is still up. See the .cpp.
-    void shutdown();
-
-    // Bound lazily and owned here rather than through a function-local static.
-    // A static is torn down from an exit handler, long after Qt has closed the
-    // Wayland connection.
-    PlasmaWindowManagement* m_management = nullptr;
-    // Parented to this, so they also go away with the service. Raw pointers
-    // rather than unique_ptr because QHash requires a copyable value type.
-    QHash<QString, PlasmaWindowHandle*> m_handles;
     QHash<QString, QRect> m_published;
 };
 

--- a/shell/plugin/src/Caelestia/Services/plasmawindowicon.cpp
+++ b/shell/plugin/src/Caelestia/Services/plasmawindowicon.cpp
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-3.0-only
+#include "plasmawindowicon.hpp"
+
+#include "plasmawindows.hpp"
+
+#include <QBuffer>
+#include <QCryptographicHash>
+#include <QDataStream>
+#include <QDir>
+#include <QFile>
+#include <QIcon>
+#include <QLoggingCategory>
+#include <QSocketNotifier>
+#include <QStandardPaths>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+namespace caelestia::services {
+
+namespace {
+
+Q_LOGGING_CATEGORY(logPlasmaWindowIcon, "caelestia.services.plasmawindowicon");
+
+/// Largest pixmap the icon can give us, so the dock has something to scale down
+/// from rather than up.
+QImage largestPixmap(const QIcon& icon) {
+    QSize best;
+    const auto sizes = icon.availableSizes();
+    for (const auto& size : sizes) {
+        if (static_cast<qint64>(size.width()) * size.height() > static_cast<qint64>(best.width()) * best.height()) {
+            best = size;
+        }
+    }
+
+    // An icon with no advertised sizes can still be scalable, so ask for
+    // something reasonable rather than giving up.
+    if (!best.isValid()) {
+        best = QSize(256, 256);
+    }
+    return icon.pixmap(best).toImage();
+}
+
+} // namespace
+
+PlasmaWindowIcon::PlasmaWindowIcon(QObject* parent)
+    : QObject(parent) {
+    connect(PlasmaWindows::instance(), &PlasmaWindows::handleLost, this, [this](const QString& uuid) {
+        m_resolved.remove(uuid);
+        m_inFlight.remove(uuid);
+    });
+}
+
+void PlasmaWindowIcon::request(const QString& uuid) {
+    if (uuid.isEmpty()) {
+        return;
+    }
+
+    const auto key = PlasmaWindows::normaliseUuid(uuid);
+    if (const auto it = m_resolved.constFind(key); it != m_resolved.constEnd()) {
+        emit resolved(key, *it);
+        return;
+    }
+    if (m_inFlight.contains(key)) {
+        return;
+    }
+
+    auto* handle = PlasmaWindows::instance()->handleFor(key);
+    if (!handle) {
+        return;
+    }
+
+    // The compositor writes the icon into the far end of a pipe from its own
+    // thread, so this cannot be read inline — the write blocks until someone
+    // drains it.
+    int fds[2];
+    if (::pipe2(fds, O_CLOEXEC | O_NONBLOCK) != 0) {
+        qCWarning(logPlasmaWindowIcon) << "could not create a pipe for" << key;
+        return;
+    }
+
+    handle->get_icon(fds[1]);
+    // Ours to close: the request duplicates what it needs. Leaving it open
+    // would mean never seeing EOF.
+    ::close(fds[1]);
+
+    m_inFlight.insert(key);
+
+    const int readFd = fds[0];
+    auto* payload = new QByteArray();
+    auto* notifier = new QSocketNotifier(readFd, QSocketNotifier::Read, this);
+
+    connect(notifier, &QSocketNotifier::activated, this, [this, notifier, readFd, payload, key]() {
+        char chunk[4096];
+        for (;;) {
+            const auto got = ::read(readFd, chunk, sizeof(chunk));
+            if (got > 0) {
+                payload->append(chunk, static_cast<int>(got));
+                continue;
+            }
+            if (got < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                return; // more to come
+            }
+
+            // 0 is EOF, anything else is a broken pipe; either way we are done.
+            notifier->setEnabled(false);
+            notifier->deleteLater();
+            ::close(readFd);
+            m_inFlight.remove(key);
+
+            const QByteArray data = *payload;
+            delete payload;
+            deliver(key, data);
+            return;
+        }
+    });
+}
+
+void PlasmaWindowIcon::deliver(const QString& uuid, const QByteArray& payload) {
+    if (payload.isEmpty()) {
+        return;
+    }
+
+    QIcon icon;
+    QDataStream stream(payload);
+    stream >> icon;
+    if (stream.status() != QDataStream::Ok || icon.isNull()) {
+        qCDebug(logPlasmaWindowIcon) << "no usable icon for" << uuid;
+        return;
+    }
+
+    const auto image = largestPixmap(icon);
+    if (image.isNull()) {
+        return;
+    }
+
+    QByteArray png;
+    QBuffer buffer(&png);
+    buffer.open(QIODevice::WriteOnly);
+    if (!image.save(&buffer, "PNG")) {
+        qCWarning(logPlasmaWindowIcon) << "could not encode icon for" << uuid;
+        return;
+    }
+    buffer.close();
+
+    // Same content-addressed cache the X extractor writes to: naming files
+    // after the icon's own bytes means two windows sharing an icon share the
+    // file, and no window can ever pick up one belonging to something else.
+    const auto cacheRoot =
+        QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + QStringLiteral("/caelestia/winicons");
+    const auto digest =
+        QString::fromLatin1(QCryptographicHash::hash(png, QCryptographicHash::Sha256).toHex().left(16));
+    const auto path = cacheRoot + QStringLiteral("/") + digest + QStringLiteral(".png");
+
+    if (!QFile::exists(path)) {
+        QFile file(path);
+        if (!QDir().mkpath(cacheRoot) || !file.open(QIODevice::WriteOnly) || file.write(png) != png.size()) {
+            qCWarning(logPlasmaWindowIcon) << "could not write icon cache for" << uuid << "to" << path;
+            return;
+        }
+    }
+
+    m_resolved.insert(uuid, path);
+    emit resolved(uuid, path);
+}
+
+} // namespace caelestia::services

--- a/shell/plugin/src/Caelestia/Services/plasmawindowicon.hpp
+++ b/shell/plugin/src/Caelestia/Services/plasmawindowicon.hpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-only
+#pragma once
+
+// Asks KWin for a window's icon, for windows that cannot be served any other
+// way.
+//
+// The existing extractor reads _NET_WM_ICON straight off the window, which only
+// exists for XWayland clients. A native Wayland window with no resolvable
+// desktop entry — a game launched through Proton's Wayland path reports its own
+// exe name as the app id and matches nothing — has no X window to read and no
+// themed icon to look up, so the dock falls back to a generic placeholder.
+//
+// KWin does know the icon: it resolves it from the app id, from
+// xdg_toplevel_icon_v1, or from whatever the client set, and hands it to
+// taskbars over plasma-window-management. That is how Plasma's own Task Manager
+// draws icons on Wayland (libtaskmanager, waylandtasksmodel.cpp).
+
+#include <QHash>
+#include <QObject>
+#include <QQmlEngine>
+#include <QSet>
+
+namespace caelestia::services {
+
+class PlasmaWindowIcon : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+public:
+    explicit PlasmaWindowIcon(QObject* parent = nullptr);
+
+    /**
+     * Ask for the icon of the window with KWin's internal id @p uuid — the same
+     * value the KWin bridge reports as a window's address.
+     *
+     * The compositor answers on a pipe, so this returns immediately and
+     * resolved() carries the result. Repeat calls while one is in flight are
+     * dropped. Nothing is emitted when the window has no icon to give.
+     */
+    Q_INVOKABLE void request(const QString& uuid);
+
+signals:
+    /// @p path is a PNG in the same cache the X extractor writes to.
+    void resolved(const QString& uuid, const QString& path);
+
+private:
+    void deliver(const QString& uuid, const QByteArray& payload);
+
+    QSet<QString> m_inFlight;
+    // uuid -> path, so a second ask for a window we already have costs nothing.
+    QHash<QString, QString> m_resolved;
+};
+
+} // namespace caelestia::services

--- a/shell/plugin/src/Caelestia/Services/plasmawindows.cpp
+++ b/shell/plugin/src/Caelestia/Services/plasmawindows.cpp
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-3.0-only
+#include "plasmawindows.hpp"
+
+#include <QCoreApplication>
+#include <QLoggingCategory>
+#include <QUuid>
+
+namespace caelestia::services {
+
+namespace {
+
+Q_LOGGING_CATEGORY(logPlasmaWindows, "caelestia.services.plasmawindows");
+
+// get_window_by_uuid, which is what lets us address a window without mirroring
+// KWin's entire window list. get_icon needs 7, so 12 covers both.
+constexpr int kRequiredVersion = 12;
+
+// Set once the Wayland connection is on its way out. Releasing a proxy is
+// itself a request, so doing it afterwards marshals onto freed memory and takes
+// the shell down with a SIGSEGV. Everything is released up front from
+// aboutToQuit, while the connection is still live; anything that survives past
+// that point must let its proxy leak rather than touch it.
+bool s_connectionGone = false;
+
+} // namespace
+
+PlasmaWindowHandle::PlasmaWindowHandle(::org_kde_plasma_window* window)
+    : QtWayland::org_kde_plasma_window(window) {}
+
+PlasmaWindowHandle::~PlasmaWindowHandle() {
+    if (!s_connectionGone && isInitialized()) {
+        destroy();
+    }
+}
+
+void PlasmaWindowHandle::org_kde_plasma_window_unmapped() {
+    emit unmapped();
+}
+
+PlasmaWindowManagement::PlasmaWindowManagement(QObject* parent)
+    : QWaylandClientExtensionTemplate<PlasmaWindowManagement>(kRequiredVersion) {
+    setParent(parent);
+    initialize();
+    if (!isInitialized() || !isActive()) {
+        qCWarning(logPlasmaWindows)
+            << "org_kde_plasma_window_management is not available (isInitialized:" << isInitialized()
+            << ", isActive:" << isActive() << ")."
+            << "The compositor may not support it at version" << kRequiredVersion
+            << "or this app is missing org_kde_plasma_window_management from"
+               " X-KDE-Wayland-Interfaces in its desktop file.";
+    }
+}
+
+// org_kde_plasma_window_management has no destructor request, so there is
+// nothing to release here beyond the base class teardown.
+PlasmaWindowManagement::~PlasmaWindowManagement() = default;
+
+PlasmaWindows::PlasmaWindows(QObject* parent)
+    : QObject(parent) {
+    if (auto* app = QCoreApplication::instance()) {
+        connect(app, &QCoreApplication::aboutToQuit, this, &PlasmaWindows::shutdown);
+    }
+}
+
+PlasmaWindows* PlasmaWindows::instance() {
+    static auto* s_instance = new PlasmaWindows();
+    return s_instance;
+}
+
+QString PlasmaWindows::normaliseUuid(const QString& uuid) {
+    // A uuid that differs only in its braces resolves to a window that is
+    // immediately unmapped, which looks exactly like the protocol silently
+    // doing nothing.
+    const auto parsed = QUuid::fromString(uuid);
+    return parsed.isNull() ? uuid : parsed.toString(QUuid::WithBraces);
+}
+
+bool PlasmaWindows::available() {
+    if (s_connectionGone) {
+        return false;
+    }
+    if (!m_management) {
+        m_management = new PlasmaWindowManagement(this);
+    }
+    return m_management->isActive();
+}
+
+PlasmaWindowHandle* PlasmaWindows::handleFor(const QString& uuid) {
+    if (uuid.isEmpty() || !available()) {
+        return nullptr;
+    }
+
+    const auto key = normaliseUuid(uuid);
+    if (const auto it = m_handles.constFind(key); it != m_handles.constEnd()) {
+        return *it;
+    }
+
+    auto* handle = new PlasmaWindowHandle(m_management->get_window_by_uuid(key));
+    handle->setParent(this);
+    // The compositor answers an unknown uuid with an immediately unmapped
+    // window rather than an error, so this doubles as the "no such window"
+    // path: drop it and let the next call ask again.
+    connect(handle, &PlasmaWindowHandle::unmapped, this, [this, key]() { forget(key); });
+    m_handles.insert(key, handle);
+    return handle;
+}
+
+void PlasmaWindows::forget(const QString& uuid) {
+    if (auto* handle = m_handles.take(uuid)) {
+        handle->deleteLater();
+    }
+    emit handleLost(uuid);
+}
+
+void PlasmaWindows::shutdown() {
+    if (s_connectionGone) {
+        return;
+    }
+
+    const auto uuids = m_handles.keys();
+    for (const auto& uuid : uuids) {
+        delete m_handles.take(uuid);
+    }
+
+    delete m_management;
+    m_management = nullptr;
+
+    s_connectionGone = true;
+}
+
+} // namespace caelestia::services

--- a/shell/plugin/src/Caelestia/Services/plasmawindows.hpp
+++ b/shell/plugin/src/Caelestia/Services/plasmawindows.hpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-only
+#pragma once
+
+// Shared access to KWin's taskbar-side window handles.
+//
+// org_kde_plasma_window is what a taskbar uses to talk about a window it did
+// not create: publishing where its entry sits, asking for its icon, and so on.
+// More than one service here needs the same handle for the same window, so the
+// handles live in one place rather than each service opening its own.
+//
+// The shell already requests org_kde_plasma_window_management in its desktop
+// file, which is what makes KWin advertise this restricted interface to it.
+
+#include <QHash>
+#include <QObject>
+#include <QtWaylandClient/QWaylandClientExtension>
+
+#include "qwayland-plasma-window-management.h"
+
+namespace caelestia::services {
+
+/// One org_kde_plasma_window handle, held for as long as something has a use
+/// for the window it names.
+class PlasmaWindowHandle : public QObject, public QtWayland::org_kde_plasma_window {
+    Q_OBJECT
+
+public:
+    explicit PlasmaWindowHandle(::org_kde_plasma_window* window);
+    ~PlasmaWindowHandle() override;
+
+signals:
+    /// The compositor dropped the window; the handle is spent after this.
+    void unmapped();
+
+protected:
+    void org_kde_plasma_window_unmapped() override;
+};
+
+class PlasmaWindowManagement : public QWaylandClientExtensionTemplate<PlasmaWindowManagement>,
+                               public QtWayland::org_kde_plasma_window_management {
+    Q_OBJECT
+
+public:
+    explicit PlasmaWindowManagement(QObject* parent = nullptr);
+    ~PlasmaWindowManagement() override;
+};
+
+/**
+ * Hands out one handle per window, keyed on KWin's internal window id — the
+ * same value the KWin bridge reports as a window's address.
+ *
+ * Deliberately leaked rather than held in a destructible static. Releasing a
+ * Wayland proxy is itself a request, and a static is torn down from an exit
+ * handler, long after Qt has closed the display; marshalling there segfaults
+ * the shell on its way out. Handles are released early, from aboutToQuit,
+ * while the connection is still live.
+ */
+class PlasmaWindows : public QObject {
+    Q_OBJECT
+
+public:
+    static PlasmaWindows* instance();
+
+    /// Whether the compositor actually gave us the interface.
+    bool available();
+
+    /// The handle for @p uuid, or nullptr if the interface is unavailable or
+    /// the connection is already gone. Uuids are normalised, so callers need
+    /// not care whether theirs arrived brace-wrapped.
+    PlasmaWindowHandle* handleFor(const QString& uuid);
+
+    /// KWin hands out window ids as QUuid::toString(), i.e. brace-wrapped.
+    static QString normaliseUuid(const QString& uuid);
+
+signals:
+    /// A handle went away, so anything a service cached against @p uuid is
+    /// stale. The uuid is the normalised form.
+    void handleLost(const QString& uuid);
+
+private:
+    explicit PlasmaWindows(QObject* parent = nullptr);
+
+    void forget(const QString& uuid);
+    void shutdown();
+
+    PlasmaWindowManagement* m_management = nullptr;
+    QHash<QString, PlasmaWindowHandle*> m_handles;
+};
+
+} // namespace caelestia::services

--- a/shell/services/WinIcons.qml
+++ b/shell/services/WinIcons.qml
@@ -23,6 +23,10 @@ Singleton {
     // key -> extraction already attempted (don't re-spawn the helper)
     property var tried: ({})
 
+    // uuid -> the key its icon should be registered under, for the compositor
+    // path below, which answers asynchronously and only knows the window id.
+    property var _awaiting: ({})
+
     // Icons are tracked per window, not per class. Steam reports every Proton
     // title it cannot map to an appid as "steam_app_default", so a class-keyed
     // map served whichever of those games happened to be extracted first to all
@@ -32,10 +36,17 @@ Singleton {
         return pid > 0 ? String(pid) : (appClass || "");
     }
 
-    // Ask the plugin for the icon, at most once per window. The extraction is a
-    // direct XGetWindowProperty read on _NET_WM_ICON — no helper process, and no
-    // python-xlib/Pillow to have installed.
-    function request(appClass: string, title: string, pid: int): void {
+    // Ask for the icon, at most once per window.
+    //
+    // Two sources, in order. First a direct XGetWindowProperty read of
+    // _NET_WM_ICON — no helper process, and nothing to have installed — which
+    // covers XWayland clients. A native Wayland window has no X window to read,
+    // so fall back to asking KWin over plasma-window-management: it resolves
+    // the icon from the app id, from xdg_toplevel_icon_v1, or from whatever the
+    // client set, and hands it to taskbars. That second path is the only way to
+    // draw a Wayland game, which reports its own exe name as the app id and so
+    // matches no desktop entry either.
+    function request(appClass: string, title: string, pid: int, address: string): void {
         const key = root.keyFor(appClass, pid ?? 0);
         if (!key || root.tried[key])
             return;
@@ -45,17 +56,16 @@ Singleton {
         root.tried = t;
 
         const path = WindowIcon.extract(appClass || "", title || "", pid ?? 0);
-        if (path)
+        if (path) {
             root.register(key, path);
-    }
+            return;
+        }
 
-    // extract() returns the path directly; the signal carries the same result
-    // for any caller that did not go through request().
-    Connections {
-        target: WindowIcon
-
-        function onExtracted(key: string, path: string): void {
-            root.register(key, path);
+        if (address) {
+            const a = root._awaiting;
+            a[String(address)] = key;
+            root._awaiting = a;
+            PlasmaWindowIcon.request(String(address));
         }
     }
 
@@ -79,5 +89,26 @@ Singleton {
         if (wp)
             return "file://" + wp;
         return Quickshell.iconPath(iconName, "application-x-executable");
+    }
+
+    // extract() returns the path directly; the signal carries the same result
+    // for any caller that did not go through request().
+    Connections {
+        target: WindowIcon
+
+        function onExtracted(key: string, path: string): void {
+            root.register(key, path);
+        }
+    }
+
+    Connections {
+        target: PlasmaWindowIcon
+
+        // The uuid comes back normalised, which is also how it was stored.
+        function onResolved(uuid: string, path: string): void {
+            const key = root._awaiting[uuid];
+            if (key)
+                root.register(key, path);
+        }
     }
 }


### PR DESCRIPTION
## What does this change?

The extractor reads `_NET_WM_ICON` straight off the window, which only exists for XWayland clients. A native Wayland window with no resolvable desktop entry has no X window to read and no themed icon to look up, so the dock drew a generic placeholder for it.

Games are the case that matters. Launched through Proton's Wayland path a game reports its own exe name as the app id — `watchdogs2.exe` — which matches no desktop entry, and there is no X window behind it either, so both existing sources come up empty.

KWin does know the icon: it resolves it from the app id, from `xdg_toplevel_icon_v1`, or from whatever the client set, and hands it to taskbars over plasma-window-management. This asks for it there when the X read finds nothing — the same source Plasma's own Task Manager draws from on Wayland.

Icons land in the same content-addressed cache the X path writes to, so when both sources produce the same icon they share one file.

## How did you test it?

Against a real session that had gone fully Wayland (`_NET_CLIENT_LIST` was empty — not a single X client left, so the existing extractor could do nothing for anything on screen):

- Asked for the icon of every live window through an isolated second Quickshell instance. Five of seven resolved, including `watchdogs2.exe` and `explorer.exe`, which previously had nothing.
- The strongest check: the same game had been running under XWayland earlier in the day, and the X extractor had produced `ee9ba6a0fb3988ac.png` for it. Under Wayland, the compositor path resolved to **the same file** — the cache is content-addressed, so that is a byte-for-byte match confirming the icon is genuinely the game's and not something adjacent.
- Ran the whole chain through the QML service (`WinIcons.request` → `sourceFor`) for a Wayland window and got the cached PNG back where it would previously have returned a themed-icon fallback.
- Checked the process exits cleanly with no coredump, since this adds proxies with the lifetime constraints described in #428.
- Installed and running in a live shell.

Two windows did not resolve (`com.anthropic.Claude`, `heroic`). Both have desktop entries, so the dock already draws them correctly and never reaches this path — but worth stating that a null answer from the compositor is a normal outcome, not an error, and simply leaves the existing fallback in place.

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Config / theme
- [ ] Docs
- [ ] Refactor
- [ ] Other

## Notes for reviewers

The compositor writes the icon into a pipe from its own thread, so it cannot be read inline — the write blocks until someone drains it. The read is non-blocking on a `QSocketNotifier` and the result arrives on a signal; repeat asks while one is in flight are dropped.

The `org_kde_plasma_window` handle bookkeeping moves out of `MinimizeGeometry` into a shared owner, because two services now want the same handle for the same window and opening two of them would be wasteful. That owner is deliberately leaked rather than held in a destructible static, and releases its proxies from `aboutToQuit` — same constraint as #428, and the same trap #426 fixes in the screencast code.

One thing I deliberately did not do: subscribe to `themed_icon_name_changed` / `icon_changed` to keep icons live. Window icons effectively never change after mapping, and a one-shot ask keeps this much simpler. Easy to add if you would rather it track.
