### PR TITLE
fix: stop overview cards overlapping, centre the grid, and cut the open cost

### DIFF
--- a/.github/workflows/test-dependencies.yml
+++ b/.github/workflows/test-dependencies.yml
@@ -36,7 +36,7 @@ jobs:
           # Give builduser ownership of the workspace so it can run the script
           chown -R builduser:builduser .
           su - builduser -c "cd $GITHUB_WORKSPACE && ./sdata/arch-dist/installDP.sh || true"
-          
+
           if [ -s /home/builduser/.cache/caelestia-kde/failed_packages.txt ]; then
             FAILED=$(cat /home/builduser/.cache/caelestia-kde/failed_packages.txt | tr '\n' ' ')
             echo "::error::[ARCH] Failed to install packages: $FAILED"

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -35,15 +35,15 @@ jobs:
             echo "All submodules are fully up to date."
           else
             BRANCH_NAME="chore/update-dependencies-$(date +%s)"
-            
+
             git checkout -b "$BRANCH_NAME"
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            
+
             git add .
             git commit -m "chore: update submodules to latest upstream commits"
             git push origin "$BRANCH_NAME"
-            
+
             gh pr create \
               --base dev \
               --head "$BRANCH_NAME" \

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -164,7 +164,7 @@ jobs:
           set -euo pipefail
 
           echo "Attempting to open a PR to sync main into dev..."
-          
+
           gh pr create \
             --base dev \
             --head main \

--- a/shell/modules/Shortcuts.qml
+++ b/shell/modules/Shortcuts.qml
@@ -55,7 +55,13 @@ Scope {
         description: "Toggle overview"
         onPressed: {
             const visibilities = Visibilities.getForActive();
-            visibilities.overview = !visibilities.overview;
+            // Pressing it again while the overview is up steps through the
+            // windows rather than dismissing it, so the same key that opened
+            // the grid also walks it — the thing every task switcher does.
+            if (visibilities.overview)
+                Visibilities.cycleOverview(false);
+            else
+                visibilities.overview = true;
         }
     }
     // qmllint disable unresolved-type

--- a/shell/modules/Shortcuts.qml
+++ b/shell/modules/Shortcuts.qml
@@ -55,13 +55,16 @@ Scope {
         description: "Toggle overview"
         onPressed: {
             const visibilities = Visibilities.getForActive();
-            // Pressing it again while the overview is up steps through the
-            // windows rather than dismissing it, so the same key that opened
-            // the grid also walks it — the thing every task switcher does.
-            if (visibilities.overview)
-                Visibilities.cycleOverview(false);
-            else
+            if (visibilities.overview) {
+                visibilities.overview = false;
+            } else {
+                if (typeof KWinActiveWindowBridge !== "undefined" && KWinActiveWindowBridge.activeWindow && KWinActiveWindowBridge.activeWindow.address) {
+                    Visibilities.preOverviewActiveWindowAddress = KWinActiveWindowBridge.activeWindow.address;
+                } else {
+                    Visibilities.preOverviewActiveWindowAddress = "";
+                }
                 visibilities.overview = true;
+            }
         }
     }
     // qmllint disable unresolved-type

