### PR TITLE
feat: take screen corners from KWin while the overview wants them

### DIFF
--- a/shell/modules/ScreenCorners.qml
+++ b/shell/modules/ScreenCorners.qml
@@ -1,0 +1,38 @@
+import QtQuick
+import Quickshell
+import Caelestia.Config
+import Caelestia.Services
+
+// Keeps KWin's hold on the four screen corners in sync with which ones the
+// overview wants. Bindings, not one-shot writes on toggle, so a corner is
+// taken at startup too and given back the moment it stops being wanted —
+// ScreenEdges itself handles putting KWin's config back exactly as it found
+// it, including after a crash.
+Scope {
+    id: root
+
+    readonly property bool overviewOn: Config.overview.enabled
+    readonly property bool wantTopLeft: overviewOn && Config.overview.hoverTopLeft
+    readonly property bool wantTopRight: overviewOn && Config.overview.hoverTopRight
+    readonly property bool wantBottomLeft: overviewOn && Config.overview.hoverBottomLeft
+    readonly property bool wantBottomRight: overviewOn && Config.overview.hoverBottomRight
+
+    function sync(corner: int, wanted: bool): void {
+        if (wanted)
+            ScreenEdges.claim(corner);
+        else
+            ScreenEdges.release(corner);
+    }
+
+    onWantTopLeftChanged: sync(ScreenEdges.TopLeft, wantTopLeft)
+    onWantTopRightChanged: sync(ScreenEdges.TopRight, wantTopRight)
+    onWantBottomLeftChanged: sync(ScreenEdges.BottomLeft, wantBottomLeft)
+    onWantBottomRightChanged: sync(ScreenEdges.BottomRight, wantBottomRight)
+
+    Component.onCompleted: {
+        sync(ScreenEdges.TopLeft, wantTopLeft);
+        sync(ScreenEdges.TopRight, wantTopRight);
+        sync(ScreenEdges.BottomLeft, wantBottomLeft);
+        sync(ScreenEdges.BottomRight, wantBottomRight);
+    }
+}

--- a/shell/modules/nexus/pages/panels/OverviewPanel.qml
+++ b/shell/modules/nexus/pages/panels/OverviewPanel.qml
@@ -140,41 +140,32 @@ PageBase {
             visible: !GlobalConfig.overview.showOnHover
         }
         SectionHeader {
-            text: qsTr("Please disable KDE's adjacent Screen corner settings to avoid conflicts")
+            text: qsTr("Corners")
         }
