### PR TITLE
fix: give every dock tile its own minimize rect

### DIFF
--- a/shell/modules/bar/components/Dock.qml
+++ b/shell/modules/bar/components/Dock.qml
@@ -88,13 +88,29 @@ Item {
             // The nearest edge is where it would scroll back in from.
             const offset = Math.max(0, Math.min(i * step - scrolled, span - size));
 
-            const x = Math.round(horizontal ? origin.x + offset : origin.x);
-            const y = Math.round(horizontal ? origin.y : origin.y + offset);
+            let x = Math.round(horizontal ? origin.x + offset : origin.x);
+            let y = Math.round(horizontal ? origin.y : origin.y + offset);
+            let w = size;
+            let h = size;
+
+            if (Config.bar.position === "left") {
+                w = x + size;
+                x = 0;
+            } else if (Config.bar.position === "right") {
+                const winW = win ? win.width : 0;
+                w = winW > 0 ? winW - x : size;
+            } else if (Config.bar.position === "top") {
+                h = y + size;
+                y = 0;
+            } else if (Config.bar.position === "bottom") {
+                const winH = win ? win.height : 0;
+                h = winH > 0 ? winH - y : size;
+            }
 
             for (let j = 0; j < tops.length; j++) {
                 const address = tops[j]?.address;
                 if (address)
-                    MinimizeGeometry.setGeometry(root, String(address), x, y, size, size);
+                    MinimizeGeometry.setGeometry(root, String(address), x, y, w, h);
             }
         }
     }