--- a/shell/modules/background/Wallpaper.qml
+++ b/shell/modules/background/Wallpaper.qml
@@ -162,6 +162,10 @@ Item {
         readonly property bool isDynamicScheme: currentSchemeName.startsWith("dynamic")
         readonly property bool isDynamicMonochrome: isDynamicScheme && currentVariantName === "monochrome"
         readonly property bool needsMask: img.z === 1 && maskAnim.running
+        readonly property bool tiled: {
+            const m = Config.background.wallpaperFillMode;
+            return m === Image.Tile || m === Image.TileVertically || m === Image.TileHorizontally;
+        }
         readonly property bool shouldRecolor: Config.background.wallpaperRecolor
 
         function update(): void {
@@ -278,18 +282,39 @@ Item {
                 fillMode: Config.background.wallpaperFillMode
                 source: img.imagePath || ""
                 playing: true
-                // Decode at the size actually being drawn. Without this the full
-                // image is decoded whatever its resolution: an 8K wallpaper costs
-                // ~132MB of pixels and a slow decode, twice over while the old and
-                // new ones overlap during the reveal — a visible hitch on every
-                // change. JPEG can scale during decode, so asking for the screen
-                // size makes it both quicker and far smaller. Every other wallpaper
-                // view already does this; only the one drawing the biggest image
-                // did not.
-                // sourceSize: {
-                //     const dpr = (QsWindow.window as QsWindow)?.devicePixelRatio ?? 1;
-                //     return Qt.size(wallpaperImage.width * dpr, wallpaperImage.height * dpr);
-                // }
+                // Decode near the size actually drawn. Left alone, the image is
+                // decoded at whatever resolution it happens to be: an 8K wallpaper
+                // is ~132MB of pixels and a slow decode, paid twice over while the
+                // outgoing and incoming images overlap through the reveal — which
+                // is the hitch on every wallpaper change. Every other wallpaper
+                // view already asks for a size; only the one drawing the biggest
+                // image did not.
+                //
+                // Only the width is given. Setting both dimensions scales the
+                // decode to exactly that box and drops the aspect ratio, which
+                // turns a 16:9 wallpaper into a square — fillMode is configurable
+                // and PreserveAspectCrop then shows that square pillarboxed. With
+                // one dimension the other follows the image's own aspect.
+                //
+                // It asks for half again the long edge so the result still covers
+                // the item under PreserveAspectCrop even for footage much wider
+                // than the screen; Qt never upscales a decode, so nothing is lost
+                // on images that are already smaller. An 8K wallpaper on this
+                // screen still comes down from ~33MP to under 7MP.
+                //
+                // Tiling is left unconstrained: there the decode size is the tile
+                // size, so capping it would change how the wallpaper looks.
+                sourceSize: {
+                    // Nothing to size when this element is not the one drawing:
+                    // for a video the source here is empty, and handing a decode
+                    // size to an AnimatedImage in that state leaves the wallpaper
+                    // blank.
+                    if (img.isVideoImage || img.imagePath === "" || img.tiled)
+                        return Qt.size(0, 0);
+                    const dpr = wallpaperImage.Screen.devicePixelRatio || 1;
+                    const edge = Math.ceil(Math.max(wallpaperImage.width, wallpaperImage.height) * dpr * 1.5);
+                    return edge > 0 ? Qt.size(edge, 0) : Qt.size(0, 0);
+                }
                 onStatusChanged: {
                     if (status === Image.Ready && !img.isVideoImage)
                         root.current = img;

--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -862,7 +862,7 @@ StyledWindow {
         }
     }
     WlrLayershell.exclusionMode: ExclusionMode.Ignore
-    WlrLayershell.layer: (actualFullscreen && (hasOpenOverlay || fsTransitionProg < 1)) || (fsTransitionProg > 0 && Config.general.showOverFullscreen) || (((monitor?.lastIpcObject?.specialWorkspace?.name?.length ?? 0) > 0) && (monitor?.activeWorkspace?.toplevels?.values?.some(t => (t?.lastIpcObject?.fullscreen ?? 0) > 1) ?? false)) ? WlrLayer.Overlay : WlrLayer.Top
+    WlrLayershell.layer: hasOpenOverlay || (actualFullscreen && fsTransitionProg < 1) || (fsTransitionProg > 0 && Config.general.showOverFullscreen) || (((monitor?.lastIpcObject?.specialWorkspace?.name?.length ?? 0) > 0) && (monitor?.activeWorkspace?.toplevels?.values?.some(t => (t?.lastIpcObject?.fullscreen ?? 0) > 1) ?? false)) ? WlrLayer.Overlay : WlrLayer.Top
     WlrLayershell.keyboardFocus: visibilities.launcher || visibilities.session || visibilities.dashboard || visibilities.sidebar || visibilities.overview || panels.popouts.hasCurrent ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
 
     component PanelBg: BlobRect {

--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -216,7 +216,13 @@ StyledWindow {
     Item {
         id: overviewWallpaperLayer
 
-        property bool active: visibilities.overview
+        property bool active: visibilities.overview || warming
+        // Paint this layer once, invisibly, shortly after startup. The first
+        // time the shell covers the whole screen the driver has to allocate for
+        // it, and that lands as ~80-100ms of blocked swap on whichever frame
+        // triggers it. Paying it here costs nothing anyone sees; leaving it to
+        // the user's first overview drops most of that transition's frames.
+        property bool warming: false
         property real _maxBorder: Math.max(1, Math.min(root.width, root.height) * 0.15)
         property real bgScale: 1.0 + (dynamicBorderThickness / _maxBorder) * 0.1
 
@@ -224,9 +230,20 @@ StyledWindow {
         visible: active || opacity > 0
         layer.enabled: true
         // Ensure fade-in starts only after the wallpaper has actually loaded
-        opacity: (visibilities.overview && wallpaperLoader.status === Loader.Ready) ? 1 : 0
+        opacity: warming ? 0.004 : ((visibilities.overview && wallpaperLoader.status === Loader.Ready) ? 1 : 0)
 
-        Behavior on opacity { NumberAnimation { duration: animConfig.wallpaperDuration; easing.type: animConfig.easingType } }
+        Behavior on opacity { NumberAnimation { duration: overviewWallpaperLayer.warming ? 0 : animConfig.wallpaperDuration; easing.type: animConfig.easingType } }
+        Timer {
+            running: true
+            interval: 2500
+            onTriggered: { overviewWallpaperLayer.warming = true; warmDone.start(); }
+        }
+        Timer {
+            id: warmDone
+
+            interval: 400
+            onTriggered: overviewWallpaperLayer.warming = false
+        }
         Item {
             id: scaledWallpaperContainer
 

--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -197,7 +197,7 @@ StyledWindow {
             }
             onTriggered: {
                 let anyActive = root.active || root.activeFocusItem !== null;
-                
+
                 if (anyActive) {
                     parent._wasActive = true;
                 } else if (parent._wasActive && !anyActive) {
@@ -733,7 +733,7 @@ StyledWindow {
             rLeft: !GlobalConfig.appearance.islands ? root.borderRounding : 0
             rRight: !GlobalConfig.appearance.islands ? root.borderRounding : 0
         }
-        BlurMask { 
+        BlurMask {
             target: bar
             contentItem: root.contentItem
             blurOffsetTop: root.blurOffsetTop
@@ -743,7 +743,7 @@ StyledWindow {
             vAnchor: bar.vAnchor
             hAnchor: bar.hAnchor
         }
-        BlurMask { 
+        BlurMask {
             target: panels.sidebar
             contentItem: root.contentItem
             blurOffsetTop: root.blurOffsetTop
@@ -755,7 +755,7 @@ StyledWindow {
             offsetScale: panels.sidebar.offsetScale
             deformMatrix: sidebarBg.deformMatrix
         }
-        BlurMask { 
+        BlurMask {
             target: panels.notifications
             contentItem: root.contentItem
             blurOffsetTop: root.blurOffsetTop
@@ -766,7 +766,7 @@ StyledWindow {
             hAnchor: panels.notifications.hAnchor
             deformMatrix: notifsBg.deformMatrix
         }
-        BlurMask { 
+        BlurMask {
             target: panels.osdWrapper
             contentItem: root.contentItem
             blurOffsetTop: root.blurOffsetTop
@@ -778,7 +778,7 @@ StyledWindow {
             offsetScale: panels.osd.offsetScale
             deformMatrix: osdBg.deformMatrix
         }
-        BlurMask { 
+        BlurMask {
             target: panels.sessionWrapper
             contentItem: root.contentItem
             blurOffsetTop: root.blurOffsetTop
@@ -790,7 +790,7 @@ StyledWindow {
             offsetScale: panels.session.offsetScale
             deformMatrix: sessionBg.deformMatrix
         }
-        BlurMask { 
+        BlurMask {
             target: panels.launcher
             contentItem: root.contentItem
             blurOffsetTop: root.blurOffsetTop
@@ -802,7 +802,7 @@ StyledWindow {
             offsetScale: panels.launcher.offsetScale
             deformMatrix: launcherBg.deformMatrix
         }
-        BlurMask { 
+        BlurMask {
             target: panels.dashboard
             contentItem: root.contentItem
             blurOffsetTop: root.blurOffsetTop
@@ -814,7 +814,7 @@ StyledWindow {
             offsetScale: panels.dashboard.offsetScale
             deformMatrix: dashBg.deformMatrix
         }
-        BlurMask { 
+        BlurMask {
             target: panels.popoutsWrapper
             contentItem: root.contentItem
             blurOffsetTop: root.blurOffsetTop
@@ -826,7 +826,7 @@ StyledWindow {
             offsetScale: panels.popoutsWrapper.offsetScale
             deformMatrix: popoutBg.deformMatrix
         }
-        BlurMask { 
+        BlurMask {
             target: panels.utilities
             contentItem: root.contentItem
             blurOffsetTop: root.blurOffsetTop

--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -51,6 +51,13 @@ StyledWindow {
     // happened to put it.
     readonly property real overviewBorderThickness: Math.min(root.width, root.height) * 0.15
     property real dynamicBorderThickness: visibilities.overview ? overviewBorderThickness : Config.border.thickness
+    property real overviewVerticalOffset: {
+        if (!visibilities.overview) return 0;
+        const grid = panels && panels.overview ? panels.overview.windowGrid : null;
+        const indicator = grid ? grid.indicatorContainer : null;
+        const indicatorSpace = indicator ? indicator.height + Tokens.padding.large * 2 : 100;
+        return indicatorSpace - overviewBorderThickness;
+    }
     readonly property real borderThickness: dynamicBorderThickness * (1 - fsTransitionProg)
     readonly property real borderRounding: Config.border.rounding * (1 - fsTransitionProg)
     readonly property real shadowOpacity: 0.7 * (1 - fsTransitionProg)
@@ -121,6 +128,7 @@ StyledWindow {
         category: "Blur"
     }
     Behavior on dynamicBorderThickness { NumberAnimation { duration: animConfig.blobDuration; easing.type: animConfig.easingType } }
+    Behavior on overviewVerticalOffset { NumberAnimation { duration: animConfig.blobDuration; easing.type: animConfig.easingType } }
     Behavior on fsTransitionProg {
         Anim {}
     }
@@ -277,8 +285,8 @@ StyledWindow {
                 radius: root.borderRounding
                 borderLeft: Math.max(Config.bar.position === "left" ? bar.implicitWidth : 0, root.borderThickness) - anchors.margins - root.sdfBorderOffset
                 borderRight: Math.max(Config.bar.position === "right" ? bar.implicitWidth : 0, root.borderThickness) - anchors.margins - root.sdfBorderOffset
-                borderTop: Math.max(Config.bar.position === "top" ? bar.implicitHeight : 0, root.borderThickness) - anchors.margins - root.sdfBorderOffset
-                borderBottom: Math.max(Config.bar.position === "bottom" ? bar.implicitHeight : 0, root.borderThickness) - anchors.margins - root.sdfBorderOffset
+                borderTop: Math.max(Config.bar.position === "top" ? bar.implicitHeight : 0, root.borderThickness) - root.overviewVerticalOffset - anchors.margins - root.sdfBorderOffset
+                borderBottom: Math.max(Config.bar.position === "bottom" ? bar.implicitHeight : 0, root.borderThickness) + root.overviewVerticalOffset - anchors.margins - root.sdfBorderOffset
                 Config.screen: root.screen.name
             }
         }
@@ -330,8 +338,8 @@ StyledWindow {
             radius: root.borderRounding
             borderLeft: Math.max(Config.bar.position === "left" ? bar.implicitWidth : 0, root.borderThickness) - anchors.margins - root.sdfBorderOffset
             borderRight: Math.max(Config.bar.position === "right" ? bar.implicitWidth : 0, root.borderThickness) - anchors.margins - root.sdfBorderOffset
-            borderTop: Math.max(Config.bar.position === "top" ? bar.implicitHeight : 0, root.borderThickness) - anchors.margins - root.sdfBorderOffset
-            borderBottom: Math.max(Config.bar.position === "bottom" ? bar.implicitHeight : 0, root.borderThickness) - anchors.margins - root.sdfBorderOffset
+            borderTop: Math.max(Config.bar.position === "top" ? bar.implicitHeight : 0, root.borderThickness) - root.overviewVerticalOffset - anchors.margins - root.sdfBorderOffset
+            borderBottom: Math.max(Config.bar.position === "bottom" ? bar.implicitHeight : 0, root.borderThickness) + root.overviewVerticalOffset - anchors.margins - root.sdfBorderOffset
             Config.screen: root.screen.name
         }
         BlobRect {

--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -44,7 +44,13 @@ StyledWindow {
     readonly property bool hasFullscreen: actualFullscreen && !hasOpenOverlay
     property real fsTransitionProg: hasFullscreen ? 1 : 0
     readonly property real sdfBorderOffset: 2 * fsTransitionProg // SDFs joins are not exact, so offset by 2px to ensure nothing shows
-    property real dynamicBorderThickness: visibilities.overview ? Math.min(root.width, root.height) * 0.15 : Config.border.thickness
+    // Where dynamicBorderThickness lands once the overview is open. It is the
+    // target of a 300ms animation, and anything that lays content out inside the
+    // overview wants this rather than the animating value — laying out against a
+    // moving rect makes the result slide into place from wherever the first frame
+    // happened to put it.
+    readonly property real overviewBorderThickness: Math.min(root.width, root.height) * 0.15
+    property real dynamicBorderThickness: visibilities.overview ? overviewBorderThickness : Config.border.thickness
     readonly property real borderThickness: dynamicBorderThickness * (1 - fsTransitionProg)
     readonly property real borderRounding: Config.border.rounding * (1 - fsTransitionProg)
     readonly property real shadowOpacity: 0.7 * (1 - fsTransitionProg)
@@ -561,6 +567,7 @@ StyledWindow {
             visibilities: visibilities
             bar: bar
             borderThickness: root.borderThickness
+            overviewBorderThickness: root.overviewBorderThickness
             overviewAnimConfig: root.overviewAnimConfig
             utilities.horizontalStretch: (sidebarBg.rawDeformMatrix.m11 - 1) / 2 + 1
             utilities.deformMatrix: utilsBg.rawDeformMatrix

--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -54,9 +54,7 @@ StyledWindow {
     property real overviewVerticalOffset: {
         if (!visibilities.overview) return 0;
         const grid = panels && panels.overview ? panels.overview.windowGrid : null;
-        const indicator = grid ? grid.indicatorContainer : null;
-        const indicatorSpace = indicator ? indicator.height + Tokens.padding.large * 2 : 100;
-        return indicatorSpace - overviewBorderThickness;
+        return grid ? grid.verticalOffset : 0;
     }
     readonly property real borderThickness: dynamicBorderThickness * (1 - fsTransitionProg)
     readonly property real borderRounding: Config.border.rounding * (1 - fsTransitionProg)

--- a/shell/modules/drawers/Panels.qml
+++ b/shell/modules/drawers/Panels.qml
@@ -22,6 +22,10 @@ Item {
     required property DrawerVisibilities visibilities
     required property Bar.BarWrapper bar
     required property real borderThickness
+    // The settled overview border, i.e. what borderThickness animates towards
+    // when the overview opens. Content laid out inside the overview sizes to
+    // this so it does not have to chase the animation.
+    required property real overviewBorderThickness
     property var overviewAnimConfig
     readonly property alias osd: osd
     readonly property alias osdWrapper: osdWrapper

--- a/shell/modules/drawers/Panels.qml
+++ b/shell/modules/drawers/Panels.qml
@@ -22,9 +22,6 @@ Item {
     required property DrawerVisibilities visibilities
     required property Bar.BarWrapper bar
     required property real borderThickness
-    // The settled overview border, i.e. what borderThickness animates towards
-    // when the overview opens. Content laid out inside the overview sizes to
-    // this so it does not have to chase the animation.
     required property real overviewBorderThickness
     property var overviewAnimConfig
     readonly property alias osd: osd

--- a/shell/modules/overview/Content.qml
+++ b/shell/modules/overview/Content.qml
@@ -32,6 +32,7 @@ Item {
         onRequestWindowInfo: client => {
             windowGrid.activeInfoClient = client
             windowInfoOverlay.clientAddress = client.address
+            windowInfoOverlay.isOpen = true
         }
         onRequestClose: {
             root.visibilities.overview = false
@@ -48,11 +49,18 @@ Item {
         id: windowInfoOverlay
 
         property string clientAddress: ""
+        property bool isOpen: false
 
         z: 100
         anchors.fill: parent
         visible: opacity > 0
-        opacity: clientAddress ? 1 : 0
+        opacity: isOpen ? 1 : 0
+        onOpacityChanged: {
+            if (opacity <= 0 && !isOpen) {
+                windowInfoOverlay.clientAddress = ""
+                windowGrid.activeInfoClient = null
+            }
+        }
 
         Behavior on opacity {
             NumberAnimation { duration: 250; easing.type: Easing.OutCubic }
@@ -65,8 +73,7 @@ Item {
             WheelHandler { } // block scroll
             TapHandler {
                 onTapped: {
-                    windowInfoOverlay.clientAddress = ""
-                    windowGrid.activeInfoClient = null
+                    windowInfoOverlay.isOpen = false
                 }
             }
         }
@@ -86,8 +93,7 @@ Item {
                 border.width: 2
                 border.color: Colours.palette.m3primary
                 onCloseRequested: {
-                    windowInfoOverlay.clientAddress = ""
-                    windowGrid.activeInfoClient = null
+                    windowInfoOverlay.isOpen = false
                 }
             }
         }

--- a/shell/modules/overview/Content.qml
+++ b/shell/modules/overview/Content.qml
@@ -2,6 +2,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import qs.components
+import qs.services
 import qs.modules.windowinfo as WInfo
 
 Item {
@@ -82,6 +83,8 @@ Item {
 
                 anchors.fill: parent
                 clientAddress: windowInfoOverlay.clientAddress
+                border.width: 2
+                border.color: Colours.palette.m3primary
                 onCloseRequested: {
                     windowInfoOverlay.clientAddress = ""
                     windowGrid.activeInfoClient = null

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -22,8 +22,8 @@ Item {
     property var panels: null
     property alias indicatorContainer: indicatorContainer
     readonly property real overviewBorderThickness: Math.min(width, height) * 0.15
-    readonly property real indicatorSpace: indicatorContainer.height + Tokens.padding.large
-    readonly property real verticalOffset: Math.max(0, indicatorSpace - overviewBorderThickness)
+    readonly property real indicatorSpace: indicatorContainer.height + Tokens.padding.large * 2
+    readonly property real verticalOffset: indicatorSpace - overviewBorderThickness
     readonly property int activeWsId: typeof KWinWorkspaceState !== "undefined" ? KWinWorkspaceState.activeId : 1
     property bool ignoreNextSwitch: false
     property bool _initialized: false

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -24,6 +24,9 @@ Item {
     property bool ignoreNextSwitch: false
     property bool _initialized: false
     property bool isDragging: false
+    // How much a hovered card grows. The grid reserves room for exactly this, so
+    // keep the two in step.
+    readonly property real hoverScale: 1.02
 
     signal requestWindowInfo(var client)
     signal requestClose()
@@ -145,11 +148,24 @@ Item {
             Item {
                 id: gridItem
 
+                readonly property real hoverHeadroom: Math.ceil(Math.max(parent.width, parent.height) * (root.hoverScale - 1) / 2)
                 property var windowLayout: Config.overview.layoutType === 0 ? LayoutKde.calculateLayout(page.wsWindows, width, height, Tokens.spacing.large, Tokens.spacing.large) : LayoutGnome.calculateLayout(page.wsWindows, width, height, Tokens.spacing.large, Tokens.spacing.large)
 
+                // Opening the overview pulls the desktop into a rounded inset —
+                // ContentWindow grows the border to 15% of the short edge — and
+                // that inset is what reads as the stage. The layout fills whatever
+                // area it is handed edge to edge, so hand it the stage rather than
+                // the whole screen, or the outermost cards end up out on the black
+                // frame, past the wallpaper they belong to. The border is the same
+                // on all four sides (the workspace switcher lives out in the frame,
+                // below it), so panels' own margins are the wrong thing to use here:
+                // on whichever edge holds the bar, that margin is the bar's size
+                // instead.
                 anchors.fill: parent
-                anchors.bottomMargin: workspaceIndicator.implicitHeight * 2
-                // Behaviors for smooth resizing of the whole container if needed (though it fills parent)
+                // Plus the headroom a hovered card needs to grow into. Without it
+                // a card sitting on the edge of the stage grows straight off the
+                // wallpaper, which is most obvious on the bottom row.
+                anchors.margins: (root.panels ? root.panels.borderThickness : Tokens.padding.extraLarge) + hoverHeadroom
 
                 Repeater {
                     model: page.wsWindows
@@ -160,20 +176,38 @@ Item {
                         readonly property string clientAddress: modelData.address
                         readonly property int wsId: page.wsId
                             readonly property var layoutProps: gridItem.windowLayout && gridItem.windowLayout[modelData.address] ? gridItem.windowLayout[modelData.address] : { x: 0, y: 0, width: 200, height: 150 }
-                            readonly property int cardWidth: layoutProps.width
-                            readonly property int thumbHeight: layoutProps.height
                             readonly property real windowAspect: {
                                 const w = modelData.width;
                                 const h = modelData.height;
                                 return (w > 0 && h > 0) ? (w / h) : (16.0 / 10.0);
                             }
+                            readonly property bool isActive: {
+                                if (typeof KWinActiveWindowBridge === "undefined")
+                                    return false;
+                                const a = KWinActiveWindowBridge.activeWindow;
+                                return !!a && a.address === modelData.address;
+                            }
+                            // Cards below this get the caption dropped — a title
+                            // strip on a thumbnail that small costs more than it
+                            // tells you.
+                            readonly property bool showCaption: height > 96
 
                             x: dragHandler.active ? x : layoutProps.x
                             y: dragHandler.active ? y : layoutProps.y
-                            implicitWidth: cardLayout.implicitWidth + Tokens.padding.medium * 2
-                            implicitHeight: cardLayout.implicitHeight + Tokens.padding.medium * 2
-                            color: "transparent"
+                            // The layout hands out boxes that tile the page without
+                            // overlapping, so a card has to *be* its box. Sizing from
+                            // content instead made every card wider and taller than
+                            // its slot by the padding and the caption underneath it,
+                            // which is what had them spilling over each other and off
+                            // the page entirely.
+                            width: layoutProps.width
+                            height: layoutProps.height
+                            color: Colours.tPalette.m3surfaceContainer
                             radius: Tokens.rounding.large
+                            scale: hover.hovered && !dragHandler.active ? root.hoverScale : 1
+                            border.width: activeWin.isActive ? 2 : 1
+                            border.color: activeWin.isActive ? Colours.palette.m3primary : Colours.tPalette.m3outlineVariant
+
                             Component.onCompleted: {
                                 root.cardItems = [...root.cardItems, activeWin];
                             }
@@ -215,6 +249,7 @@ Item {
                                     }
                                 }
                             }
+                            Behavior on scale { Anim {} }
                             Behavior on x { enabled: !dragHandler.active && root.opacity > 0.5; NumberAnimation { duration: 250; easing.type: Easing.OutQuad } }
                             Behavior on y { enabled: !dragHandler.active && root.opacity > 0.5; NumberAnimation { duration: 250; easing.type: Easing.OutQuad } }
                             HoverHandler { id: hover }
@@ -239,7 +274,8 @@ Item {
                             ColumnLayout {
                                 id: cardLayout
 
-                                anchors.centerIn: parent
+                                anchors.fill: parent
+                                anchors.margins: Tokens.padding.small
                                 spacing: Tokens.spacing.small
 
                                 StyledClippingRect {
@@ -262,8 +298,10 @@ Item {
                                         }
                                     }
 
+                                    Layout.fillWidth: true
+                                    Layout.fillHeight: true
                                     color: Colours.tPalette.m3surfaceContainerHighest
-                                    radius: Tokens.rounding.large
+                                    radius: Tokens.rounding.medium
                                     Component.onCompleted: updateStream()
                                     Component.onDestruction: {
                                         if (streamRequest && modelData.address) {
@@ -367,18 +405,30 @@ Item {
                                             }
                                         }
                                     }
-                                    Layout.preferredWidth: activeWin.cardWidth
-                                    Layout.preferredHeight: activeWin.thumbHeight
                                 }
-                                StyledText {
-                                    id: titleText
+                                RowLayout {
+                                    id: caption
 
-                                    text: modelData.title || ""
-                                    color: Colours.palette.m3onSurfaceVariant
-                                    font: Tokens.font.body.small
-                                    elide: Text.ElideRight
-                                    horizontalAlignment: Text.AlignHCenter
-                                    Layout.preferredWidth: activeWin.cardWidth
+                                    spacing: Tokens.spacing.small
+                                    visible: activeWin.showCaption
+                                    Layout.fillWidth: true
+                                    Layout.leftMargin: Tokens.padding.extraSmall
+                                    Layout.rightMargin: Tokens.padding.extraSmall
+
+                                    IconImage {
+                                        implicitSize: Math.round(titleText.implicitHeight * 1.1)
+                                        asynchronous: true
+                                        source: modelData.class ? Icons.getAppIcon(modelData.class, "image-missing") : ""
+                                    }
+                                    StyledText {
+                                        id: titleText
+
+                                        text: modelData.title || modelData.class || ""
+                                        color: activeWin.isActive ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                                        font: Tokens.font.body.small
+                                        elide: Text.ElideRight
+                                        Layout.fillWidth: true
+                                    }
                                 }
                             }
                             Drag.active: dragHandler.active

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -20,6 +20,10 @@ Item {
     property var cardItems: []
     property var activeInfoClient: null
     property var panels: null
+    property alias indicatorContainer: indicatorContainer
+    readonly property real overviewBorderThickness: Math.min(width, height) * 0.15
+    readonly property real indicatorSpace: indicatorContainer.height + Tokens.padding.large
+    readonly property real verticalOffset: Math.max(0, indicatorSpace - overviewBorderThickness)
     readonly property int activeWsId: typeof KWinWorkspaceState !== "undefined" ? KWinWorkspaceState.activeId : 1
     property bool ignoreNextSwitch: false
     property bool _initialized: false
@@ -176,6 +180,8 @@ Item {
         property real rawSwipeOffset: typeof KWinWorkspaceState !== "undefined" ? KWinWorkspaceState.swipeOffset : 0.0
 
         anchors.fill: parent
+        anchors.topMargin: -verticalOffset
+        anchors.bottomMargin: verticalOffset
         orientation: ListView.Horizontal
         highlightRangeMode: ListView.NoHighlightRange
         cacheBuffer: 100000 // Keep all pages instantiated to prevent drag-and-drop interruption

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -121,12 +121,24 @@ Item {
         onActivated: root.activateSelected()
     }
     Shortcut {
-        sequences: ["Tab", "Right"]
+        sequences: {
+            const s = ["Tab", "Right", "Down"];
+            if (GlobalConfig.launcher.vimKeybinds) {
+                s.push("Ctrl+J", "Ctrl+N");
+            }
+            return s;
+        }
         enabled: root.opacity > 0
         onActivated: root.cycleSelection(false)
     }
     Shortcut {
-        sequences: ["Shift+Tab", "Left"]
+        sequences: {
+            const s = ["Shift+Tab", "Backtab", "Left", "Up"];
+            if (GlobalConfig.launcher.vimKeybinds) {
+                s.push("Ctrl+K", "Ctrl+P");
+            }
+            return s;
+        }
         enabled: root.opacity > 0
         onActivated: root.cycleSelection(true)
     }
@@ -315,7 +327,7 @@ Item {
                                         if (dropAction !== Qt.IgnoreAction) {
                                             return; // Handled by DropArea
                                         }
-                                        
+
                                         if (typeof KWinWorkspaceState === "undefined" || typeof KWinActiveWindowBridge === "undefined") return;
                                         const targetWsId = KWinWorkspaceState.workspaces[listView.currentIndex].index;
                                         if (targetWsId !== page.wsId) {
@@ -347,12 +359,11 @@ Item {
                                     if (v) v.overview = false;
                                 }
                             }
-                            ColumnLayout {
+                            Item {
                                 id: cardLayout
 
                                 anchors.fill: parent
                                 anchors.margins: Tokens.padding.small
-                                spacing: Tokens.spacing.small
 
                                 StyledClippingRect {
                                     id: thumb
@@ -378,8 +389,10 @@ Item {
                                         }
                                     }
 
-                                    Layout.fillWidth: true
-                                    Layout.fillHeight: true
+                                    anchors.top: parent.top
+                                    anchors.left: parent.left
+                                    anchors.right: parent.right
+                                    height: parent.height - (caption.opacity * (caption.implicitHeight + Tokens.padding.extraSmall * 2))
                                     color: Colours.tPalette.m3surfaceContainerHighest
                                     radius: Tokens.rounding.medium
                                     Component.onCompleted: updateStream()
@@ -417,12 +430,12 @@ Item {
                                         width: {
                                             const wAspect = activeWin.windowAspect;
                                             const containerAspect = thumb.width / Math.max(1, thumb.height);
-                                            return (wAspect > containerAspect) ? thumb.width : thumb.height * wAspect;
+                                            return (wAspect > containerAspect) ? thumb.height * wAspect : thumb.width;
                                         }
                                         height: {
                                             const wAspect = activeWin.windowAspect;
                                             const containerAspect = thumb.width / Math.max(1, thumb.height);
-                                            return (wAspect > containerAspect) ? thumb.width / wAspect : thumb.height;
+                                            return (wAspect > containerAspect) ? thumb.height : thumb.width / wAspect;
                                         }
                                         anchors.centerIn: parent
                                         visible: thumb.screencastSerial !== 0
@@ -499,9 +512,14 @@ Item {
                                     spacing: Tokens.spacing.small
                                     opacity: activeWin.showCaption ? 1 : 0
                                     visible: opacity > 0.01
-                                    Layout.fillWidth: true
-                                    Layout.leftMargin: Tokens.padding.extraSmall
-                                    Layout.rightMargin: Tokens.padding.extraSmall
+                                    anchors.left: parent.left
+                                    anchors.right: parent.right
+                                    anchors.bottom: parent.bottom
+                                    anchors.leftMargin: Tokens.padding.extraSmall
+                                    anchors.rightMargin: Tokens.padding.extraSmall
+                                    anchors.bottomMargin: Tokens.padding.extraSmall
+
+                                    Behavior on opacity { Anim {} }
 
                                     IconImage {
                                         implicitSize: Math.round(titleText.implicitHeight * 1.1)
@@ -546,7 +564,7 @@ Item {
             acceptedButtons: Qt.NoButton
             onWheel: event => {
                 if (!Config.bar.scrollActions.workspaces) return;
-                
+
                 if (event.angleDelta.y > 0 || event.angleDelta.x > 0) {
                     if (listView.currentIndex > 0) {
                         listView.currentIndex -= 1;

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -20,6 +20,7 @@ Item {
     property var cardItems: []
     property var activeInfoClient: null
     property var panels: null
+    property var closingWindows: []
     property alias indicatorContainer: indicatorContainer
     readonly property real overviewBorderThickness: Math.min(width, height) * 0.15
     readonly property real indicatorSpace: indicatorContainer.height + Tokens.padding.large * 2
@@ -306,7 +307,9 @@ Item {
                             height: layoutProps.height
                             color: Colours.palette.m3surfaceContainer
                             radius: Tokens.rounding.large
-                            scale: activeWin.isSelected && !dragHandler.active ? root.hoverScale : 1
+                            property bool closing: false
+                            scale: closing ? 0 : (activeWin.isSelected && !dragHandler.active ? root.hoverScale : 1)
+                            opacity: closing ? 0 : 1
                             border.width: activeWin.isSelected ? 2 : 0
                             border.color: Colours.palette.m3primary
 
@@ -355,6 +358,25 @@ Item {
                                 }
                             }
                             Behavior on scale { Anim {} }
+                            Behavior on opacity {
+                                NumberAnimation {
+                                    id: opacityAnim
+                                    duration: 250
+                                    easing.type: Easing.OutCubic
+                                }
+                            }
+                            Connections {
+                                target: opacityAnim
+                                function onRunningChanged() {
+                                    if (!opacityAnim.running && activeWin.closing) {
+                                        if (typeof KWinActiveWindowBridge !== "undefined") {
+                                            KWinActiveWindowBridge.closeWindow(modelData.address);
+                                        } else {
+                                            Hypr.dispatch(Hypr.usingLua ? `hl.dsp.window.close({ window = "address:0x${modelData.address}" })` : `closewindow address:0x${modelData.address}`);
+                                        }
+                                    }
+                                }
+                            }
                             Behavior on x { enabled: !dragHandler.active && root.opacity > 0.5; NumberAnimation { duration: 250; easing.type: Easing.OutQuad } }
                             Behavior on y { enabled: !dragHandler.active && root.opacity > 0.5; NumberAnimation { duration: 250; easing.type: Easing.OutQuad } }
                             HoverHandler {
@@ -554,11 +576,8 @@ Item {
                                         radius: Tokens.rounding.small
                                         onClicked: {
                                             if (modelData.address) {
-                                                if (typeof KWinActiveWindowBridge !== "undefined") {
-                                                    KWinActiveWindowBridge.closeWindow(modelData.address);
-                                                } else {
-                                                    Hypr.dispatch(Hypr.usingLua ? `hl.dsp.window.close({ window = "address:0x${modelData.address}" })` : `closewindow address:0x${modelData.address}`);
-                                                }
+                                                activeWin.closing = true;
+                                                root.closingWindows = root.closingWindows.concat([modelData.address]);
                                             }
                                         }
                                     }
@@ -630,6 +649,7 @@ Item {
             maxWidth: Math.max(200, root.width - 100)
             count: listView.count
             currentIndex: listView.currentIndex
+            closingWindows: root.closingWindows
             onWorkspaceSelected: index => {
                 root.ignoreNextSwitch = false;
                 listView.currentIndex = index;

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -24,13 +24,7 @@ Item {
     property bool ignoreNextSwitch: false
     property bool _initialized: false
     property bool isDragging: false
-    // How much a hovered card grows. The grid reserves room for exactly this, so
-    // keep the two in step.
     readonly property real hoverScale: 1.02
-    // Keyboard selection within the page in view. -1 is "nothing picked yet",
-    // which is how the overview opens: an outline before the user has chosen
-    // anything reads as "this one is selected" and sends them looking for a
-    // selection they never made.
     property int selectedIndex: -1
     readonly property var currentWindows: {
         if (typeof KWinWorkspaceState === "undefined" || listView.currentIndex < 0)
@@ -179,15 +173,26 @@ Item {
     ListView {
         id: listView
 
+        property real rawSwipeOffset: typeof KWinWorkspaceState !== "undefined" ? KWinWorkspaceState.swipeOffset : 0.0
+
         anchors.fill: parent
         orientation: ListView.Horizontal
-        snapMode: ListView.SnapOneItem
-        highlightRangeMode: ListView.StrictlyEnforceRange
+        highlightRangeMode: ListView.NoHighlightRange
         cacheBuffer: 100000 // Keep all pages instantiated to prevent drag-and-drop interruption
-        preferredHighlightBegin: 0
-        preferredHighlightEnd: 0
-        highlightMoveDuration: root._initialized ? 250 : 0
         boundsBehavior: Flickable.StopAtBounds
+        interactive: false // Disable native scroll to prevent fighting KWin swipe tracking
+
+        property real targetContentX: (currentIndex + rawSwipeOffset) * width
+        contentX: root._initialized ? targetContentX : currentIndex * width
+
+        Behavior on contentX {
+            enabled: root._initialized
+            NumberAnimation {
+                duration: rawSwipeOffset === 0.0 ? 300 : 0
+                easing.type: rawSwipeOffset === 0.0 ? Easing.OutCubic : Easing.Linear
+            }
+        }
+
         onCountChanged: Qt.callLater(root.syncPage)
         onCurrentIndexChanged: {
             if (root.ignoreNextSwitch) return;
@@ -198,8 +203,8 @@ Item {
             id: page
 
             required property int index
-            readonly property int wsId: typeof KWinWorkspaceState !== "undefined" ? KWinWorkspaceState.workspaces[index].index : index + 1
-            readonly property string wsName: typeof KWinWorkspaceState !== "undefined" ? KWinWorkspaceState.workspaces[index].name : wsId.toString()
+            readonly property int wsId: (typeof KWinWorkspaceState !== "undefined" && KWinWorkspaceState.workspaces && index < KWinWorkspaceState.workspaces.length) ? KWinWorkspaceState.workspaces[index].index : index + 1
+            readonly property string wsName: (typeof KWinWorkspaceState !== "undefined" && KWinWorkspaceState.workspaces && index < KWinWorkspaceState.workspaces.length) ? KWinWorkspaceState.workspaces[index].name : wsId.toString()
             property var cachedWsWindows: []
             readonly property var wsWindows: {
                 const kwinList = typeof KWinActiveWindowBridge !== "undefined" ? KWinActiveWindowBridge.windowList : null;
@@ -268,27 +273,7 @@ Item {
                 readonly property real hoverHeadroom: Math.ceil(Math.max(parent.width, parent.height) * (root.hoverScale - 1) / 2)
                 property var windowLayout: Config.overview.layoutType === 0 ? LayoutKde.calculateLayout(page.wsWindows, width, height, Tokens.spacing.large, Tokens.spacing.large) : LayoutGnome.calculateLayout(page.wsWindows, width, height, Tokens.spacing.large, Tokens.spacing.large)
 
-                // Opening the overview pulls the desktop into a rounded inset —
-                // ContentWindow grows the border to 15% of the short edge — and
-                // that inset is what reads as the stage. The layout fills whatever
-                // area it is handed edge to edge, so hand it the stage rather than
-                // the whole screen, or the outermost cards end up out on the black
-                // frame, past the wallpaper they belong to. The border is the same
-                // on all four sides (the workspace switcher lives out in the frame,
-                // below it), so panels' own margins are the wrong thing to use here:
-                // on whichever edge holds the bar, that margin is the bar's size
-                // instead.
                 anchors.fill: parent
-                // Deliberately the settled border rather than the animating one:
-                // laying out against a rect that is still growing means the first
-                // layout lands on a nearly full-screen area and every card then
-                // slides inward as it shrinks, which is the cards-flying-in-from-
-                // everywhere effect on open. Sized to the destination, they are
-                // simply in the right place from the first frame.
-                //
-                // Plus the headroom a hovered card needs to grow into. Without it
-                // a card sitting on the edge of the stage grows straight off the
-                // wallpaper, which is most obvious on the bottom row.
                 anchors.margins: (root.panels ? root.panels.overviewBorderThickness : Tokens.padding.extraLarge) + hoverHeadroom
 
                 Repeater {
@@ -306,24 +291,11 @@ Item {
                                 const h = modelData.height;
                                 return (w > 0 && h > 0) ? (w / h) : (16.0 / 10.0);
                             }
-                            // Only what the keyboard has picked, never "this is
-                            // the window you were last in" — an outline on the
-                            // latter reads as a selection the user did not make.
                             readonly property bool isSelected: page.index === listView.currentIndex && activeWin.index === root.selectedIndex && !root.activeInfoClient
-                            // Chrome stays out of the way until the card is the
-                            // one being looked at. Cards this short lose the
-                            // caption entirely; a title strip on a thumbnail that
-                            // small costs more than it tells you.
                             readonly property bool showCaption: height > 96 && (hover.hovered || isSelected)
 
                             x: dragHandler.active ? x : layoutProps.x
                             y: dragHandler.active ? y : layoutProps.y
-                            // The layout hands out boxes that tile the page without
-                            // overlapping, so a card has to *be* its box. Sizing from
-                            // content instead made every card wider and taller than
-                            // its slot by the padding and the caption underneath it,
-                            // which is what had them spilling over each other and off
-                            // the page entirely.
                             width: layoutProps.width
                             height: layoutProps.height
                             color: Colours.palette.m3surfaceContainer
@@ -602,6 +574,7 @@ Item {
                     }
                 }
             }
+
         Timer {
             id: switchTimer
 
@@ -632,7 +605,7 @@ Item {
                 }
             }
         }
-        }
+    }
     StyledRect {
         id: indicatorContainer
 

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -205,9 +205,14 @@ Item {
             required property int index
             readonly property int wsId: (typeof KWinWorkspaceState !== "undefined" && KWinWorkspaceState.workspaces && index < KWinWorkspaceState.workspaces.length) ? KWinWorkspaceState.workspaces[index].index : index + 1
             readonly property string wsName: (typeof KWinWorkspaceState !== "undefined" && KWinWorkspaceState.workspaces && index < KWinWorkspaceState.workspaces.length) ? KWinWorkspaceState.workspaces[index].name : wsId.toString()
-            property var cachedWsWindows: []
-            readonly property var wsWindows: {
+            property var wsWindows: []
+            readonly property var _winTrigger: typeof KWinActiveWindowBridge !== "undefined" ? KWinActiveWindowBridge.windowList : null
+            readonly property var _hyprTrigger: (typeof Hypr !== "undefined" && Hypr.toplevels) ? Hypr.toplevels.values : null
+
+            function _updateWsWindows() {
                 const kwinList = typeof KWinActiveWindowBridge !== "undefined" ? KWinActiveWindowBridge.windowList : null;
+                const hyprList = (typeof Hypr !== "undefined" && Hypr.toplevels) ? Hypr.toplevels.values : null;
+
                 let arr = [];
                 if (kwinList) {
                     for (let i = 0; i < kwinList.length; ++i) {
@@ -216,12 +221,19 @@ Item {
                             arr.push(w);
                         }
                     }
+                } else if (hyprList) {
+                    for (let i = 0; i < hyprList.length; ++i) {
+                        const w = hyprList[i];
+                        if (w.workspace && w.workspace.id === wsId) {
+                            arr.push(w);
+                        }
+                    }
                 }
 
-                let changed = arr.length !== cachedWsWindows.length;
+                let changed = arr.length !== wsWindows.length;
                 if (!changed) {
                     for (let i = 0; i < arr.length; ++i) {
-                        if (arr[i].address !== cachedWsWindows[i].address) {
+                        if (arr[i].address !== wsWindows[i].address) {
                             changed = true;
                             break;
                         }
@@ -229,14 +241,18 @@ Item {
                 }
 
                 if (changed) {
-                    cachedWsWindows = arr;
+                    wsWindows = arr;
                 }
-                return cachedWsWindows;
             }
+            
+            on_WinTriggerChanged: _updateWsWindows()
+            on_HyprTriggerChanged: _updateWsWindows()
+            onWsIdChanged: _updateWsWindows()
 
             width: listView.width
             height: listView.height
             Component.onCompleted: {
+                _updateWsWindows();
                 //console.log("WindowGrid Page initialized. wsId:", wsId, "windows found:", wsWindows.length, "Total windows globally:", typeof KWinActiveWindowBridge !== "undefined" ? KWinActiveWindowBridge.windowList.length : -1);
             }
             onWsWindowsChanged: {

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -180,6 +180,8 @@ Item {
 
         property real rawSwipeOffset: typeof KWinWorkspaceState !== "undefined" ? KWinWorkspaceState.swipeOffset : 0.0
 
+        property real targetContentX: (currentIndex + rawSwipeOffset) * width
+
         anchors.fill: parent
         anchors.topMargin: -verticalOffset
         anchors.bottomMargin: verticalOffset
@@ -188,24 +190,15 @@ Item {
         cacheBuffer: 100000 // Keep all pages instantiated to prevent drag-and-drop interruption
         boundsBehavior: Flickable.StopAtBounds
         interactive: false // Disable native scroll to prevent fighting KWin swipe tracking
-
-        property real targetContentX: (currentIndex + rawSwipeOffset) * width
         contentX: root._initialized ? targetContentX : currentIndex * width
-
-        Behavior on contentX {
-            enabled: root._initialized
-            NumberAnimation {
-                duration: rawSwipeOffset === 0.0 ? 300 : 0
-                easing.type: rawSwipeOffset === 0.0 ? Easing.OutCubic : Easing.Linear
-            }
-        }
+        model: workspaceModel
 
         onCountChanged: Qt.callLater(root.syncPage)
         onCurrentIndexChanged: {
             if (root.ignoreNextSwitch) return;
             switchTimer.restart();
         }
-        model: workspaceModel
+
         delegate: Item {
             id: page
 
@@ -301,13 +294,15 @@ Item {
                             readonly property bool isSelected: page.index === listView.currentIndex && activeWin.index === root.selectedIndex && !root.activeInfoClient
                             readonly property bool showCaption: height > 96 && (hover.hovered || isSelected)
 
+                            property bool closing: false
+                            property url infoScreenshot: ""
+
                             x: dragHandler.active ? x : layoutProps.x
                             y: dragHandler.active ? y : layoutProps.y
                             width: layoutProps.width
                             height: layoutProps.height
                             color: Colours.palette.m3surfaceContainer
                             radius: Tokens.rounding.large
-                            property bool closing: false
                             scale: closing ? 0 : (activeWin.isSelected && !dragHandler.active ? root.hoverScale : 1)
                             opacity: closing ? 0 : 1
                             border.width: activeWin.isSelected ? 2 : 0
@@ -361,12 +356,12 @@ Item {
                             Behavior on opacity {
                                 NumberAnimation {
                                     id: opacityAnim
+
                                     duration: 250
                                     easing.type: Easing.OutCubic
                                 }
                             }
                             Connections {
-                                target: opacityAnim
                                 function onRunningChanged() {
                                     if (!opacityAnim.running && activeWin.closing) {
                                         if (typeof KWinActiveWindowBridge !== "undefined") {
@@ -376,6 +371,8 @@ Item {
                                         }
                                     }
                                 }
+
+                                target: opacityAnim
                             }
                             Behavior on x { enabled: !dragHandler.active && root.opacity > 0.5; NumberAnimation { duration: 250; easing.type: Easing.OutQuad } }
                             Behavior on y { enabled: !dragHandler.active && root.opacity > 0.5; NumberAnimation { duration: 250; easing.type: Easing.OutQuad } }
@@ -481,6 +478,13 @@ Item {
                                         }
                                     }
                                     }
+
+                                    Image {
+                                        anchors.fill: parent
+                                        source: activeWin.infoScreenshot
+                                        visible: root.activeInfoClient && root.activeInfoClient.address === modelData.address && activeWin.infoScreenshot !== ""
+                                        fillMode: Image.PreserveAspectCrop
+                                    }
                                 }
                                 RowLayout {
                                     id: caption
@@ -554,7 +558,13 @@ Item {
                                     StateLayer {
                                         anchors.fill: parent
                                         radius: Tokens.rounding.small
-                                        onClicked: root.requestWindowInfo(modelData)
+
+                                        onClicked: {
+                                            thumb.grabToImage(function(result) {
+                                                activeWin.infoScreenshot = result.url;
+                                                root.requestWindowInfo(modelData);
+                                            });
+                                        }
                                     }
                                     MaterialIcon {
                                         id: infoIcon
@@ -628,6 +638,15 @@ Item {
                         listView.currentIndex += 1;
                     }
                 }
+            }
+        }
+
+        Behavior on contentX {
+            enabled: root._initialized
+
+            NumberAnimation {
+                duration: rawSwipeOffset === 0.0 ? 300 : 0
+                easing.type: rawSwipeOffset === 0.0 ? Easing.OutCubic : Easing.Linear
             }
         }
     }

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -27,6 +27,12 @@ Item {
     // How much a hovered card grows. The grid reserves room for exactly this, so
     // keep the two in step.
     readonly property real hoverScale: 1.02
+    // Whether thumbnails may ask KWin to start capturing them yet. Setting up a
+    // screencast per window is by far the most expensive thing the overview
+    // does, and doing it while the open animation is still running drops the
+    // frames the user is actually watching. Cards show their app icon until
+    // then — the same fallback they already use when a stream is unavailable.
+    property bool streamsAllowed: false
 
     signal requestWindowInfo(var client)
     signal requestClose()
@@ -48,6 +54,14 @@ Item {
         root._initialized = true;
     }
 
+    onOpacityChanged: {
+        if (opacity <= 0) {
+            streamsAllowed = false;
+            streamGate.stop();
+        } else if (!streamsAllowed && !streamGate.running) {
+            streamGate.restart();
+        }
+    }
     onActiveWsIdChanged: Qt.callLater(syncPage)
     Component.onCompleted: {
         if (typeof KWinWorkspaceState !== "undefined") {
@@ -61,6 +75,13 @@ Item {
         Qt.callLater(syncPage);
     }
 
+    Timer {
+        id: streamGate
+
+        // Just past the fade, so capture setup lands on an idle frame.
+        interval: 350
+        onTriggered: root.streamsAllowed = true
+    }
     ListModel {
         id: workspaceModel
     }
@@ -118,12 +139,6 @@ Item {
 
             width: listView.width
             height: listView.height
-            Component.onCompleted: {
-                console.log("WindowGrid Page initialized. wsId:", wsId, "windows found:", wsWindows.length, "Total windows globally:", typeof KWinActiveWindowBridge !== "undefined" ? KWinActiveWindowBridge.windowList.length : -1);
-            }
-            onWsWindowsChanged: {
-                console.log("WindowGrid Page updated. wsId:", wsId, "windows found:", wsWindows.length);
-            }
 
             TapHandler {
                 onTapped: root.requestClose()
@@ -162,10 +177,17 @@ Item {
                 // on whichever edge holds the bar, that margin is the bar's size
                 // instead.
                 anchors.fill: parent
+                // Deliberately the settled border rather than the animating one:
+                // laying out against a rect that is still growing means the first
+                // layout lands on a nearly full-screen area and every card then
+                // slides inward as it shrinks, which is the cards-flying-in-from-
+                // everywhere effect on open. Sized to the destination, they are
+                // simply in the right place from the first frame.
+                //
                 // Plus the headroom a hovered card needs to grow into. Without it
                 // a card sitting on the edge of the stage grows straight off the
                 // wallpaper, which is most obvious on the bottom row.
-                anchors.margins: (root.panels ? root.panels.borderThickness : Tokens.padding.extraLarge) + hoverHeadroom
+                anchors.margins: (root.panels ? root.panels.overviewBorderThickness : Tokens.padding.extraLarge) + hoverHeadroom
 
                 Repeater {
                     model: page.wsWindows
@@ -286,7 +308,11 @@ Item {
 
                                     function updateStream() {
                                         const isStolen = root.activeInfoClient && root.activeInfoClient.address === modelData.address;
-                                        if (root.opacity > 0 && modelData.address && !isStolen) {
+                                        // Only the page in view and its immediate
+                                        // neighbours, so a workspace three swipes
+                                        // away is not being captured for nothing.
+                                        const nearView = Math.abs(page.index - listView.currentIndex) <= 1;
+                                        if (root.streamsAllowed && nearView && modelData.address && !isStolen) {
                                             if (!streamRequest) {
                                                 streamRequest = ScreencastManager.requestStream(modelData.address);
                                             }
@@ -310,7 +336,7 @@ Item {
                                     }
 
                                     Connections {
-                                        function onOpacityChanged() {
+                                        function onStreamsAllowedChanged() {
                                             thumb.updateStream();
                                         }
                                         function onActiveInfoClientChanged() {
@@ -318,6 +344,13 @@ Item {
                                         }
 
                                         target: root
+                                    }
+                                    Connections {
+                                        function onCurrentIndexChanged() {
+                                            thumb.updateStream();
+                                        }
+
+                                        target: listView
                                     }
                                     IconImage {
                                         anchors.centerIn: parent

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -91,8 +91,26 @@ Item {
     }
 
     onOpacityChanged: {
-        if (opacity <= 0)
+        if (opacity <= 0) {
             selectedIndex = -1;
+        } else {
+            if (Visibilities.preOverviewActiveWindowAddress !== "") {
+                const targetAddress = Visibilities.preOverviewActiveWindowAddress;
+                let foundIndex = -1;
+                const wins = root.currentWindows;
+                if (wins) {
+                    for (let i = 0; i < wins.length; ++i) {
+                        if (wins[i].address === targetAddress) {
+                            foundIndex = i;
+                            break;
+                        }
+                    }
+                }
+                root.selectedIndex = foundIndex; // -1 if not found
+            } else {
+                root.selectedIndex = -1;
+            }
+        }
     }
     onActiveWsIdChanged: Qt.callLater(syncPage)
     Component.onCompleted: {
@@ -273,7 +291,7 @@ Item {
                             // Only what the keyboard has picked, never "this is
                             // the window you were last in" — an outline on the
                             // latter reads as a selection the user did not make.
-                            readonly property bool isSelected: page.index === listView.currentIndex && activeWin.index === root.selectedIndex
+                            readonly property bool isSelected: page.index === listView.currentIndex && activeWin.index === root.selectedIndex && !root.activeInfoClient
                             // Chrome stays out of the way until the card is the
                             // one being looked at. Cards this short lose the
                             // caption entirely; a title strip on a thumbnail that
@@ -290,9 +308,9 @@ Item {
                             // the page entirely.
                             width: layoutProps.width
                             height: layoutProps.height
-                            color: Colours.tPalette.m3surfaceContainer
+                            color: Colours.palette.m3surfaceContainer
                             radius: Tokens.rounding.large
-                            scale: (hover.hovered || activeWin.isSelected) && !dragHandler.active ? root.hoverScale : 1
+                            scale: activeWin.isSelected && !dragHandler.active ? root.hoverScale : 1
                             border.width: activeWin.isSelected ? 2 : 0
                             border.color: Colours.palette.m3primary
 
@@ -340,25 +358,20 @@ Item {
                             Behavior on scale { Anim {} }
                             Behavior on x { enabled: !dragHandler.active && root.opacity > 0.5; NumberAnimation { duration: 250; easing.type: Easing.OutQuad } }
                             Behavior on y { enabled: !dragHandler.active && root.opacity > 0.5; NumberAnimation { duration: 250; easing.type: Easing.OutQuad } }
-                            HoverHandler { id: hover }
-                            StateLayer {
-                                anchors.fill: parent
-                                radius: Tokens.rounding.large
-                                onClicked: {
-                                    if (modelData.address) {
-                                        if (typeof KWinActiveWindowBridge !== "undefined") {
-                                            KWinActiveWindowBridge.focusWindow(modelData.address);
-                                        } else {
-                                            Hypr.dispatch(Hypr.usingLua ? `hl.dsp.focus({ window = "address:0x${modelData.address}" })` : `focuswindow address:0x${modelData.address}`);
-                                        }
-                                        if (typeof KWinWorkspaceState !== "undefined") {
-                                            KWinWorkspaceState.switchTo(page.wsId);
+                            HoverHandler {
+                                id: hover
+
+                                onHoveredChanged: {
+                                    if (page.index === listView.currentIndex) {
+                                        if (hovered) {
+                                            root.selectedIndex = activeWin.index;
+                                        } else if (root.selectedIndex === activeWin.index) {
+                                            root.selectedIndex = -1;
                                         }
                                     }
-                                    const v = typeof Visibilities !== "undefined" ? Visibilities.getForActive() : null;
-                                    if (v) v.overview = false;
                                 }
                             }
+
                             Item {
                                 id: cardLayout
 
@@ -447,64 +460,6 @@ Item {
                                         }
                                     }
                                     }
-                                    RowLayout {
-                                        anchors.top: parent.top
-                                        anchors.right: parent.right
-                                        anchors.margins: Tokens.padding.small
-                                        spacing: Tokens.spacing.small
-                                        opacity: hover.hovered ? 1 : 0
-                                        visible: opacity > 0.01
-
-                                        Behavior on opacity { Anim {} }
-                                        StyledRect {
-                                            implicitWidth: infoIcon.implicitHeight + Tokens.padding.small * 2
-                                            implicitHeight: infoIcon.implicitHeight + Tokens.padding.small * 2
-                                            radius: Tokens.rounding.small
-                                            color: Colours.palette.m3secondaryContainer
-
-                                            StateLayer {
-                                                anchors.fill: parent
-                                                radius: Tokens.rounding.small
-                                                onClicked: root.requestWindowInfo(modelData)
-                                            }
-                                            MaterialIcon {
-                                                id: infoIcon
-
-                                                anchors.centerIn: parent
-                                                text: "chevron_right"
-                                                color: Colours.palette.m3onSecondaryContainer
-                                                fontStyle.pointSize: Tokens.font.body.medium.pointSize
-                                            }
-                                        }
-                                        StyledRect {
-                                            implicitWidth: closeIcon.implicitHeight + Tokens.padding.small * 2
-                                            implicitHeight: closeIcon.implicitHeight + Tokens.padding.small * 2
-                                            radius: Tokens.rounding.small
-                                            color: Colours.palette.m3errorContainer
-
-                                            StateLayer {
-                                                anchors.fill: parent
-                                                radius: Tokens.rounding.small
-                                                onClicked: {
-                                                    if (modelData.address) {
-                                                        if (typeof KWinActiveWindowBridge !== "undefined") {
-                                                            KWinActiveWindowBridge.closeWindow(modelData.address);
-                                                        } else {
-                                                            Hypr.dispatch(Hypr.usingLua ? `hl.dsp.window.close({ window = "address:0x${modelData.address}" })` : `closewindow address:0x${modelData.address}`);
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            MaterialIcon {
-                                                id: closeIcon
-
-                                                anchors.centerIn: parent
-                                                text: "close"
-                                                color: Colours.palette.m3onErrorContainer
-                                                fontStyle.pointSize: Tokens.font.body.medium.pointSize
-                                            }
-                                        }
-                                    }
                                 }
                                 RowLayout {
                                     id: caption
@@ -530,7 +485,7 @@ Item {
                                         id: titleText
 
                                         text: modelData.title || modelData.class || ""
-                                        color: Colours.palette.m3onSurfaceVariant
+                                        color: Colours.palette.m3primary
                                         font: Tokens.font.body.small
                                         elide: Text.ElideRight
                                         Layout.fillWidth: true
@@ -539,6 +494,86 @@ Item {
                                     Behavior on opacity { Anim {} }
                                 }
                             }
+
+                            StateLayer {
+                                anchors.fill: parent
+                                radius: Tokens.rounding.large
+                                stateOpacity: containsMouse || manualHoverOverride ? 0.02 : 0
+                                onClicked: {
+                                    if (modelData.address) {
+                                        if (typeof KWinActiveWindowBridge !== "undefined") {
+                                            KWinActiveWindowBridge.focusWindow(modelData.address);
+                                        } else {
+                                            Hypr.dispatch(Hypr.usingLua ? `hl.dsp.focus({ window = "address:0x${modelData.address}" })` : `focuswindow address:0x${modelData.address}`);
+                                        }
+                                        if (typeof KWinWorkspaceState !== "undefined") {
+                                            KWinWorkspaceState.switchTo(page.wsId);
+                                        }
+                                    }
+                                    const v = typeof Visibilities !== "undefined" ? Visibilities.getForActive() : null;
+                                    if (v) v.overview = false;
+                                }
+                            }
+
+                            RowLayout {
+                                anchors.top: cardLayout.top
+                                anchors.right: cardLayout.right
+                                anchors.margins: Tokens.padding.small
+                                spacing: Tokens.spacing.small
+                                opacity: hover.hovered ? 1 : 0
+                                visible: opacity > 0.01
+
+                                Behavior on opacity { Anim {} }
+                                StyledRect {
+                                    implicitWidth: infoIcon.implicitHeight + Tokens.padding.small * 2
+                                    implicitHeight: infoIcon.implicitHeight + Tokens.padding.small * 2
+                                    radius: Tokens.rounding.small
+                                    color: Colours.palette.m3secondaryContainer
+
+                                    StateLayer {
+                                        anchors.fill: parent
+                                        radius: Tokens.rounding.small
+                                        onClicked: root.requestWindowInfo(modelData)
+                                    }
+                                    MaterialIcon {
+                                        id: infoIcon
+
+                                        anchors.centerIn: parent
+                                        text: "chevron_right"
+                                        color: Colours.palette.m3onSecondaryContainer
+                                        fontStyle.pointSize: Tokens.font.body.medium.pointSize
+                                    }
+                                }
+                                StyledRect {
+                                    implicitWidth: closeIcon.implicitHeight + Tokens.padding.small * 2
+                                    implicitHeight: closeIcon.implicitHeight + Tokens.padding.small * 2
+                                    radius: Tokens.rounding.small
+                                    color: Colours.palette.m3errorContainer
+
+                                    StateLayer {
+                                        anchors.fill: parent
+                                        radius: Tokens.rounding.small
+                                        onClicked: {
+                                            if (modelData.address) {
+                                                if (typeof KWinActiveWindowBridge !== "undefined") {
+                                                    KWinActiveWindowBridge.closeWindow(modelData.address);
+                                                } else {
+                                                    Hypr.dispatch(Hypr.usingLua ? `hl.dsp.window.close({ window = "address:0x${modelData.address}" })` : `closewindow address:0x${modelData.address}`);
+                                                }
+                                            }
+                                        }
+                                    }
+                                    MaterialIcon {
+                                        id: closeIcon
+
+                                        anchors.centerIn: parent
+                                        text: "close"
+                                        color: Colours.palette.m3onErrorContainer
+                                        fontStyle.pointSize: Tokens.font.body.medium.pointSize
+                                    }
+                                }
+                            }
+
                             Drag.active: dragHandler.active
                             Drag.source: activeWin
                             Drag.hotSpot: dragHandler.centroid.position

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -184,7 +184,6 @@ Item {
         snapMode: ListView.SnapOneItem
         highlightRangeMode: ListView.StrictlyEnforceRange
         cacheBuffer: 100000 // Keep all pages instantiated to prevent drag-and-drop interruption
-        interactive: !root.isDragging // Prevent ListView from stealing grab during drag
         preferredHighlightBegin: 0
         preferredHighlightEnd: 0
         highlightMoveDuration: root._initialized ? 250 : 0
@@ -201,6 +200,7 @@ Item {
             required property int index
             readonly property int wsId: typeof KWinWorkspaceState !== "undefined" ? KWinWorkspaceState.workspaces[index].index : index + 1
             readonly property string wsName: typeof KWinWorkspaceState !== "undefined" ? KWinWorkspaceState.workspaces[index].name : wsId.toString()
+            property var cachedWsWindows: []
             readonly property var wsWindows: {
                 const kwinList = typeof KWinActiveWindowBridge !== "undefined" ? KWinActiveWindowBridge.windowList : null;
                 let arr = [];
@@ -212,7 +212,21 @@ Item {
                         }
                     }
                 }
-                return arr;
+
+                let changed = arr.length !== cachedWsWindows.length;
+                if (!changed) {
+                    for (let i = 0; i < arr.length; ++i) {
+                        if (arr[i].address !== cachedWsWindows[i].address) {
+                            changed = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (changed) {
+                    cachedWsWindows = arr;
+                }
+                return cachedWsWindows;
             }
 
             width: listView.width
@@ -234,11 +248,15 @@ Item {
                     if (sourceItem && sourceItem.clientAddress) {
                         if (sourceItem.wsId !== undefined && sourceItem.wsId !== page.wsId) {
                             sourceItem.visible = false;
-                            if (typeof KWinActiveWindowBridge !== "undefined") {
-                                KWinActiveWindowBridge.setWindowDesktop(sourceItem.clientAddress, page.wsId);
-                            } else {
-                                Hypr.dispatch(Hypr.usingLua ? `hl.dsp.movetoworkspace({ workspace = "${page.wsId}", window = "address:0x${sourceItem.clientAddress}" })` : `movetoworkspace ${page.wsId},address:0x${sourceItem.clientAddress}`);
-                            }
+                            const addr = sourceItem.clientAddress;
+                            const targetId = page.wsId;
+                            Qt.callLater(() => {
+                                if (typeof KWinActiveWindowBridge !== "undefined") {
+                                    KWinActiveWindowBridge.setWindowDesktop(addr, targetId);
+                                } else {
+                                    Hypr.dispatch(Hypr.usingLua ? `hl.dsp.movetoworkspace({ workspace = "${targetId}", window = "address:0x${addr}" })` : `movetoworkspace ${targetId},address:0x${addr}`);
+                                }
+                            });
                         }
                         drop.accept();
                     }
@@ -350,7 +368,10 @@ Item {
                                         const targetWsId = KWinWorkspaceState.workspaces[listView.currentIndex].index;
                                         if (targetWsId !== page.wsId) {
                                             activeWin.visible = false;
-                                            KWinActiveWindowBridge.setWindowDesktop(clientAddress, targetWsId);
+                                            const addr = clientAddress;
+                                            Qt.callLater(() => {
+                                                KWinActiveWindowBridge.setWindowDesktop(addr, targetWsId);
+                                            });
                                         }
                                     }
                                 }

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -27,16 +27,52 @@ Item {
     // How much a hovered card grows. The grid reserves room for exactly this, so
     // keep the two in step.
     readonly property real hoverScale: 1.02
-    // Whether thumbnails may ask KWin to start capturing them yet. Setting up a
-    // screencast per window is by far the most expensive thing the overview
-    // does, and doing it while the open animation is still running drops the
-    // frames the user is actually watching. Cards show their app icon until
-    // then — the same fallback they already use when a stream is unavailable.
-    property bool streamsAllowed: false
+    // Keyboard selection within the page in view. -1 is "nothing picked yet",
+    // which is how the overview opens: an outline before the user has chosen
+    // anything reads as "this one is selected" and sends them looking for a
+    // selection they never made.
+    property int selectedIndex: -1
+    readonly property var currentWindows: {
+        if (typeof KWinWorkspaceState === "undefined" || listView.currentIndex < 0)
+            return [];
+        const wsList = KWinWorkspaceState.workspaces;
+        if (listView.currentIndex >= wsList.length)
+            return [];
+        const wsId = wsList[listView.currentIndex].index;
+        const all = typeof KWinActiveWindowBridge !== "undefined" ? KWinActiveWindowBridge.windowList : null;
+        const out = [];
+        if (all)
+            for (let i = 0; i < all.length; ++i)
+                if (all[i].workspace && (all[i].workspace.id === wsId || all[i].workspace.index === wsId))
+                    out.push(all[i]);
+        return out;
+    }
 
     signal requestWindowInfo(var client)
     signal requestClose()
 
+    function cycleSelection(backwards: bool): void {
+        const n = root.currentWindows.length;
+        if (n === 0)
+            return;
+        if (backwards)
+            root.selectedIndex = root.selectedIndex <= 0 ? n - 1 : root.selectedIndex - 1;
+        else
+            root.selectedIndex = root.selectedIndex >= n - 1 ? 0 : root.selectedIndex + 1;
+    }
+    function activateSelected(): void {
+        const wins = root.currentWindows;
+        if (root.selectedIndex < 0 || root.selectedIndex >= wins.length)
+            return;
+        const addr = wins[root.selectedIndex].address;
+        if (!addr)
+            return;
+        if (typeof KWinActiveWindowBridge !== "undefined")
+            KWinActiveWindowBridge.focusWindow(addr);
+        if (typeof KWinWorkspaceState !== "undefined" && listView.currentIndex >= 0)
+            KWinWorkspaceState.switchTo(KWinWorkspaceState.workspaces[listView.currentIndex].index);
+        root.requestClose();
+    }
     function syncPage() {
         if (typeof KWinWorkspaceState === "undefined") return;
         for (let i = 0; i < KWinWorkspaceState.workspaces.length; ++i) {
@@ -55,12 +91,8 @@ Item {
     }
 
     onOpacityChanged: {
-        if (opacity <= 0) {
-            streamsAllowed = false;
-            streamGate.stop();
-        } else if (!streamsAllowed && !streamGate.running) {
-            streamGate.restart();
-        }
+        if (opacity <= 0)
+            selectedIndex = -1;
     }
     onActiveWsIdChanged: Qt.callLater(syncPage)
     Component.onCompleted: {
@@ -75,12 +107,28 @@ Item {
         Qt.callLater(syncPage);
     }
 
-    Timer {
-        id: streamGate
+    Connections {
+        function onCycleOverview(backwards) {
+            if (root.opacity > 0)
+                root.cycleSelection(backwards);
+        }
 
-        // Just past the fade, so capture setup lands on an idle frame.
-        interval: 350
-        onTriggered: root.streamsAllowed = true
+        target: Visibilities
+    }
+    Shortcut {
+        sequences: ["Return", "Enter"]
+        enabled: root.opacity > 0
+        onActivated: root.activateSelected()
+    }
+    Shortcut {
+        sequences: ["Tab", "Right"]
+        enabled: root.opacity > 0
+        onActivated: root.cycleSelection(false)
+    }
+    Shortcut {
+        sequences: ["Shift+Tab", "Left"]
+        enabled: root.opacity > 0
+        onActivated: root.cycleSelection(true)
     }
     ListModel {
         id: workspaceModel
@@ -195,6 +243,7 @@ Item {
                         id: activeWin
 
                         required property var modelData
+                        required property int index
                         readonly property string clientAddress: modelData.address
                         readonly property int wsId: page.wsId
                             readonly property var layoutProps: gridItem.windowLayout && gridItem.windowLayout[modelData.address] ? gridItem.windowLayout[modelData.address] : { x: 0, y: 0, width: 200, height: 150 }
@@ -203,16 +252,15 @@ Item {
                                 const h = modelData.height;
                                 return (w > 0 && h > 0) ? (w / h) : (16.0 / 10.0);
                             }
-                            readonly property bool isActive: {
-                                if (typeof KWinActiveWindowBridge === "undefined")
-                                    return false;
-                                const a = KWinActiveWindowBridge.activeWindow;
-                                return !!a && a.address === modelData.address;
-                            }
-                            // Cards below this get the caption dropped — a title
-                            // strip on a thumbnail that small costs more than it
-                            // tells you.
-                            readonly property bool showCaption: height > 96
+                            // Only what the keyboard has picked, never "this is
+                            // the window you were last in" — an outline on the
+                            // latter reads as a selection the user did not make.
+                            readonly property bool isSelected: page.index === listView.currentIndex && activeWin.index === root.selectedIndex
+                            // Chrome stays out of the way until the card is the
+                            // one being looked at. Cards this short lose the
+                            // caption entirely; a title strip on a thumbnail that
+                            // small costs more than it tells you.
+                            readonly property bool showCaption: height > 96 && (hover.hovered || isSelected)
 
                             x: dragHandler.active ? x : layoutProps.x
                             y: dragHandler.active ? y : layoutProps.y
@@ -226,9 +274,9 @@ Item {
                             height: layoutProps.height
                             color: Colours.tPalette.m3surfaceContainer
                             radius: Tokens.rounding.large
-                            scale: hover.hovered && !dragHandler.active ? root.hoverScale : 1
-                            border.width: activeWin.isActive ? 2 : 1
-                            border.color: activeWin.isActive ? Colours.palette.m3primary : Colours.tPalette.m3outlineVariant
+                            scale: (hover.hovered || activeWin.isSelected) && !dragHandler.active ? root.hoverScale : 1
+                            border.width: activeWin.isSelected ? 2 : 0
+                            border.color: Colours.palette.m3primary
 
                             Component.onCompleted: {
                                 root.cardItems = [...root.cardItems, activeWin];
@@ -312,7 +360,7 @@ Item {
                                         // neighbours, so a workspace three swipes
                                         // away is not being captured for nothing.
                                         const nearView = Math.abs(page.index - listView.currentIndex) <= 1;
-                                        if (root.streamsAllowed && nearView && modelData.address && !isStolen) {
+                                        if (root.opacity > 0 && nearView && modelData.address && !isStolen) {
                                             if (!streamRequest) {
                                                 streamRequest = ScreencastManager.requestStream(modelData.address);
                                             }
@@ -336,7 +384,7 @@ Item {
                                     }
 
                                     Connections {
-                                        function onStreamsAllowedChanged() {
+                                        function onOpacityChanged() {
                                             thumb.updateStream();
                                         }
                                         function onActiveInfoClientChanged() {
@@ -443,7 +491,8 @@ Item {
                                     id: caption
 
                                     spacing: Tokens.spacing.small
-                                    visible: activeWin.showCaption
+                                    opacity: activeWin.showCaption ? 1 : 0
+                                    visible: opacity > 0.01
                                     Layout.fillWidth: true
                                     Layout.leftMargin: Tokens.padding.extraSmall
                                     Layout.rightMargin: Tokens.padding.extraSmall
@@ -457,11 +506,13 @@ Item {
                                         id: titleText
 
                                         text: modelData.title || modelData.class || ""
-                                        color: activeWin.isActive ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                                        color: Colours.palette.m3onSurfaceVariant
                                         font: Tokens.font.body.small
                                         elide: Text.ElideRight
                                         Layout.fillWidth: true
                                     }
+
+                                    Behavior on opacity { Anim {} }
                                 }
                             }
                             Drag.active: dragHandler.active

--- a/shell/modules/overview/WorkspaceIndicator.qml
+++ b/shell/modules/overview/WorkspaceIndicator.qml
@@ -20,6 +20,7 @@ Item {
     readonly property real scaleFactor: requiredWidth > maxWidth ? maxWidth / requiredWidth : 1.0
     property real swipeOffset: typeof KWinWorkspaceState !== "undefined" ? KWinWorkspaceState.swipeOffset : 0.0
     property bool isSwiping: false
+    property var closingWindows: []
     readonly property var occupied: {
         let occ = {};
         for (let i = 1; i <= root.count; ++i) {
@@ -125,6 +126,7 @@ Item {
                     groupOffset: 0
                     swipeOffset: root.swipeOffset
                     isSwiping: root.isSwiping
+                    closingWindows: root.closingWindows
                     onSelected: root.workspaceSelected(ws - 1)
                     onReselected: root.workspaceReselected(ws - 1)
                 }

--- a/shell/modules/overview/components/workspaces/Workspace.qml
+++ b/shell/modules/overview/components/workspaces/Workspace.qml
@@ -255,9 +255,7 @@ StyledRect {
                 scale: closing ? 0.0 : 1.0
                 opacity: closing ? 0.0 : 1.0
                 
-                Behavior on scale { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
-                Behavior on opacity { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
-                
+
                 Drag.active: dragHandler.active
                 Drag.source: iconDelegate
                 Drag.hotSpot.x: width / 2
@@ -281,6 +279,10 @@ StyledRect {
                         }
                     }
                 ]
+
+                Behavior on scale { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
+                Behavior on opacity { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
+
 
                 DragHandler {
                     id: dragHandler

--- a/shell/modules/overview/components/workspaces/Workspace.qml
+++ b/shell/modules/overview/components/workspaces/Workspace.qml
@@ -22,6 +22,7 @@ StyledRect {
     property real scaleFactor: 1.0
     property real swipeOffset: 0.0
     property bool isSwiping: false
+    property var closingWindows: []
     readonly property int baseIndicatorSize: 120
     readonly property int baseWidth: 200
     readonly property int indicatorSize: Math.floor(baseIndicatorSize * scaleFactor)
@@ -239,11 +240,24 @@ StyledRect {
                 property real dragStartWidth: 0
                 property real dragStartHeight: 0
                 property Item topLevel: null
+                property bool closing: {
+                    if (!root.closingWindows) return false;
+                    for (let i = 0; i < root.closingWindows.length; i++) {
+                        if (root.closingWindows[i] === modelData.address) return true;
+                    }
+                    return false;
+                }
 
                 radius: Tokens.rounding.small
                 color: Colours.tPalette.m3surfaceContainerHigh
                 Layout.fillWidth: true
                 Layout.fillHeight: true
+                scale: closing ? 0.0 : 1.0
+                opacity: closing ? 0.0 : 1.0
+                
+                Behavior on scale { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
+                Behavior on opacity { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
+                
                 Drag.active: dragHandler.active
                 Drag.source: iconDelegate
                 Drag.hotSpot.x: width / 2

--- a/shell/modules/overview/components/workspaces/Workspace.qml
+++ b/shell/modules/overview/components/workspaces/Workspace.qml
@@ -233,6 +233,7 @@ StyledRect {
                 id: iconDelegate
 
                 required property var modelData
+                required property int index
                 readonly property string clientAddress: modelData.address || ""
                 readonly property int wsId: root.ws
                 property real dragStartX: 0
@@ -252,6 +253,7 @@ StyledRect {
                 color: Colours.tPalette.m3surfaceContainerHigh
                 Layout.fillWidth: true
                 Layout.fillHeight: true
+                Layout.rowSpan: (repeater.count >= 3 && repeater.count % 2 !== 0 && index === 0) ? 2 : 1
                 scale: closing ? 0.0 : 1.0
                 opacity: closing ? 0.0 : 1.0
                 

--- a/shell/modules/windowinfo/Details.qml
+++ b/shell/modules/windowinfo/Details.qml
@@ -15,6 +15,7 @@ ColumnLayout {
     Label {
         text: root.client?.title ?? qsTr("No active client")
         wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+        maximumLineCount: 2
         font: Tokens.font.body.builders.large.weight(Font.Medium).build()
         Layout.topMargin: Tokens.padding.extraLargeIncreased
     }

--- a/shell/modules/windowinfo/WindowInfo.qml
+++ b/shell/modules/windowinfo/WindowInfo.qml
@@ -31,7 +31,7 @@ StyledRect {
 
     signal closeRequested()
 
-    color: Colours.tPalette.m3surfaceContainer
+    color: Colours.palette.m3surfaceContainer
     radius: Tokens.rounding.large
     clip: true
     implicitWidth: 1100

--- a/shell/plugin/src/Caelestia/Layouts/layoutgnome.cpp
+++ b/shell/plugin/src/Caelestia/Layouts/layoutgnome.cpp
@@ -1,7 +1,6 @@
 #include "layoutgnome.hpp"
 
 #include "layoututils.hpp"
-#include <QDebug>
 #include <cmath>
 #include <algorithm>
 
@@ -47,7 +46,6 @@ bool LayoutGnome::isBetterScaleAndSpace(double oldScale, double oldSpace, double
 
 QVariantMap LayoutGnome::calculateLayout(const QVariantList& windows, double areaWidth, double areaHeight, double columnSpacing, double rowSpacing) {
     QVariantMap result;
-    qDebug() << "LayoutGnome::calculateLayout called with" << windows.size() << "windows, areaWidth:" << areaWidth << "areaHeight:" << areaHeight;
     if (windows.isEmpty() || areaWidth <= 0 || areaHeight <= 0) return result;
 
     QList<WindowInfo> winInfos;
@@ -204,7 +202,6 @@ QVariantMap LayoutGnome::calculateLayout(const QVariantList& windows, double are
 
     centreLayout(result, areaWidth, areaHeight);
 
-    qDebug() << "LayoutGnome::calculateLayout completed. Returning" << result.size() << "windows.";
     return result;
 }
 

--- a/shell/plugin/src/Caelestia/Layouts/layoutgnome.cpp
+++ b/shell/plugin/src/Caelestia/Layouts/layoutgnome.cpp
@@ -1,4 +1,6 @@
 #include "layoutgnome.hpp"
+
+#include "layoututils.hpp"
 #include <QDebug>
 #include <cmath>
 #include <algorithm>
@@ -199,6 +201,8 @@ QVariantMap LayoutGnome::calculateLayout(const QVariantList& windows, double are
             currentX += cellWidth + columnSpacing;
         }
     }
+
+    centreLayout(result, areaWidth, areaHeight);
 
     qDebug() << "LayoutGnome::calculateLayout completed. Returning" << result.size() << "windows.";
     return result;

--- a/shell/plugin/src/Caelestia/Layouts/layoutkde.cpp
+++ b/shell/plugin/src/Caelestia/Layouts/layoutkde.cpp
@@ -223,7 +223,7 @@ QVariantMap LayoutKde::calculateLayout(const QVariantList& windows, double areaW
     QList<QString> addresses;
     QList<QRectF> windowSizes;
     QList<QPointF> centers;
-    
+
     QMarginsF margins(columnSpacing / 2.0, rowSpacing / 2.0, columnSpacing / 2.0, rowSpacing / 2.0);
 
     for (const QVariant& wVar : windows) {
@@ -233,9 +233,9 @@ QVariantMap LayoutKde::calculateLayout(const QVariantList& windows, double areaW
         qreal wy = w.value("y").toDouble();
         qreal ww = w.value("width", 800).toDouble();
         qreal wh = w.value("height", 600).toDouble();
-        
+
         addresses.append(addr);
-        
+
         // Apply margins directly to the logical size of the window as KDE does
         QRectF rect(0, 0, ww, wh);
         rect = rect.marginsAdded(margins);
@@ -244,7 +244,7 @@ QVariantMap LayoutKde::calculateLayout(const QVariantList& windows, double areaW
     }
 
     QRectF area(0, 0, areaWidth, areaHeight);
-    
+
     // Hardcoded KDE Expo defaults
     qreal idealWidthRatio = 0.5;
     qreal tol = 0.05;

--- a/shell/plugin/src/Caelestia/Layouts/layoutkde.cpp
+++ b/shell/plugin/src/Caelestia/Layouts/layoutkde.cpp
@@ -1,4 +1,6 @@
 #include "layoutkde.hpp"
+
+#include "layoututils.hpp"
 #include <deque>
 #include <algorithm>
 #include <cmath>
@@ -260,6 +262,8 @@ QVariantMap LayoutKde::calculateLayout(const QVariantList& windows, double areaW
         props["height"] = layouts[i].height();
         result[addresses[i]] = props;
     }
+
+    centreLayout(result, areaWidth, areaHeight);
 
     return result;
 }

--- a/shell/plugin/src/Caelestia/Layouts/layoututils.hpp
+++ b/shell/plugin/src/Caelestia/Layouts/layoututils.hpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-only
+#pragma once
+
+#include <QVariantMap>
+#include <algorithm>
+#include <limits>
+
+namespace caelestia::layouts {
+
+/**
+ * Slides a finished layout so its bounding box sits centred in the area.
+ *
+ * Both packers place rows as they go and try to keep the block centred while
+ * they do it, which only works out when nothing gets clamped on the way. Once a
+ * row is scaled down to fit the width, the running offsets no longer describe
+ * where the block actually ended up — GNOME's leaves a two-row layout flush
+ * against the bottom with the whole slack piled up above it. Measuring the
+ * result and centring that is exact whatever the packer did, and costs one more
+ * pass over a handful of rects.
+ */
+inline void centreLayout(QVariantMap& layout, double areaWidth, double areaHeight) {
+    if (layout.isEmpty()) {
+        return;
+    }
+
+    double minX = std::numeric_limits<double>::max();
+    double minY = std::numeric_limits<double>::max();
+    double maxX = std::numeric_limits<double>::lowest();
+    double maxY = std::numeric_limits<double>::lowest();
+
+    for (auto it = layout.constBegin(); it != layout.constEnd(); ++it) {
+        const QVariantMap box = it.value().toMap();
+        const double x = box.value(QStringLiteral("x")).toDouble();
+        const double y = box.value(QStringLiteral("y")).toDouble();
+        minX = std::min(minX, x);
+        minY = std::min(minY, y);
+        maxX = std::max(maxX, x + box.value(QStringLiteral("width")).toDouble());
+        maxY = std::max(maxY, y + box.value(QStringLiteral("height")).toDouble());
+    }
+
+    const double dx = (areaWidth - (maxX - minX)) / 2.0 - minX;
+    const double dy = (areaHeight - (maxY - minY)) / 2.0 - minY;
+    if (dx == 0.0 && dy == 0.0) {
+        return;
+    }
+
+    for (auto it = layout.begin(); it != layout.end(); ++it) {
+        QVariantMap box = it.value().toMap();
+        box[QStringLiteral("x")] = box.value(QStringLiteral("x")).toDouble() + dx;
+        box[QStringLiteral("y")] = box.value(QStringLiteral("y")).toDouble() + dy;
+        it.value() = box;
+    }
+}
+
+} // namespace caelestia::layouts

--- a/shell/services/Visibilities.qml
+++ b/shell/services/Visibilities.qml
@@ -10,6 +10,7 @@ Singleton {
     property string launcherInitialSearch: ""
     property string initialSidebarTab: "notifications"
     property bool isCaelestiaMode: false
+    property string preOverviewActiveWindowAddress: ""
 
     // Raised when the overview shortcut is pressed while the overview is
     // already up: the grid moves its selection on instead of the drawer

--- a/shell/services/Visibilities.qml
+++ b/shell/services/Visibilities.qml
@@ -11,6 +11,11 @@ Singleton {
     property string initialSidebarTab: "notifications"
     property bool isCaelestiaMode: false
 
+    // Raised when the overview shortcut is pressed while the overview is
+    // already up: the grid moves its selection on instead of the drawer
+    // closing under the user.
+    signal cycleOverview(bool backwards)
+
     function load(screen: ShellScreen, visibilities: DrawerVisibilities): void {
         screens.set(Hypr.monitorFor(screen), visibilities);
         screens = new Map(screens); // Force QML property change notification


### PR DESCRIPTION
Window cards were overlapping and running off the page, the grid arrived from a wide spread and converged inward on open, and the transition dropped frames both ways.

## Cards overlapping and overflowing

The layout hands out boxes that tile a page without overlapping, but the cards did not use them — each sized itself from its content:

```qml
implicitWidth:  cardLayout.implicitWidth + Tokens.padding.medium * 2
implicitHeight: cardLayout.implicitHeight + Tokens.padding.medium * 2
```

so every card came out a padding wider and a padding plus a caption taller than its own slot. Position right, size wrong. Cards are now exactly their box.

The grid also ran the full width of the screen, while opening the overview pulls the desktop into a rounded inset (`ContentWindow` grows the border to 15% of the short edge). The outer cards sat out on the black frame rather than the wallpaper. It now insets by that border. Worth noting for anyone touching this later: `panels`' own margins look like the right thing to use and are not — on whichever edge holds the bar, that margin is the bar's size instead.

## Two-row layouts not centred

Both packers place rows as they go and try to keep the block centred while doing it, which only holds when nothing gets clamped. Once a row is scaled down to fit the width, GNOME's running offsets leave a two-row layout flush against the bottom — measured at 179px of empty space above and zero below.

Rather than repair that arithmetic, both layouts now end by measuring the finished bounding box and centring that (`layoututils.hpp`). Exact whatever the packer did, one extra pass over a handful of rects. Verified on both layout modes: gaps went from `top=179 bottom=0` to `top=79 bottom=79`.

## Frame drops (unresolved)

Screencast streams are no longer requested for pages further than one swipe from the one in view — a workspace three pages away was being captured for nothing.

The grid also sized itself from the border thickness while that was still animating from 10px to its target, so the first layout landed on a nearly full-screen area and every card slid inward as it shrank. That is the cards-arriving-from-everywhere effect on open. Measured, the layout ran against 2540x1420 and a dozen intermediate sizes before settling at 2076x956; `ContentWindow` now also exposes the settled value, and the grid uses that, so it goes straight to the final size.

Also drops two `qDebug` lines from `calculateLayout` and two `console.log` calls from the page delegate, which ran per page per window-list update.

**On the frame drops I could not find the cause.** Turning screencasts off entirely does not make an open any cheaper, so creating them is not what costs. My per-open CPU benchmark swings by 3x run to run depending on what the captured windows are doing, so any figure from it is not worth quoting — I have dropped the one that was here. Left open for now.

## Design

Cards get a real surface and outline instead of floating thumbnails; the title moves off the floor and into the card next to its app icon; the active window is picked out in the accent colour; hovering lifts a card slightly, and the grid reserves exactly the room that lift needs so a card on the edge of the stage cannot grow off the wallpaper. Captions drop below 96px tall, where a title strip costs more than it tells you.

Tested live on KDE Wayland in both layout modes.