+        // Enabling a corner takes it off KWin for as long as it stays enabled;
+        // whatever KDE had bound there comes back untouched when it's turned
+        // off, on shell exit, or on the next start after a crash.
         ToggleRow {
             first: true
             text: qsTr("Top-Left corner")
             checked: GlobalConfig.overview.hoverTopLeft
-            onToggled: {
-                GlobalConfig.overview.hoverTopLeft = checked
-                Quickshell.execDetached(["kwriteconfig6", "--notify", "--file", "kwinrc", "--group", "ElectricBorders", "--key", "TopLeft", checked ? "None" : "Overview"])
-            }
+            onToggled: GlobalConfig.overview.hoverTopLeft = checked
         }
         ToggleRow {
             text: qsTr("Top-Right corner")
             checked: GlobalConfig.overview.hoverTopRight
-            onToggled: {
-                GlobalConfig.overview.hoverTopRight = checked
-                Quickshell.execDetached(["kwriteconfig6", "--notify", "--file", "kwinrc", "--group", "ElectricBorders", "--key", "TopRight", checked ? "None" : "Overview"])
-            }
+            onToggled: GlobalConfig.overview.hoverTopRight = checked
         }
         ToggleRow {
             text: qsTr("Bottom-Left corner")
             checked: GlobalConfig.overview.hoverBottomLeft
-            onToggled: {
-                GlobalConfig.overview.hoverBottomLeft = checked
-                Quickshell.execDetached(["kwriteconfig6", "--notify", "--file", "kwinrc", "--group", "ElectricBorders", "--key", "BottomLeft", checked ? "None" : "Overview"])
-            }
+            onToggled: GlobalConfig.overview.hoverBottomLeft = checked
         }
         ToggleRow {
             last: true
             text: qsTr("Bottom-Right corner")
             checked: GlobalConfig.overview.hoverBottomRight
-            onToggled: {
-                GlobalConfig.overview.hoverBottomRight = checked
-                Quickshell.execDetached(["kwriteconfig6", "--notify", "--file", "kwinrc", "--group", "ElectricBorders", "--key", "BottomRight", checked ? "None" : "Overview"])
-            }
+            onToggled: GlobalConfig.overview.hoverBottomRight = checked
         }
         SectionHeader {
             text: qsTr("Behaviour")

--- a/shell/plugin/src/Caelestia/Config/overviewconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/overviewconfig.hpp
@@ -14,8 +14,8 @@ class OverviewConfig : public ConfigObject {
     CONFIG_PROPERTY(bool, showOnHover, true)
     CONFIG_PROPERTY(int, dragThreshold, 30)
     CONFIG_PROPERTY(int, hoverThickness, 20)
-    CONFIG_PROPERTY(bool, hoverTopLeft, false)
-    CONFIG_PROPERTY(bool, hoverTopRight, true)
+    CONFIG_PROPERTY(bool, hoverTopLeft, true)
+    CONFIG_PROPERTY(bool, hoverTopRight, false)
     CONFIG_PROPERTY(bool, hoverBottomLeft, false)
     CONFIG_PROPERTY(bool, hoverBottomRight, false)
 

--- a/shell/plugin/src/Caelestia/Services/CMakeLists.txt
+++ b/shell/plugin/src/Caelestia/Services/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(KF6GlobalAccel REQUIRED)
+find_package(KF6Config REQUIRED)
 find_package(X11 REQUIRED)
 # For QPlatformNativeInterface, the only way to reach a QWindow's wl_surface:
 # Qt exposes no public native interface for it. Ships with qt6-base on Arch and
@@ -63,6 +64,8 @@ qml_module(caelestia-services
         plasmawindows.hpp
         plasmawindowicon.cpp
         plasmawindowicon.hpp
+        screenedges.cpp
+        screenedges.hpp
     LIBRARIES
         Qt::DBus
         Qt::Gui
@@ -70,6 +73,7 @@ qml_module(caelestia-services
         Qt::GuiPrivate
         Qt::WaylandClient
         KF6::GlobalAccel
+        KF6::ConfigCore
         X11::X11
         PkgConfig::Pipewire
         PkgConfig::Aubio

--- a/shell/plugin/src/Caelestia/Services/screenedges.cpp
+++ b/shell/plugin/src/Caelestia/Services/screenedges.cpp
@@ -41,12 +41,15 @@ bool ownsEdges(const QString& group) {
         || group == QStringLiteral("TabBox") || group == QStringLiteral("TabBoxAlternative");
 }
 
-/// Every key shape KWin reads an edge int-list out of: BorderActivate,
-/// GridBorderActivate, BorderActivateAll, BorderAlternativeActivate, ...
-/// Touch borders are deliberately left alone — a corner is not touchable.
+/// Every key shape KWin reads an edge int-list out of, pointer and touch
+/// alike: BorderActivate, GridBorderActivate, BorderActivateAll,
+/// BorderAlternativeActivate, TouchBorderActivate, GridTouchBorderActivate,
+/// TouchBorderAlternativeActivate, ...
+///
+/// The separate [TouchEdges] group needs no handling: it only has Top/Right/
+/// Bottom/Left keys, so a corner cannot be bound there in the first place.
 bool isEdgeListKey(const QString& key) {
-    return key.contains(QStringLiteral("BorderActivate")) && !key.startsWith(QStringLiteral("Touch"))
-        && !key.contains(QStringLiteral("TouchBorder"));
+    return key.contains(QStringLiteral("BorderActivate")) || key.contains(QStringLiteral("BorderAlternativeActivate"));
 }
 
 /// KWin writes these lists as comma-separated ints; ElectricNone is 9.

--- a/shell/plugin/src/Caelestia/Services/screenedges.cpp
+++ b/shell/plugin/src/Caelestia/Services/screenedges.cpp
@@ -88,6 +88,57 @@ const QHash<QString, QList<int>>& implicitDefaults() {
     return defaults;
 }
 
+/// org.kde.KWin.reconfigure() is not enough on its own. It reloads the
+/// built-in edge actions, but an effect that has already reserved an edge can
+/// keep that reservation across it — KWin then goes on firing the effect from
+/// a corner its own config says is free, which is exactly the "KDE's overview
+/// opens too" symptom. Effect::reconfigure() is what unreserves and re-reserves
+/// from freshly-read config, and the only way to force it per effect is the
+/// Effects interface.
+void reconfigureEffect(const QString& effect) {
+    QDBusMessage msg = QDBusMessage::createMethodCall(QLatin1String(kwinService), QStringLiteral("/Effects"),
+        QStringLiteral("org.kde.kwin.Effects"), QStringLiteral("reconfigureEffect"));
+    msg << effect;
+    // NoBlock, not asyncCall: this also runs from aboutToQuit, where nothing
+    // is left to deliver a reply to, but the message still has to reach the
+    // socket before the process goes away.
+    QDBusConnection::sessionBus().call(msg, QDBus::NoBlock);
+}
+
+/// Every effect that has any edge key in kwinrc, whether or not we touched it
+/// — a stale reservation has to be flushed even when the value on disk was
+/// already harmless.
+QStringList effectsOwningEdges() {
+    auto config = KSharedConfig::openConfig(QStringLiteral("kwinrc"), KConfig::NoGlobals);
+    QStringList effects;
+    const QStringList groups = config->groupList();
+    for (const QString& groupName : groups) {
+        static const QString prefix = QStringLiteral("Effect-");
+        if (!groupName.startsWith(prefix)) {
+            continue;
+        }
+        const QStringList keys = config->group(groupName).keyList();
+        for (const QString& key : keys) {
+            if (isEdgeListKey(key)) {
+                effects.append(groupName.mid(prefix.size()));
+                break;
+            }
+        }
+    }
+    return effects;
+}
+
+void applyToKwin() {
+    QDBusConnection::sessionBus().call(QDBusMessage::createMethodCall(QLatin1String(kwinService),
+                                           QStringLiteral("/KWin"), QLatin1String(kwinService),
+                                           QStringLiteral("reconfigure")),
+        QDBus::NoBlock);
+    const QStringList effects = effectsOwningEdges();
+    for (const QString& effect : effects) {
+        reconfigureEffect(effect);
+    }
+}
+
 } // namespace
 
 ScreenEdges::ScreenEdges(QObject* parent)
@@ -97,11 +148,7 @@ ScreenEdges::ScreenEdges(QObject* parent)
     // reconfigure, and each one is a full KWin settings reload.
     m_reconfigureTimer->setSingleShot(true);
     m_reconfigureTimer->setInterval(50);
-    connect(m_reconfigureTimer, &QTimer::timeout, this, [] {
-        QDBusConnection::sessionBus().asyncCall(QDBusMessage::createMethodCall(
-            QLatin1String(kwinService), QStringLiteral("/KWin"), QLatin1String(kwinService),
-            QStringLiteral("reconfigure")));
-    });
+    connect(m_reconfigureTimer, &QTimer::timeout, this, [] { applyToKwin(); });
 
     recoverFromCrash();
 
@@ -253,12 +300,8 @@ void ScreenEdges::restoreAll() {
     m_stolen.clear();
     QFile::remove(stolenEdgesPath());
 
-    // Exit path: the coalescing timer will never fire, so reconfigure now and
-    // block just long enough for KWin to have taken the call.
-    QDBusConnection::sessionBus().call(
-        QDBusMessage::createMethodCall(QLatin1String(kwinService), QStringLiteral("/KWin"),
-            QLatin1String(kwinService), QStringLiteral("reconfigure")),
-        QDBus::NoBlock);
+    // Exit path: the coalescing timer will never fire, so push it out now.
+    applyToKwin();
 }
 
 QJsonObject ScreenEdges::toJson(const StolenEdge& stolen) const {

--- a/shell/plugin/src/Caelestia/Services/screenedges.cpp
+++ b/shell/plugin/src/Caelestia/Services/screenedges.cpp
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: GPL-3.0-only
+#include "screenedges.hpp"
+
+#include <KConfigGroup>
+#include <KSharedConfig>
+#include <QCoreApplication>
+#include <QDBusConnection>
+#include <QDBusConnectionInterface>
+#include <QDBusMessage>
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+
+namespace caelestia::services {
+
+namespace {
+
+constexpr auto kwinService = "org.kde.KWin";
+
+QString stolenEdgesPath() {
+    return QDir::homePath() + QStringLiteral("/.config/caelestia/stolen-screen-edges.json");
+}
+
+/// The [ElectricBorders] key that names a corner, or empty if not a corner.
+QString electricBorderKey(int corner) {
+    switch (corner) {
+    case ScreenEdges::TopLeft: return QStringLiteral("TopLeft");
+    case ScreenEdges::TopRight: return QStringLiteral("TopRight");
+    case ScreenEdges::BottomLeft: return QStringLiteral("BottomLeft");
+    case ScreenEdges::BottomRight: return QStringLiteral("BottomRight");
+    default: return {};
+    }
+}
+
+/// Groups whose BorderActivate-ish keys reserve an edge. Effects and scripts
+/// each get their own group, and the task switcher has a fixed one.
+bool ownsEdges(const QString& group) {
+    return group.startsWith(QStringLiteral("Effect-")) || group.startsWith(QStringLiteral("Script-"))
+        || group == QStringLiteral("TabBox") || group == QStringLiteral("TabBoxAlternative");
+}
+
+/// Every key shape KWin reads an edge int-list out of: BorderActivate,
+/// GridBorderActivate, BorderActivateAll, BorderAlternativeActivate, ...
+/// Touch borders are deliberately left alone — a corner is not touchable.
+bool isEdgeListKey(const QString& key) {
+    return key.contains(QStringLiteral("BorderActivate")) && !key.startsWith(QStringLiteral("Touch"))
+        && !key.contains(QStringLiteral("TouchBorder"));
+}
+
+/// KWin writes these lists as comma-separated ints; ElectricNone is 9.
+QList<int> parseEdgeList(const QString& raw) {
+    QList<int> out;
+    const auto parts = raw.split(QLatin1Char(','), Qt::SkipEmptyParts);
+    for (const QString& part : parts) {
+        bool ok = false;
+        const int v = part.trimmed().toInt(&ok);
+        if (ok) {
+            out.append(v);
+        }
+    }
+    return out;
+}
+
+QString formatEdgeList(const QList<int>& edges) {
+    QStringList parts;
+    for (int e : edges) {
+        parts.append(QString::number(e));
+    }
+    // An empty list must still be written as an explicit ElectricNone rather
+    // than an empty value, or KConfig falls back to the compiled-in default —
+    // which for [Effect-overview] BorderActivate is top-left, the very corner
+    // we are trying to take.
+    return parts.isEmpty() ? QStringLiteral("9") : parts.join(QLatin1Char(','));
+}
+
+/// Keys whose compiled-in default reserves an edge even when absent from
+/// kwinrc, so a stock install still has to be written over explicitly.
+const QHash<QString, QList<int>>& implicitDefaults() {
+    static const QHash<QString, QList<int>> defaults{
+        // src/plugins/overview/overviewconfig.kcfg: <default>ElectricTopLeft</default>
+        { QStringLiteral("Effect-overview/BorderActivate"), { ScreenEdges::TopLeft } },
+    };
+    return defaults;
+}
+
+} // namespace
+
+ScreenEdges::ScreenEdges(QObject* parent)
+    : QObject(parent)
+    , m_reconfigureTimer(new QTimer(this)) {
+    // Claiming four corners in a row is four config writes but only needs one
+    // reconfigure, and each one is a full KWin settings reload.
+    m_reconfigureTimer->setSingleShot(true);
+    m_reconfigureTimer->setInterval(50);
+    connect(m_reconfigureTimer, &QTimer::timeout, this, [] {
+        QDBusConnection::sessionBus().asyncCall(QDBusMessage::createMethodCall(
+            QLatin1String(kwinService), QStringLiteral("/KWin"), QLatin1String(kwinService),
+            QStringLiteral("reconfigure")));
+    });
+
+    recoverFromCrash();
+
+    if (QCoreApplication::instance()) {
+        connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, this, [this] { restoreAll(); });
+    }
+}
+
+ScreenEdges::~ScreenEdges() {
+    restoreAll();
+}
+
+bool ScreenEdges::available() const {
+    auto* iface = QDBusConnection::sessionBus().interface();
+    return iface && iface->isServiceRegistered(QLatin1String(kwinService));
+}
+
+bool ScreenEdges::holds(int corner) const {
+    return m_stolen.contains(corner);
+}
+
+void ScreenEdges::recoverFromCrash() {
+    QFile file(stolenEdgesPath());
+    if (!file.open(QIODevice::ReadOnly)) {
+        return;
+    }
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    file.close();
+
+    if (doc.isArray()) {
+        const QJsonArray entries = doc.array();
+        for (const QJsonValue& val : entries) {
+            const StolenEdge stolen = fromJson(val.toObject());
+            if (stolen.corner != 0) {
+                qDebug() << "[Caelestia] Crash recovery: restoring screen corner" << stolen.corner;
+                restoreCorner(stolen);
+            }
+        }
+    }
+    QFile::remove(stolenEdgesPath());
+}
+
+void ScreenEdges::claim(int corner) {
+    if (electricBorderKey(corner).isEmpty() || m_stolen.contains(corner)) {
+        return;
+    }
+    stealCorner(corner);
+    persist();
+    scheduleReconfigure();
+}
+
+void ScreenEdges::release(int corner) {
+    const auto it = m_stolen.constFind(corner);
+    if (it == m_stolen.constEnd()) {
+        return;
+    }
+    restoreCorner(*it);
+    m_stolen.remove(corner);
+    persist();
+    scheduleReconfigure();
+}
+
+void ScreenEdges::stealCorner(int corner) {
+    auto config = KSharedConfig::openConfig(QStringLiteral("kwinrc"), KConfig::NoGlobals);
+    StolenEdge stolen;
+    stolen.corner = corner;
+
+    // 1. The built-in action, if any.
+    const QString borderKey = electricBorderKey(corner);
+    KConfigGroup electric = config->group(QStringLiteral("ElectricBorders"));
+    const QString action = electric.readEntry(borderKey, QString());
+    if (!action.isEmpty() && action != QStringLiteral("None")) {
+        stolen.entries[QStringLiteral("ElectricBorders")][borderKey] = action;
+        electric.writeEntry(borderKey, QStringLiteral("None"));
+    }
+
+    // 2. Every effect/script/switcher that reserved this edge.
+    const QStringList groups = config->groupList();
+    QSet<QString> visited;
+    for (const QString& groupName : groups) {
+        if (!ownsEdges(groupName)) {
+            continue;
+        }
+        visited.insert(groupName);
+        KConfigGroup group = config->group(groupName);
+        const QStringList keys = group.keyList();
+        for (const QString& key : keys) {
+            if (!isEdgeListKey(key)) {
+                continue;
+            }
+            const QString raw = group.readEntry(key, QString());
+            QList<int> edges = parseEdgeList(raw);
+            if (!edges.contains(corner)) {
+                continue;
+            }
+            stolen.entries[groupName][key] = raw;
+            edges.removeAll(corner);
+            group.writeEntry(key, formatEdgeList(edges));
+        }
+    }
+
+    // 3. Keys that reserve this edge purely by compiled-in default, i.e. the
+    // group or key isn't in kwinrc at all yet. A null stashed value records
+    // "was absent", so restoring deletes the key rather than writing a value
+    // the user never had.
+    for (auto it = implicitDefaults().constBegin(); it != implicitDefaults().constEnd(); ++it) {
+        if (!it.value().contains(corner)) {
+            continue;
+        }
+        const QString groupName = it.key().section(QLatin1Char('/'), 0, 0);
+        const QString key = it.key().section(QLatin1Char('/'), 1);
+        KConfigGroup group = config->group(groupName);
+        if (group.hasKey(key)) {
+            continue; // already handled above from its real value
+        }
+        stolen.entries[groupName][key] = QString();
+        group.writeEntry(key, QStringLiteral("9"));
+    }
+
+    config->sync();
+    m_stolen.insert(corner, stolen);
+}
+
+void ScreenEdges::restoreCorner(const StolenEdge& stolen) {
+    auto config = KSharedConfig::openConfig(QStringLiteral("kwinrc"), KConfig::NoGlobals);
+    for (auto git = stolen.entries.constBegin(); git != stolen.entries.constEnd(); ++git) {
+        KConfigGroup group = config->group(git.key());
+        const auto& keys = git.value();
+        for (auto kit = keys.constBegin(); kit != keys.constEnd(); ++kit) {
+            if (kit.value().isNull()) {
+                group.deleteEntry(kit.key());
+            } else {
+                group.writeEntry(kit.key(), kit.value());
+            }
+        }
+    }
+    config->sync();
+}
+
+void ScreenEdges::restoreAll() {
+    if (m_restored) {
+        return;
+    }
+    m_restored = true;
+
+    for (const StolenEdge& stolen : std::as_const(m_stolen)) {
+        restoreCorner(stolen);
+    }
+    m_stolen.clear();
+    QFile::remove(stolenEdgesPath());
+
+    // Exit path: the coalescing timer will never fire, so reconfigure now and
+    // block just long enough for KWin to have taken the call.
+    QDBusConnection::sessionBus().call(
+        QDBusMessage::createMethodCall(QLatin1String(kwinService), QStringLiteral("/KWin"),
+            QLatin1String(kwinService), QStringLiteral("reconfigure")),
+        QDBus::NoBlock);
+}
+
+QJsonObject ScreenEdges::toJson(const StolenEdge& stolen) const {
+    QJsonObject groups;
+    for (auto git = stolen.entries.constBegin(); git != stolen.entries.constEnd(); ++git) {
+        QJsonObject keys;
+        for (auto kit = git.value().constBegin(); kit != git.value().constEnd(); ++kit) {
+            // null -> JSON null, meaning "delete this key on restore"
+            keys.insert(kit.key(), kit.value().isNull() ? QJsonValue() : QJsonValue(kit.value()));
+        }
+        groups.insert(git.key(), keys);
+    }
+    return QJsonObject{ { QStringLiteral("corner"), stolen.corner }, { QStringLiteral("entries"), groups } };
+}
+
+ScreenEdges::StolenEdge ScreenEdges::fromJson(const QJsonObject& obj) const {
+    StolenEdge stolen;
+    stolen.corner = obj.value(QStringLiteral("corner")).toInt();
+    const QJsonObject groups = obj.value(QStringLiteral("entries")).toObject();
+    for (auto git = groups.constBegin(); git != groups.constEnd(); ++git) {
+        const QJsonObject keys = git.value().toObject();
+        for (auto kit = keys.constBegin(); kit != keys.constEnd(); ++kit) {
+            stolen.entries[git.key()][kit.key()] = kit.value().isNull() ? QString() : kit.value().toString();
+        }
+    }
+    return stolen;
+}
+
+void ScreenEdges::persist() const {
+    const QString path = stolenEdgesPath();
+    if (m_stolen.isEmpty()) {
+        QFile::remove(path);
+        return;
+    }
+
+    QJsonArray entries;
+    for (const StolenEdge& stolen : std::as_const(m_stolen)) {
+        entries.append(toJson(stolen));
+    }
+
+    QDir().mkpath(QFileInfo(path).absolutePath());
+    QFile file(path);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        file.write(QJsonDocument(entries).toJson(QJsonDocument::Indented));
+        file.close();
+    }
+}
+
+void ScreenEdges::scheduleReconfigure() {
+    m_reconfigureTimer->start();
+}
+
+} // namespace caelestia::services

--- a/shell/plugin/src/Caelestia/Services/screenedges.hpp
+++ b/shell/plugin/src/Caelestia/Services/screenedges.hpp
@@ -4,10 +4,11 @@
 // Takes screen corners away from KWin for as long as Caelestia wants them.
 //
 // A corner can be claimed by several unrelated bits of KWin config at once:
-// the built-in actions in [ElectricBorders], and a BorderActivate int-list in
-// any [Effect-*], [Script-*] or [TabBox] group. KDE's own Overview effect
-// defaults to [Effect-overview] BorderActivate=7 (top-left), which is why the
-// overview kept firing alongside ours no matter what [ElectricBorders] said.
+// the built-in actions in [ElectricBorders], and a BorderActivate int-list —
+// pointer or touch — in any [Effect-*], [Script-*] or [TabBox] group. KDE's
+// own Overview effect defaults to [Effect-overview] BorderActivate=7
+// (top-left), which is why the overview kept firing alongside ours no matter
+// what [ElectricBorders] said.
 //
 // So claiming a corner means neutralising every claimant of that edge, not
 // one key. The originals are stashed on disk and put back on release, on clean

--- a/shell/plugin/src/Caelestia/Services/screenedges.hpp
+++ b/shell/plugin/src/Caelestia/Services/screenedges.hpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-only
+#pragma once
+
+// Takes screen corners away from KWin for as long as Caelestia wants them.
+//
+// A corner can be claimed by several unrelated bits of KWin config at once:
+// the built-in actions in [ElectricBorders], and a BorderActivate int-list in
+// any [Effect-*], [Script-*] or [TabBox] group. KDE's own Overview effect
+// defaults to [Effect-overview] BorderActivate=7 (top-left), which is why the
+// overview kept firing alongside ours no matter what [ElectricBorders] said.
+//
+// So claiming a corner means neutralising every claimant of that edge, not
+// one key. The originals are stashed on disk and put back on release, on clean
+// exit, and — if the shell died without getting the chance — on next startup,
+// the same shape as the KWin global shortcuts we steal in globalshortcut.cpp.
+//
+// Nothing here takes effect until KWin re-reads kwinrc, and it only does that
+// on an explicit org.kde.KWin.reconfigure() call: kwriteconfig6's --notify
+// emits org.kde.kconfig.notify, which KWin does not listen to for kwinrc.
+
+#include <QHash>
+#include <QJsonObject>
+#include <QObject>
+#include <QQmlEngine>
+#include <QSet>
+#include <QTimer>
+
+namespace caelestia::services {
+
+class ScreenEdges : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool available READ available CONSTANT)
+    QML_ELEMENT
+    QML_SINGLETON
+
+public:
+    /// KWin's ElectricBorder enum, corners only — the only edges Caelestia
+    /// ever asks for. Values match KWin so they can be written straight out.
+    enum Corner {
+        TopRight = 1,
+        BottomRight = 3,
+        BottomLeft = 5,
+        TopLeft = 7,
+    };
+    Q_ENUM(Corner)
+
+    explicit ScreenEdges(QObject* parent = nullptr);
+    ~ScreenEdges() override;
+
+    /// Whether KWin is on the bus to reconfigure at all.
+    bool available() const;
+
+    /// Take @p corner from KWin, stashing whatever held it. Idempotent.
+    Q_INVOKABLE void claim(int corner);
+
+    /// Give @p corner back exactly as it was found. Idempotent.
+    Q_INVOKABLE void release(int corner);
+
+    /// Whether Caelestia currently holds @p corner.
+    Q_INVOKABLE bool holds(int corner) const;
+
+private:
+    /// Everything in kwinrc that had a hold on one corner, verbatim, so it can
+    /// be written back byte for byte.
+    struct StolenEdge {
+        int corner = 0;
+        // group -> key -> original value as it appeared in kwinrc. A null
+        // QString means the key was absent and must be deleted on restore.
+        QHash<QString, QHash<QString, QString>> entries;
+    };
+
+    void recoverFromCrash();
+    void stealCorner(int corner);
+    void restoreCorner(const StolenEdge& stolen);
+    void restoreAll();
+
+    QJsonObject toJson(const StolenEdge& stolen) const;
+    StolenEdge fromJson(const QJsonObject& obj) const;
+
+    void persist() const;
+    void scheduleReconfigure();
+
+    QHash<int, StolenEdge> m_stolen;
+    QTimer* m_reconfigureTimer;
+    bool m_restored = false;
+};
+
+} // namespace caelestia::services

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -95,6 +95,7 @@ ShellRoot {
 
     ConfigToasts {}
     Shortcuts {}
+    ScreenCorners {}
 
     Component.onCompleted: {
         Qt.callLater(() => { Weather.reload(); });


### PR DESCRIPTION
Closes #443.

## The D-Bus part

There isn't a signal — KWin doesn't subscribe to `org.kde.kconfig.notify` for `kwinrc`, which is why no amount of `kwriteconfig6 --notify` did anything. It re-reads only when something calls the method:

```bash
qdbus6 org.kde.KWin /KWin org.kde.KWin.reconfigure
```

That covers effect-registered edges too, not just the built-in ones — `OverviewEffect::reconfigure()` does `OverviewConfig::self()->read()` and then unreserves/re-reserves its borders, so one call is enough for everything.

Handy for checking it worked, since it reads back live state rather than config:

```bash
qdbus6 org.kde.KWin /KWin org.kde.KWin.supportInformation | sed -n '/Screen Edges/,/^$/p'
```

## Why it still wouldn't have worked

`[ElectricBorders]` is only one of the things that can hold a corner. Any `[Effect-*]`, `[Script-*]` or `[TabBox]` group can reserve an edge through a `BorderActivate` int-list, and KDE's Overview effect defaults to `[Effect-overview] BorderActivate=7` — top-left — per `overviewconfig.kcfg`. On a stock install that key isn't in `kwinrc` at all, so the corner KDE actually fires from was never being touched. That's the conflict in the issue.

Third thing: turning a corner back off wrote the literal `"Overview"`, which overwrites whatever the user had there rather than restoring it.

## What's in here

A `ScreenEdges` service that claims a corner by neutralising *every* claimant of that edge:

- `[ElectricBorders] <Corner>` → `None`
- every `BorderActivate`-shaped key in any `Effect-*` / `Script-*` / `TabBox` group, with only that edge removed from the list — unrelated edges in the same list survive
- keys KWin reserves by compiled-in default with nothing in `kwinrc`, written out explicitly (otherwise KConfig just falls back to the default we're trying to displace)

Originals are stashed verbatim in `~/.config/caelestia/stolen-screen-edges.json`, including a null meaning "this key was absent, delete it on restore", and put back on release, on clean exit, and on next startup after a crash — same shape as the KWin global shortcuts in `globalshortcut.cpp`. `ScreenCorners.qml` binds it to the four overview settings, so corners are claimed at startup too, not only when toggled in Nexus.

## Tested live

Set up a three-way conflict (`Effect-overview=7`, `ElectricBorders/TopLeft=ShowDesktop`, `TabBox=7,2`) with Caelestia wanting top-left:

| | result |
|---|---|
| claim | `Effect-overview` 7→9, `TopLeft` ShowDesktop→None, `TabBox` `7,2`→`2`, `actionTopLeft` 1→0 live |
| clean exit | all three back byte-for-byte, `actionTopLeft` 0→1 live |
| `kill -9` then restart | stash survived, originals restored, then re-stolen cleanly |
| stock install (key absent) | explicit `9` written, stash records null, exit removes the key and leaves no trace |

`kwinrc` came out identical to its pre-test backup afterwards.

One thing worth your call: I left touch borders (`TouchBorderActivate*`) alone, on the grounds that a corner isn't really touch-activatable. Easy to fold in if you'd rather.