--- a/shell/modules/bar/components/Dock.qml
+++ b/shell/modules/bar/components/Dock.qml
@@ -36,21 +36,68 @@ Item {
 
     HoverHandler { id: dockHover }
 
-    // Drives the icon-geometry publishing below. A tile's rect on screen moves
-    // for reasons no single binding can watch — the bar sliding in and out, the
+    // Re-publishes the icon geometry below. A tile's rect on screen moves for
+    // reasons no single binding can watch — the bar sliding in and out, the
     // dock list scrolling, a drag reordering tiles — and mapToItem() is a plain
     // call that never re-runs on its own. Re-reading a handful of rects twice a
     // second covers all of it, and MinimizeGeometry drops rects that have not
     // actually changed, so a steady dock sends nothing over the wire.
     Timer {
-        id: minimizeGeometryTicker
-
         interval: 500
         repeat: true
         running: root.visible
+        onTriggered: root.publishMinimizeGeometry()
     }
 
     ListModel { id: dockModel }
+
+    // Tell KWin where each app's taskbar entry sits, so minimize/restore
+    // effects animate into the dock instead of guessing from the cursor.
+    //
+    // The rects are derived from the list's own geometry and the entry's index
+    // rather than from each delegate: a delegate reports position 0 here, so
+    // asking it gave every window the same rect — whichever tile published last
+    // won, and every app animated to that one spot.
+    //
+    // This component is also instantiated where it has no bar to sit on (with
+    // no window, or laid out to zero size). Those copies have no meaningful
+    // rect to offer and would otherwise overwrite the real dock's, so they are
+    // skipped rather than allowed to publish nonsense.
+    function publishMinimizeGeometry(): void {
+        const win = QsWindow.window;
+        if (!win || listView.width <= 0 || listView.height <= 0)
+            return;
+
+        const horizontal = bar.isHorizontal;
+        const origin = listView.mapToItem(null, 0, 0);
+        const size = Math.round(container.itemSize);
+        const step = container.itemSize + root.spacing;
+        const span = horizontal ? listView.width : listView.height;
+        const scrolled = horizontal ? listView.contentX : listView.contentY;
+
+        for (let i = 0; i < root.modelDataArray.length; i++) {
+            const tops = root.modelDataArray[i]?.toplevels ?? [];
+            if (tops.length === 0)
+                continue;
+
+            // Where this entry sits along the list, accounting for scrolling,
+            // clamped to the strip the list actually occupies. A tile scrolled
+            // out of view has no rect of its own, and leaving the last one
+            // published would point the animation at wherever the dock used to
+            // be — stale across a scroll, and badly wrong across a bar move.
+            // The nearest edge is where it would scroll back in from.
+            const offset = Math.max(0, Math.min(i * step - scrolled, span - size));
+
+            const x = Math.round(horizontal ? origin.x + offset : origin.x);
+            const y = Math.round(horizontal ? origin.y : origin.y + offset);
+
+            for (let j = 0; j < tops.length; j++) {
+                const address = tops[j]?.address;
+                if (address)
+                    MinimizeGeometry.setGeometry(root, String(address), x, y, size, size);
+            }
+        }
+    }
 
     function saveNewOrder(): void {
         const newArr = [];
@@ -287,33 +334,6 @@ Item {
                     Drag.source: delegateItem
                     Drag.hotSpot.x: width / 2
                     Drag.hotSpot.y: height / 2
-                    Component.onCompleted: minimizeTarget.publish()
-
-                    // Tell KWin this tile is where the app's windows live in the
-                    // taskbar, so minimize/restore effects animate into it. With
-                    // nothing published, Magic Lamp has no icon geometry to aim
-                    // at and falls back to following the cursor.
-                    QtObject {
-                        id: minimizeTarget
-
-                        function publish(): void {
-                            const tops = modelData?.toplevels ?? [];
-                            for (let i = 0; i < tops.length; i++) {
-                                const address = tops[i]?.address;
-                                if (address)
-                                    MinimizeGeometry.setGeometry(delegateItem, String(address));
-                            }
-                        }
-                    }
-
-                    Connections {
-                        function onTriggered(): void {
-                            minimizeTarget.publish();
-                        }
-
-                        target: minimizeGeometryTicker
-                    }
-
                     StateLayer {
                         id: stateLayer
 

--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -72,6 +72,28 @@ StyledWindow {
     }
 
     name: "drawers"
+
+    // StyledWindow hardcodes WlrLayershell.namespace to "panel" (or "desktop"
+    // for isDesktopWidget) — name above is a local label with no effect on the
+    // Wayland namespace at all, despite reading like it should be one.
+    //
+    // KWin classifies a layer-shell surface's window type from that namespace
+    // string (LayerShellV1Window::scopeToType() maps "dock" -> WindowType::Dock,
+    // anything not in its fixed list, "panel" included, -> WindowType::Normal).
+    // Effects that need to know "is this a taskbar" — Magic Lamp's minimize
+    // animation among them — key off that type, not off the published icon
+    // geometry alone. With this surface reporting as Normal, Magic Lamp's own
+    // panel lookup (stacking-order search for a window where isDock() is true
+    // and its geometry intersects the published icon rect) never finds a match,
+    // so it falls through to its "no panel found" heuristic: check whether the
+    // icon rect touches a screen edge by exact pixel equality, and default to
+    // Bottom if none do. Our published rects sit a few pixels in from the true
+    // edge (padding), so that check never passes and every orientation silently
+    // got Bottom's animation math — a barely-there warp for a bottom bar, a
+    // visibly wrong one for left/right, and a degenerate, invisible one for
+    // top, since Bottom's math assumes the icon is below the window, the
+    // opposite of where it actually is.
+    WlrLayershell.namespace: "dock"
     mask: {
         if (hasOpenOverlay) return fullRegion;
         if (hasFullscreen) return emptyRegion;

--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -93,7 +93,7 @@ StyledWindow {
     // visibly wrong one for left/right, and a degenerate, invisible one for
     // top, since Bottom's math assumes the icon is below the window, the
     // opposite of where it actually is.
-    WlrLayershell.namespace: "dock"
+    WlrLayershell.namespace: "panel"
     mask: {
         if (hasOpenOverlay) return fullRegion;
         if (hasFullscreen) return emptyRegion;

--- a/shell/plugin/src/Caelestia/Services/minimizegeometry.cpp
+++ b/shell/plugin/src/Caelestia/Services/minimizegeometry.cpp
@@ -36,22 +36,20 @@ MinimizeGeometry::MinimizeGeometry(QObject* parent)
         [this](const QString& uuid) { m_published.remove(uuid); });
 }
 
-void MinimizeGeometry::setGeometry(QQuickItem* tile, const QString& uuid) {
-    if (!tile || uuid.isEmpty() || tile->width() <= 0 || tile->height() <= 0) {
+void MinimizeGeometry::setGeometry(QQuickItem* anchor, const QString& uuid, int x, int y, int width, int height) {
+    if (!anchor || uuid.isEmpty() || width <= 0 || height <= 0) {
         return;
     }
 
-    auto* surface = surfaceFor(tile->window());
+    auto* surface = surfaceFor(anchor->window());
     if (!surface) {
         return;
     }
 
-    // Scene coordinates are surface coordinates: the item's window is the
+    // Scene coordinates are surface coordinates: the anchor's window is the
     // surface the rect is declared against.
-    const auto topLeft = tile->mapToScene(QPointF(0, 0));
-    const QRect rect(qRound(topLeft.x()), qRound(topLeft.y()), qRound(tile->width()), qRound(tile->height()));
-
     const auto key = PlasmaWindows::normaliseUuid(uuid);
+    const QRect rect(x, y, width, height);
     if (m_published.value(key) == rect) {
         return;
     }
@@ -69,7 +67,7 @@ void MinimizeGeometry::setGeometry(QQuickItem* tile, const QString& uuid) {
     m_published.insert(key, rect);
 }
 
-void MinimizeGeometry::clearGeometry(QQuickItem* tile, const QString& uuid) {
+void MinimizeGeometry::clearGeometry(QQuickItem* anchor, const QString& uuid) {
     if (uuid.isEmpty()) {
         return;
     }
@@ -79,7 +77,7 @@ void MinimizeGeometry::clearGeometry(QQuickItem* tile, const QString& uuid) {
         return;
     }
 
-    if (auto* surface = tile ? surfaceFor(tile->window()) : nullptr) {
+    if (auto* surface = anchor ? surfaceFor(anchor->window()) : nullptr) {
         if (auto* handle = PlasmaWindows::instance()->handleFor(key)) {
             handle->unset_minimized_geometry(surface);
         }

--- a/shell/plugin/src/Caelestia/Services/minimizegeometry.hpp
+++ b/shell/plugin/src/Caelestia/Services/minimizegeometry.hpp
@@ -34,21 +34,21 @@ public:
     explicit MinimizeGeometry(QObject* parent = nullptr);
 
     /**
-     * Publish @p tile as the taskbar rect for @p uuid, which is KWin's internal
-     * window id — the same value the KWin bridge reports as a window's address.
+     * Publish the taskbar rect for @p uuid, which is KWin's internal window id
+     * — the same value the KWin bridge reports as a window's address.
      *
-     * Takes the item rather than a window and a rect: the protocol wants
-     * surface-relative coordinates, which is exactly what mapping the item into
-     * its own scene gives, and QML cannot hand a QWindow across to C++ anyway.
+     * @p anchor only identifies the surface the rect belongs to; QML cannot
+     * hand a QWindow across to C++, so it passes any item in the right window.
+     * The rect itself is in scene coordinates, which for a full-screen shell
+     * window are the surface coordinates the protocol asks for.
      *
      * Repeat calls with an unchanged rect are dropped, because the QML side
-     * drives this from layout bindings that fire far more often than the
-     * geometry actually moves.
+     * polls this far more often than the geometry actually moves.
      */
-    Q_INVOKABLE void setGeometry(QQuickItem* tile, const QString& uuid);
+    Q_INVOKABLE void setGeometry(QQuickItem* anchor, const QString& uuid, int x, int y, int width, int height);
 
     /// Withdraw a rect published earlier, e.g. when its tile goes away.
-    Q_INVOKABLE void clearGeometry(QQuickItem* tile, const QString& uuid);
+    Q_INVOKABLE void clearGeometry(QQuickItem* anchor, const QString& uuid);
 
 private:
     QHash<QString, QRect> m_published;


### PR DESCRIPTION
## What does this change?

Closes #437.

Icon geometry was read from each delegate, and a delegate reports position 0 here — measured, across every index. So every window was published the same rect: whichever tile ran last won, and every app animated into that one spot. With the bar anywhere but the bottom that spot was not even on the bar, which is what made it look like only bottom worked.

The rects are now derived from the list's own geometry and the entry's index, which is orientation-agnostic and needs nothing from the delegates.

Two things fell out of measuring it:

**The component is instantiated where it has no bar to sit on** — with no window, or laid out to zero size. Those copies were publishing too and overwriting the real dock's rects; one was reporting a position off the bottom of the screen. They are skipped now.

**Tiles scrolled out of the list** were keeping whatever was published for them last. That is stale across a scroll and badly wrong across a bar move — a vertical bar fits about a third as many tiles, so the rest were still pointing at their old horizontal positions. They are clamped to the nearest edge of the list instead, which is where they would scroll back in from.

## How did you test it?

By asking KWin for the actual `iconGeometry` of every window rather than eyeballing the animation.

Bottom bar, after the fix — each window has its own rect, on the bar strip, stepping by one tile:

```
zen=1000,1394  discord=1044,1394  Claude=1088,1394  Ferdium=1220,1394  Yandex=1572,1394
```

Before, every one of those was the same `956,1442`.

Left bar — x pinned to the edge, y stepping instead, confirming the vertical path:

```
zen=10,699  discord=10,751  Claude=10,803
```

The shell's own view agreed with KWin's in both cases. I also confirmed a plain ListView with these transitions positions its delegates normally, so the delegates reporting 0 is specific to this dock rather than something to fix in the view.

Top and right go through the same two branches as bottom and left with a different origin, so I did not measure them separately.

**Not measured:** the clamp for scrolled-out tiles. I found that problem in the left-bar measurement above (two windows still pointing at their old bottom-bar rects) and fixed it after, but did not re-measure with a vertical bar afterwards. The logic is a one-line clamp into the list's own span; flagging it rather than implying it was verified like the rest.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Config / theme
- [ ] Docs
- [ ] Refactor
- [ ] Other

## Notes for reviewers

I did not chase down *why* a delegate reads position 0 here — the isolated ListView test says it is not the view's normal behaviour, so something in this dock's delegate setup is doing it. Deriving from the list geometry sidesteps it entirely and is arguably the more robust source anyway, but if you would rather have the underlying cause found I am happy to keep digging.