### PR TITLE
feat: replace KRunner with Vicinae, themed from the shell's palette

### DIFF
--- a/scripts/06-services.sh
+++ b/scripts/06-services.sh
@@ -110,14 +110,12 @@ systemctl --user start ydotoold.service 2>/dev/null || \
     echo "  [INFO] ydotoold will start on next login."
 echo "  [OK]  ydotoold service configured."
 
-#  Vicinae (replaces KRunner)
-# KRunner is D-Bus activated, so stopping it is not enough — the next lookup
-# would start it straight back up. Masking is what actually keeps it down.
-echo "  Disabling KRunner..."
-systemctl --user mask plasma-krunner.service 2>/dev/null || true
-systemctl --user stop plasma-krunner.service 2>/dev/null || true
-pkill -x krunner 2>/dev/null || true
-
+#  Vicinae
+# KRunner is left alone. The shell binds Alt+Space through its own
+# GlobalShortcut, which takes the key off whoever holds it and hands it back
+# when the shell exits — KRunner included. Masking the service would disable it
+# outright and only be undone by the uninstaller, so a machine that simply
+# stopped running Caelestia would be left without it.
 if command -v vicinae >/dev/null 2>&1; then
     echo "  Enabling Vicinae launcher daemon..."
     # Both the AUR package and the upstream tarball ship a unit — /usr/lib for

--- a/scripts/06-services.sh
+++ b/scripts/06-services.sh
@@ -120,8 +120,11 @@ pkill -x krunner 2>/dev/null || true
 
 if command -v vicinae >/dev/null 2>&1; then
     echo "  Enabling Vicinae launcher daemon..."
-    # The package ships its own unit; only write one if it did not.
-    if [[ ! -f /usr/lib/systemd/user/vicinae.service && ! -f "$HOME/.config/systemd/user/vicinae.service" ]]; then
+    # Both the AUR package and the upstream tarball ship a unit — /usr/lib for
+    # the former, /usr/local/lib for the latter. Only write one if neither did.
+    if [[ ! -f /usr/lib/systemd/user/vicinae.service \
+       && ! -f /usr/local/lib/systemd/user/vicinae.service \
+       && ! -f "$HOME/.config/systemd/user/vicinae.service" ]]; then
         mkdir -p "$HOME/.config/systemd/user"
         cat > "$HOME/.config/systemd/user/vicinae.service" <<'UNIT'
 [Unit]

--- a/scripts/06-services.sh
+++ b/scripts/06-services.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+BUNDLE_DIR="${BUNDLE_DIR:?BUNDLE_DIR not set}"
+
 echo
 echo ""
 echo "  Step 6/11  Services & KWin"
@@ -107,5 +109,92 @@ systemctl --user enable ydotoold.service 2>/dev/null || true
 systemctl --user start ydotoold.service 2>/dev/null || \
     echo "  [INFO] ydotoold will start on next login."
 echo "  [OK]  ydotoold service configured."
+
+#  Vicinae (replaces KRunner)
+# KRunner is D-Bus activated, so stopping it is not enough — the next lookup
+# would start it straight back up. Masking is what actually keeps it down.
+echo "  Disabling KRunner..."
+systemctl --user mask plasma-krunner.service 2>/dev/null || true
+systemctl --user stop plasma-krunner.service 2>/dev/null || true
+pkill -x krunner 2>/dev/null || true
+
+if command -v vicinae >/dev/null 2>&1; then
+    echo "  Enabling Vicinae launcher daemon..."
+    # The package ships its own unit; only write one if it did not.
+    if [[ ! -f /usr/lib/systemd/user/vicinae.service && ! -f "$HOME/.config/systemd/user/vicinae.service" ]]; then
+        mkdir -p "$HOME/.config/systemd/user"
+        cat > "$HOME/.config/systemd/user/vicinae.service" <<'UNIT'
+[Unit]
+Description=Vicinae Launcher Daemon
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=vicinae server --replace
+Restart=always
+RestartSec=5
+KillMode=process
+
+[Install]
+WantedBy=graphical-session.target
+UNIT
+    fi
+
+    # Alt+Space is what KRunner used and is free here; Caelestia keeps Meta and
+    # Meta+Space for its own launcher, so the two do not fight over a key.
+    mkdir -p "$HOME/.local/share/applications"
+    cat > "$HOME/.local/share/applications/vicinae-toggle.desktop" <<'DESKTOP'
+[Desktop Entry]
+Type=Application
+Name=Toggle Vicinae
+Comment=Show or hide the Vicinae launcher
+Exec=vicinae toggle
+Icon=vicinae
+Terminal=false
+NoDisplay=true
+DESKTOP
+    kwriteconfig6 --file kglobalshortcutsrc --group services \
+        --group "vicinae-toggle.desktop" --key "_launch" "Alt+Space,none,Toggle Vicinae"
+
+    #  Material palette -> Vicinae theme
+    # Vicinae watches its theme directory, so regenerating the file is enough
+    # for a running instance to pick the new colours up.
+    if [[ -x "$BUNDLE_DIR/shell/scripts/vicinae-theme.py" ]]; then
+        mkdir -p "$HOME/.local/bin"
+        install -m755 "$BUNDLE_DIR/shell/scripts/vicinae-theme.py" "$HOME/.local/bin/caelestia-vicinae-theme"
+        "$HOME/.local/bin/caelestia-vicinae-theme" 2>/dev/null || \
+            echo "  [INFO] No scheme yet; the theme will be written on the next scheme change."
+
+        cat > "$HOME/.config/systemd/user/caelestia-vicinae-theme.service" <<'UNIT'
+[Unit]
+Description=Regenerate the Vicinae theme from Caelestia's colour scheme
+
+[Service]
+Type=oneshot
+ExecStart=%h/.local/bin/caelestia-vicinae-theme
+UNIT
+        cat > "$HOME/.config/systemd/user/caelestia-vicinae-theme.path" <<'UNIT'
+[Unit]
+Description=Watch Caelestia's colour scheme for Vicinae
+
+[Path]
+PathModified=%h/.local/state/caelestia/scheme.json
+
+[Install]
+WantedBy=graphical-session.target
+UNIT
+        systemctl --user enable caelestia-vicinae-theme.path 2>/dev/null || true
+    fi
+
+    systemctl --user daemon-reload
+    systemctl --user enable vicinae.service 2>/dev/null || true
+    systemctl --user start vicinae.service 2>/dev/null || \
+        echo "  [INFO] Vicinae will start on next login."
+    systemctl --user start caelestia-vicinae-theme.path 2>/dev/null || true
+    echo "  [OK]  Vicinae configured (Alt+Space)."
+else
+    echo "  [INFO] vicinae not installed; skipping launcher setup."
+fi
 
 echo "[OK]  Services configured."

--- a/scripts/06-services.sh
+++ b/scripts/06-services.sh
@@ -144,22 +144,6 @@ WantedBy=graphical-session.target
 UNIT
     fi
 
-    # Alt+Space is what KRunner used and is free here; Caelestia keeps Meta and
-    # Meta+Space for its own launcher, so the two do not fight over a key.
-    mkdir -p "$HOME/.local/share/applications"
-    cat > "$HOME/.local/share/applications/vicinae-toggle.desktop" <<'DESKTOP'
-[Desktop Entry]
-Type=Application
-Name=Toggle Vicinae
-Comment=Show or hide the Vicinae launcher
-Exec=vicinae toggle
-Icon=vicinae
-Terminal=false
-NoDisplay=true
-DESKTOP
-    kwriteconfig6 --file kglobalshortcutsrc --group services \
-        --group "vicinae-toggle.desktop" --key "_launch" "Alt+Space,none,Toggle Vicinae"
-
     #  Material palette -> Vicinae theme
     # Vicinae watches its theme directory, so regenerating the file is enough
     # for a running instance to pick the new colours up.

--- a/sdata/arch-dist/installDP.sh
+++ b/sdata/arch-dist/installDP.sh
@@ -6,6 +6,78 @@ set -uo pipefail
 log()  { echo -e "\033[0;36m[INFO]\033[0m $*"; }
 err()  { echo -e "\033[0;31m[ERR]\033[0m  $*"; }
 
+# Vicinae is installed from the tarball upstream publishes rather than the AUR,
+# so the only party trusted is the project itself. That tarball is laid out as a
+# prefix (bin/, libexec/, share/, lib/systemd/user/) and resolves its helpers
+# relative to the binary, so it unpacks into /usr/local — already on systemd's
+# user unit search path, so the service it ships is found as-is.
+#
+# What the AUR package did and this has to do by hand: verify the download,
+# grant the input helper its capability, and load uinput. Its runtime
+# dependencies stay with pacman, in UTILITY_PACKAGES.
+VICINAE_VERSION="0.24.0"
+# sha256 of vicinae-linux-x86_64-v0.24.0.tar.gz as published upstream; bump with
+# VICINAE_VERSION.
+VICINAE_SHA256="015a1ef2f8b23ea36a3f831a41de2d138f927cf45c987f62de3ec4add8dbafe7"
+install_vicinae_tarball() {
+    if [[ "$(uname -m)" != "x86_64" ]]; then
+        err "Vicinae ships an x86_64 tarball only; on $(uname -m) install the AppImage from https://github.com/vicinaehq/vicinae/releases"
+        return 1
+    fi
+
+    local url="https://github.com/vicinaehq/vicinae/releases/download/v${VICINAE_VERSION}/vicinae-linux-x86_64-v${VICINAE_VERSION}.tar.gz"
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+
+    log "Downloading Vicinae ${VICINAE_VERSION}..."
+    if ! curl -fsSL "$url" -o "$tmpdir/vicinae.tar.gz"; then
+        err "Failed to download Vicinae."
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
+    # This unpacks as root into /usr/local, so the download is checked before it
+    # is trusted, not after.
+    local got
+    got="$(sha256sum "$tmpdir/vicinae.tar.gz" | cut -d" " -f1)"
+    if [[ "$got" != "$VICINAE_SHA256" ]]; then
+        err "Vicinae checksum mismatch - refusing to install."
+        err "  expected $VICINAE_SHA256"
+        err "  got      $got"
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
+    if ! sudo tar -xzf "$tmpdir/vicinae.tar.gz" -C /usr/local --strip-components=1; then
+        err "Failed to unpack Vicinae into /usr/local."
+        rm -rf "$tmpdir"
+        return 1
+    fi
+    rm -rf "$tmpdir"
+    sudo systemctl daemon-reload 2>/dev/null || true
+
+    # Snippets and paste need the input helper to read /dev/input and inject
+    # through /dev/uinput. The tarball ships the modules-load.d drop-in for the
+    # latter, but that only applies at boot.
+    sudo setcap "cap_dac_override+ep" /usr/local/libexec/vicinae/vicinae-input-server 2>/dev/null || \
+        err "setcap failed; Vicinae snippets and paste will not work."
+    sudo modprobe uinput 2>/dev/null || \
+        log "Could not load uinput now; snippets and paste will work after a reboot."
+
+    local missing
+    missing="$(ldd /usr/local/bin/vicinae 2>/dev/null | awk '/not found/ {print "    " $1}')"
+    if [[ -n "$missing" ]]; then
+        err "Vicinae installed but is missing shared libraries:"
+        printf '%s\n' "$missing"
+        err "Install the packages providing those, then: systemctl --user restart vicinae"
+        return 1
+    fi
+
+    log "Vicinae ${VICINAE_VERSION} installed to /usr/local."
+    return 0
+}
+
+
 log "Installing Arch packages..."
 
 INSTALL_FISH="${INSTALL_FISH:-true}"
@@ -46,7 +118,11 @@ THEME_PACKAGES=(
 
 UTILITY_PACKAGES=(
     swappy brightnessctl ddcutil networkmanager imagemagick tesseract tesseract-data-eng satty spectacle xdg-utils sassc
-    vicinae-bin
+    # Vicinae's runtime dependencies. The launcher itself comes from upstream's
+    # tarball below rather than the AUR, but what it links against is ordinary
+    # packaged software and is left to pacman. qt6-base, qt6-declarative and
+    # libqalculate are already in CORE_PACKAGES.
+    nodejs qt6-svg layer-shell-qt qtkeychain-qt6 syntax-highlighting
 )
 
 # Build final package list based on selected group
@@ -109,6 +185,14 @@ if ! yay -S --needed --noconfirm "${PACKAGES[@]}"; then
             rm -rf "$tmpdir"
         fi
     done
+fi
+
+if [[ "$PACKAGE_GROUP" == "all" || "$PACKAGE_GROUP" == "utils" ]]; then
+    if command -v vicinae >/dev/null 2>&1; then
+        log "Vicinae already installed; skipping."
+    else
+        install_vicinae_tarball || FAILED_PKGS+=("vicinae")
+    fi
 fi
 
 if [ ${#FAILED_PKGS[@]} -ne 0 ]; then

--- a/sdata/arch-dist/installDP.sh
+++ b/sdata/arch-dist/installDP.sh
@@ -46,6 +46,7 @@ THEME_PACKAGES=(
 
 UTILITY_PACKAGES=(
     swappy brightnessctl ddcutil networkmanager imagemagick tesseract tesseract-data-eng satty spectacle xdg-utils sassc
+    vicinae-bin
 )
 
 # Build final package list based on selected group

--- a/sdata/debian-dist/installDP_debian.sh
+++ b/sdata/debian-dist/installDP_debian.sh
@@ -54,6 +54,15 @@ install_vicinae_tarball() {
     rm -rf "$tmpdir"
     sudo systemctl daemon-reload 2>/dev/null || true
 
+    # Snippets and paste need the input helper to read /dev/input and inject
+    # through /dev/uinput. The tarball ships the modules-load.d drop-in that
+    # gets uinput loaded at boot, but not the capability, and neither applies
+    # until something does them — the AUR package does both from post_install.
+    sudo setcap "cap_dac_override+ep" /usr/local/libexec/vicinae/vicinae-input-server 2>/dev/null || \
+        err "setcap failed; Vicinae snippets and paste will not work."
+    sudo modprobe uinput 2>/dev/null || \
+        log "Could not load uinput now; snippets and paste will work after a reboot."
+
     # The tarball carries no dependency metadata, so whatever it links against
     # has to be present already. Rather than guess package names for every
     # distro and release, ask the binary what is missing and say so plainly.

--- a/sdata/debian-dist/installDP_debian.sh
+++ b/sdata/debian-dist/installDP_debian.sh
@@ -6,6 +6,43 @@ set -uo pipefail
 log()  { echo -e "\033[0;36m[INFO]\033[0m $*"; }
 err()  { echo -e "\033[0;31m[ERR]\033[0m  $*"; }
 
+# Vicinae publishes no .deb or .rpm, only a relocatable tarball laid out as a
+# prefix (bin/, libexec/, share/, lib/systemd/user/), so it unpacks straight
+# into /usr/local — which is already on systemd's user unit search path, so the
+# service it ships is picked up without further work. Upstream builds the
+# tarball for x86_64 only; other architectures get an AppImage instead, which
+# does not fit this layout, so they are left to install it by hand.
+VICINAE_VERSION="0.24.0"
+install_vicinae_tarball() {
+    if [[ "$(uname -m)" != "x86_64" ]]; then
+        err "Vicinae ships an x86_64 tarball only; on $(uname -m) install the AppImage from https://github.com/vicinaehq/vicinae/releases"
+        return 1
+    fi
+
+    local url="https://github.com/vicinaehq/vicinae/releases/download/v${VICINAE_VERSION}/vicinae-linux-x86_64-v${VICINAE_VERSION}.tar.gz"
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+
+    log "Downloading Vicinae ${VICINAE_VERSION}..."
+    if ! curl -fsSL "$url" -o "$tmpdir/vicinae.tar.gz"; then
+        err "Failed to download Vicinae."
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
+    if ! sudo tar -xzf "$tmpdir/vicinae.tar.gz" -C /usr/local --strip-components=1; then
+        err "Failed to unpack Vicinae into /usr/local."
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
+    rm -rf "$tmpdir"
+    sudo systemctl daemon-reload 2>/dev/null || true
+    log "Vicinae ${VICINAE_VERSION} installed to /usr/local."
+    return 0
+}
+
+
 log "Installing Debian packages..."
 
 INSTALL_FISH="${INSTALL_FISH:-true}"
@@ -35,6 +72,7 @@ THEME_PACKAGES=(
 
 UTILITY_PACKAGES=(
     fuzzel swappy brightnessctl ddcutil network-manager imagemagick tesseract-ocr tesseract-ocr-eng kde-spectacle slurp grim xdg-utils sassc python3-venv uv konsave
+    vicinae
 )
 
 # Packages that need manual build or script fallback on Debian if apt package missing
@@ -49,9 +87,9 @@ case "$PACKAGE_GROUP" in
     core)   PACKAGES=("${CORE_PACKAGES[@]}");   FALLBACK_TARGETS=("libcava" "app2unit") ;;
     shell)  PACKAGES=("${SHELL_PACKAGES[@]}");  FALLBACK_TARGETS=("quickshell" "starship") ;;
     themes) PACKAGES=("${THEME_PACKAGES[@]}");  FALLBACK_TARGETS=("adw-gtk3") ;;
-    utils)  PACKAGES=("${UTILITY_PACKAGES[@]}"); FALLBACK_TARGETS=("gpu-screen-recorder" "wl-clip-persist" "satty" "uv" "konsave") ;;
+    utils)  PACKAGES=("${UTILITY_PACKAGES[@]}"); FALLBACK_TARGETS=("gpu-screen-recorder" "wl-clip-persist" "satty" "uv" "konsave" "vicinae") ;;
     all|*)  PACKAGES=("${CORE_PACKAGES[@]}" "${SHELL_PACKAGES[@]}" "${THEME_PACKAGES[@]}" "${UTILITY_PACKAGES[@]}")
-            FALLBACK_TARGETS=("quickshell" "starship" "libcava" "app2unit" "gpu-screen-recorder" "wl-clip-persist" "satty" "adw-gtk3" "uv" "konsave") ;;
+            FALLBACK_TARGETS=("quickshell" "starship" "libcava" "app2unit" "gpu-screen-recorder" "wl-clip-persist" "satty" "adw-gtk3" "uv" "konsave" "vicinae") ;;
 esac
 
 log "Installing packages (group: $PACKAGE_GROUP)..."
@@ -241,6 +279,9 @@ for pkg in "${FALLBACK_TARGETS[@]}"; do
                 err "uv is required to install $pkg, but it is not available."
                 FAILED_PKGS+=("$pkg")
             fi
+            ;;
+        vicinae)
+            install_vicinae_tarball || FAILED_PKGS+=("$pkg")
             ;;
         adw-gtk3)
             tmpdir="$(mktemp -d)"

--- a/sdata/debian-dist/installDP_debian.sh
+++ b/sdata/debian-dist/installDP_debian.sh
@@ -13,6 +13,9 @@ err()  { echo -e "\033[0;31m[ERR]\033[0m  $*"; }
 # tarball for x86_64 only; other architectures get an AppImage instead, which
 # does not fit this layout, so they are left to install it by hand.
 VICINAE_VERSION="0.24.0"
+# sha256 of vicinae-linux-x86_64-v0.24.0.tar.gz as published upstream. The AUR
+# package pins the same digest for the same file; bump the two together.
+VICINAE_SHA256="015a1ef2f8b23ea36a3f831a41de2d138f927cf45c987f62de3ec4add8dbafe7"
 install_vicinae_tarball() {
     if [[ "$(uname -m)" != "x86_64" ]]; then
         err "Vicinae ships an x86_64 tarball only; on $(uname -m) install the AppImage from https://github.com/vicinaehq/vicinae/releases"
@@ -30,6 +33,18 @@ install_vicinae_tarball() {
         return 1
     fi
 
+    # This unpacks as root into /usr/local, so the download is checked before it
+    # is trusted, not after.
+    local got
+    got="$(sha256sum "$tmpdir/vicinae.tar.gz" | cut -d" " -f1)"
+    if [[ "$got" != "$VICINAE_SHA256" ]]; then
+        err "Vicinae checksum mismatch - refusing to install."
+        err "  expected $VICINAE_SHA256"
+        err "  got      $got"
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
     if ! sudo tar -xzf "$tmpdir/vicinae.tar.gz" -C /usr/local --strip-components=1; then
         err "Failed to unpack Vicinae into /usr/local."
         rm -rf "$tmpdir"
@@ -38,6 +53,19 @@ install_vicinae_tarball() {
 
     rm -rf "$tmpdir"
     sudo systemctl daemon-reload 2>/dev/null || true
+
+    # The tarball carries no dependency metadata, so whatever it links against
+    # has to be present already. Rather than guess package names for every
+    # distro and release, ask the binary what is missing and say so plainly.
+    local missing
+    missing="$(ldd /usr/local/bin/vicinae 2>/dev/null | awk '/not found/ {print "    " $1}')"
+    if [[ -n "$missing" ]]; then
+        err "Vicinae installed but is missing shared libraries:"
+        printf '%s\n' "$missing"
+        err "Install the packages providing those, then: systemctl --user restart vicinae"
+        return 1
+    fi
+
     log "Vicinae ${VICINAE_VERSION} installed to /usr/local."
     return 0
 }

--- a/sdata/fedora-dist/installDP_fedora.sh
+++ b/sdata/fedora-dist/installDP_fedora.sh
@@ -54,6 +54,15 @@ install_vicinae_tarball() {
     rm -rf "$tmpdir"
     sudo systemctl daemon-reload 2>/dev/null || true
 
+    # Snippets and paste need the input helper to read /dev/input and inject
+    # through /dev/uinput. The tarball ships the modules-load.d drop-in that
+    # gets uinput loaded at boot, but not the capability, and neither applies
+    # until something does them — the AUR package does both from post_install.
+    sudo setcap "cap_dac_override+ep" /usr/local/libexec/vicinae/vicinae-input-server 2>/dev/null || \
+        err "setcap failed; Vicinae snippets and paste will not work."
+    sudo modprobe uinput 2>/dev/null || \
+        log "Could not load uinput now; snippets and paste will work after a reboot."
+
     # The tarball carries no dependency metadata, so whatever it links against
     # has to be present already. Rather than guess package names for every
     # distro and release, ask the binary what is missing and say so plainly.

--- a/sdata/fedora-dist/installDP_fedora.sh
+++ b/sdata/fedora-dist/installDP_fedora.sh
@@ -6,6 +6,43 @@ set -uo pipefail
 log()  { echo -e "\033[0;36m[INFO]\033[0m $*"; }
 err()  { echo -e "\033[0;31m[ERR]\033[0m  $*"; }
 
+# Vicinae publishes no .deb or .rpm, only a relocatable tarball laid out as a
+# prefix (bin/, libexec/, share/, lib/systemd/user/), so it unpacks straight
+# into /usr/local — which is already on systemd's user unit search path, so the
+# service it ships is picked up without further work. Upstream builds the
+# tarball for x86_64 only; other architectures get an AppImage instead, which
+# does not fit this layout, so they are left to install it by hand.
+VICINAE_VERSION="0.24.0"
+install_vicinae_tarball() {
+    if [[ "$(uname -m)" != "x86_64" ]]; then
+        err "Vicinae ships an x86_64 tarball only; on $(uname -m) install the AppImage from https://github.com/vicinaehq/vicinae/releases"
+        return 1
+    fi
+
+    local url="https://github.com/vicinaehq/vicinae/releases/download/v${VICINAE_VERSION}/vicinae-linux-x86_64-v${VICINAE_VERSION}.tar.gz"
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+
+    log "Downloading Vicinae ${VICINAE_VERSION}..."
+    if ! curl -fsSL "$url" -o "$tmpdir/vicinae.tar.gz"; then
+        err "Failed to download Vicinae."
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
+    if ! sudo tar -xzf "$tmpdir/vicinae.tar.gz" -C /usr/local --strip-components=1; then
+        err "Failed to unpack Vicinae into /usr/local."
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
+    rm -rf "$tmpdir"
+    sudo systemctl daemon-reload 2>/dev/null || true
+    log "Vicinae ${VICINAE_VERSION} installed to /usr/local."
+    return 0
+}
+
+
 log "Installing Fedora packages..."
 
 INSTALL_FISH="${INSTALL_FISH:-true}"
@@ -31,12 +68,13 @@ THEME_PACKAGES=(
 
 UTILITY_PACKAGES=(
     fuzzel swappy brightnessctl ddcutil NetworkManager ImageMagick tesseract tesseract-langpack-eng spectacle gpu-screen-recorder slurp grim xdg-utils sassc
+    vicinae
 )
 
 # Packages known to need copr or manual fallback
 COPR_CORE=(app2unit libcava)
 COPR_SHELL=(quickshell-git)
-COPR_UTILS=()
+COPR_UTILS=(vicinae)
 
 # Build final package list based on selected group
 PACKAGES=()
@@ -168,6 +206,9 @@ for pkg in "${COPR_PKGS[@]}"; do
 
     log "Copr fallback failed or not defined for $pkg. Attempting manual build..."
     case "$pkg" in
+        vicinae)
+            install_vicinae_tarball || FAILED_PKGS+=("$pkg")
+            ;;
         libcava)
             tmpdir="$(mktemp -d)"
             sudo dnf install -y alsa-lib-devel fftw-devel pulseaudio-libs-devel iniparser-devel meson ninja-build cmake gcc-c++

--- a/sdata/fedora-dist/installDP_fedora.sh
+++ b/sdata/fedora-dist/installDP_fedora.sh
@@ -13,6 +13,9 @@ err()  { echo -e "\033[0;31m[ERR]\033[0m  $*"; }
 # tarball for x86_64 only; other architectures get an AppImage instead, which
 # does not fit this layout, so they are left to install it by hand.
 VICINAE_VERSION="0.24.0"
+# sha256 of vicinae-linux-x86_64-v0.24.0.tar.gz as published upstream. The AUR
+# package pins the same digest for the same file; bump the two together.
+VICINAE_SHA256="015a1ef2f8b23ea36a3f831a41de2d138f927cf45c987f62de3ec4add8dbafe7"
 install_vicinae_tarball() {
     if [[ "$(uname -m)" != "x86_64" ]]; then
         err "Vicinae ships an x86_64 tarball only; on $(uname -m) install the AppImage from https://github.com/vicinaehq/vicinae/releases"
@@ -30,6 +33,18 @@ install_vicinae_tarball() {
         return 1
     fi
 
+    # This unpacks as root into /usr/local, so the download is checked before it
+    # is trusted, not after.
+    local got
+    got="$(sha256sum "$tmpdir/vicinae.tar.gz" | cut -d" " -f1)"
+    if [[ "$got" != "$VICINAE_SHA256" ]]; then
+        err "Vicinae checksum mismatch - refusing to install."
+        err "  expected $VICINAE_SHA256"
+        err "  got      $got"
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
     if ! sudo tar -xzf "$tmpdir/vicinae.tar.gz" -C /usr/local --strip-components=1; then
         err "Failed to unpack Vicinae into /usr/local."
         rm -rf "$tmpdir"
@@ -38,6 +53,19 @@ install_vicinae_tarball() {
 
     rm -rf "$tmpdir"
     sudo systemctl daemon-reload 2>/dev/null || true
+
+    # The tarball carries no dependency metadata, so whatever it links against
+    # has to be present already. Rather than guess package names for every
+    # distro and release, ask the binary what is missing and say so plainly.
+    local missing
+    missing="$(ldd /usr/local/bin/vicinae 2>/dev/null | awk '/not found/ {print "    " $1}')"
+    if [[ -n "$missing" ]]; then
+        err "Vicinae installed but is missing shared libraries:"
+        printf '%s\n' "$missing"
+        err "Install the packages providing those, then: systemctl --user restart vicinae"
+        return 1
+    fi
+
     log "Vicinae ${VICINAE_VERSION} installed to /usr/local."
     return 0
 }

--- a/shell/modules/Shortcuts.qml
+++ b/shell/modules/Shortcuts.qml
@@ -264,6 +264,17 @@ Scope {
         description: "Launch Browser"
         onPressed: Quickshell.execDetached(["kstart", "--", "firefox"])
     }
+    // qmllint disable unresolved-type
+    CustomShortcut {
+        // qmllint enable unresolved-type
+        name: "vicinae"
+        description: "Toggle Vicinae launcher"
+        // Registered through the shell's own KGlobalAccel component rather than
+        // a .desktop entry, so it binds at runtime instead of waiting for the
+        // next login, and shows up in the Nexus keybind list like the rest.
+        // A no-op if Vicinae is not installed.
+        onPressed: Quickshell.execDetached(["sh", "-c", "command -v vicinae >/dev/null && vicinae toggle"])
+    }
     CustomShortcut {
         name: "code"
         description: "Launch Editor"

--- a/shell/plugin/src/Caelestia/Config/keybindsdefaults.hpp
+++ b/shell/plugin/src/Caelestia/Config/keybindsdefaults.hpp
@@ -12,7 +12,7 @@ inline QJsonObject defaultKeybinds() {
         { "sidebar", "Meta+B" }, { "aiAssistant", "" }, { "utilities", "" }, { "emoji", "Meta+Shift+V" },
         { "clipboard", "Meta+V" }, { "windowSwitcher", "Alt+Tab" }, { "windowSwitcherReverse", "Alt+Shift+Tab" },
         { "wallpaper", "Meta+Ctrl+T" }, { "keybinds", "Meta+/" }, { "foot", "Meta+Return" }, { "firefox", "Meta+W" },
-        { "code", "Meta+C" }, { "github-desktop", "Meta+G" }, { "nemo", "Meta+Alt+E" },
+        { "vicinae", "Alt+Space" }, { "code", "Meta+C" }, { "github-desktop", "Meta+G" }, { "nemo", "Meta+Alt+E" },
         { "kcolorpicker", "Meta+Shift+C" }, { "krohnkiteFocusUp", "Meta+Up" }, { "krohnkiteFocusDown", "Meta+Down" },
         { "krohnkiteFocusLeft", "Meta+Left" }, { "krohnkiteFocusRight", "Meta+Right" },
         { "krohnkiteShiftUp", "Meta+Shift+Up" }, { "krohnkiteShiftDown", "Meta+Shift+Down" },

--- a/shell/scripts/vicinae-theme.py
+++ b/shell/scripts/vicinae-theme.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Write Caelestia's current colour scheme out as a Vicinae theme.
+
+Vicinae reads themes from $XDG_DATA_HOME/vicinae/themes and watches that
+directory, so dropping an updated file in is enough for a running instance to
+pick it up — no restart, no IPC. Caelestia publishes the scheme it generated
+from the wallpaper to ~/.local/state/caelestia/scheme.json, so the two only
+need this translation between them.
+
+Only the colours Vicinae cannot derive on its own are written. Everything else
+it works out from the core set, so the file stays short and there is less to
+drift when either palette changes.
+
+Usage:
+    vicinae-theme.py            # regenerate from the current scheme
+    vicinae-theme.py --print    # write nothing, dump the theme to stdout
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+STATE = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state")) / "caelestia/scheme.json"
+THEMES = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local/share")) / "vicinae/themes"
+THEME_ID = "caelestia"
+
+
+def hexc(colours: dict, *names: str) -> str:
+    """First of `names` present in the scheme, as #rrggbb.
+
+    Schemes carry the Material roles plus whatever extras their flavour adds,
+    so the accent lookups list a Material fallback behind the nicer name.
+    """
+    for name in names:
+        value = colours.get(name)
+        if value:
+            return value if value.startswith("#") else f"#{value}"
+    raise KeyError(f"scheme has none of {names}")
+
+
+def build(scheme: dict) -> str:
+    c = scheme["colours"]
+    dark = scheme.get("mode", "dark") != "light"
+    name = scheme.get("name", "caelestia")
+    flavour = scheme.get("flavour", "")
+    label = f"Caelestia ({name} {flavour})".replace(" )", ")")
+
+    return f"""# Generated from Caelestia's colour scheme — do not edit by hand.
+# Regenerate with: shell/scripts/vicinae-theme.py
+# Source: {STATE}
+
+[meta]
+version = 1
+name = "{label}"
+description = "Caelestia's active Material palette"
+variant = "{'dark' if dark else 'light'}"
+
+[colors.core]
+background = "{hexc(c, 'surface', 'background')}"
+foreground = "{hexc(c, 'onSurface', 'text')}"
+secondary_background = "{hexc(c, 'surfaceContainer')}"
+border = "{hexc(c, 'outlineVariant')}"
+accent = "{hexc(c, 'primary')}"
+accent_foreground = "{hexc(c, 'onPrimary')}"
+
+[colors.accents]
+blue = "{hexc(c, 'blue', 'primary')}"
+green = "{hexc(c, 'green', 'success', 'tertiary')}"
+red = "{hexc(c, 'red', 'error')}"
+yellow = "{hexc(c, 'yellow', 'tertiary')}"
+orange = "{hexc(c, 'peach', 'tertiary')}"
+magenta = "{hexc(c, 'pink', 'tertiary')}"
+purple = "{hexc(c, 'mauve', 'lavender', 'tertiary')}"
+cyan = "{hexc(c, 'teal', 'sky', 'secondary')}"
+
+[colors.text]
+muted = "{hexc(c, 'onSurfaceVariant')}"
+danger = "{hexc(c, 'error')}"
+success = "{hexc(c, 'success', 'green', 'tertiary')}"
+placeholder = "{hexc(c, 'outline')}"
+selection = {{ background = "{hexc(c, 'primary')}", foreground = "{hexc(c, 'onPrimary')}" }}
+
+[colors.input]
+border = "{hexc(c, 'outlineVariant')}"
+border_focus = "{hexc(c, 'primary')}"
+border_error = "{hexc(c, 'error')}"
+
+[colors.list.item.selection]
+background = "{hexc(c, 'surfaceContainerHigh')}"
+secondary_background = "{hexc(c, 'surfaceContainerHighest')}"
+
+[colors.grid.item]
+background = "{hexc(c, 'surfaceContainer')}"
+
+[colors.scrollbars]
+background = "{hexc(c, 'outlineVariant')}"
+
+[colors.loading]
+bar = "{hexc(c, 'primary')}"
+spinner = "{hexc(c, 'onSurface', 'text')}"
+"""
+
+
+def main(argv: list[str]) -> int:
+    if not STATE.is_file():
+        print(f"no scheme at {STATE} — is the shell running?", file=sys.stderr)
+        return 1
+
+    try:
+        theme = build(json.loads(STATE.read_text()))
+    except (json.JSONDecodeError, KeyError) as exc:
+        print(f"cannot build theme from {STATE}: {exc}", file=sys.stderr)
+        return 1
+
+    if "--print" in argv:
+        print(theme, end="")
+        return 0
+
+    THEMES.mkdir(parents=True, exist_ok=True)
+    out = THEMES / f"{THEME_ID}.toml"
+    # Write and move, so Vicinae's directory watcher never sees a half file.
+    tmp = out.with_suffix(".toml.tmp")
+    tmp.write_text(theme)
+    tmp.replace(out)
+    print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -284,8 +284,7 @@ do
 done
 
 # Vicinae integration: launcher shortcut, generated theme and its regenerator
-for f in "$HOME/.local/share/applications/vicinae-toggle.desktop" \
-         "$HOME/.local/share/vicinae/themes/caelestia.toml" \
+for f in "$HOME/.local/share/vicinae/themes/caelestia.toml" \
          "$HOME/.local/bin/caelestia-vicinae-theme" \
          "$HOME/.config/systemd/user/caelestia-vicinae-theme.service" \
          "$HOME/.config/systemd/user/caelestia-vicinae-theme.path" \
@@ -295,9 +294,6 @@ for f in "$HOME/.local/share/applications/vicinae-toggle.desktop" \
         ok "Removed: $f"
     fi
 done
-kwriteconfig6 --file kglobalshortcutsrc --group services \
-    --group "vicinae-toggle.desktop" --key "_launch" --delete 2>/dev/null || true
-
 # Autostart desktop entry
 if [[ -f "$HOME/.config/autostart/caelestiashell.desktop" ]]; then
     rm -f "$HOME/.config/autostart/caelestiashell.desktop"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -235,15 +235,6 @@ if systemctl --user is-enabled --quiet "caelestia-vicinae-theme.path" 2>/dev/nul
     ok "Disabled user path unit: caelestia-vicinae-theme"
 fi
 
-# Setup masked KRunner so Vicinae could take Alt+Space. Give it back, or the
-# machine is left with no launcher at all once Vicinae is gone.
-if systemctl --user is-enabled plasma-krunner.service 2>/dev/null | grep -q masked; then
-    systemctl --user unmask plasma-krunner.service 2>/dev/null || true
-    ok "Unmasked KRunner"
-else
-    skip "KRunner not masked"
-fi
-
 if systemctl --user is-enabled --quiet "caelestia-update-checker.timer" 2>/dev/null ||
    systemctl --user is-active  --quiet "caelestia-update-checker.timer" 2>/dev/null; then
     systemctl --user disable --now "caelestia-update-checker.timer" 2>/dev/null || true

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -219,7 +219,7 @@ restore_or_remove() {
 
 section "Step 1 - Stop and Disable Services"
 
-for svc in qs-kwin-bridge cliphist ydotoold kde-material-you-colors; do
+for svc in qs-kwin-bridge cliphist ydotoold kde-material-you-colors vicinae caelestia-vicinae-theme; do
     if systemctl --user is-enabled --quiet "${svc}.service" 2>/dev/null ||
        systemctl --user is-active  --quiet "${svc}.service" 2>/dev/null; then
         systemctl --user disable --now "${svc}.service" 2>/dev/null || true
@@ -228,6 +228,21 @@ for svc in qs-kwin-bridge cliphist ydotoold kde-material-you-colors; do
         skip "User service not active: $svc"
     fi
 done
+
+if systemctl --user is-enabled --quiet "caelestia-vicinae-theme.path" 2>/dev/null ||
+   systemctl --user is-active  --quiet "caelestia-vicinae-theme.path" 2>/dev/null; then
+    systemctl --user disable --now "caelestia-vicinae-theme.path" 2>/dev/null || true
+    ok "Disabled user path unit: caelestia-vicinae-theme"
+fi
+
+# Setup masked KRunner so Vicinae could take Alt+Space. Give it back, or the
+# machine is left with no launcher at all once Vicinae is gone.
+if systemctl --user is-enabled plasma-krunner.service 2>/dev/null | grep -q masked; then
+    systemctl --user unmask plasma-krunner.service 2>/dev/null || true
+    ok "Unmasked KRunner"
+else
+    skip "KRunner not masked"
+fi
 
 if systemctl --user is-enabled --quiet "caelestia-update-checker.timer" 2>/dev/null ||
    systemctl --user is-active  --quiet "caelestia-update-checker.timer" 2>/dev/null; then
@@ -267,6 +282,21 @@ do
         ok "Removed: $svc_file"
     fi
 done
+
+# Vicinae integration: launcher shortcut, generated theme and its regenerator
+for f in "$HOME/.local/share/applications/vicinae-toggle.desktop" \
+         "$HOME/.local/share/vicinae/themes/caelestia.toml" \
+         "$HOME/.local/bin/caelestia-vicinae-theme" \
+         "$HOME/.config/systemd/user/caelestia-vicinae-theme.service" \
+         "$HOME/.config/systemd/user/caelestia-vicinae-theme.path" \
+         "$HOME/.config/systemd/user/vicinae.service"; do
+    if [[ -f "$f" ]]; then
+        rm -f "$f"
+        ok "Removed: $f"
+    fi
+done
+kwriteconfig6 --file kglobalshortcutsrc --group services \
+    --group "vicinae-toggle.desktop" --key "_launch" --delete 2>/dev/null || true
 
 # Autostart desktop entry
 if [[ -f "$HOME/.config/autostart/caelestiashell.desktop" ]]; then
@@ -562,6 +592,23 @@ if [[ -f /etc/keyd/quickshell.conf ]]; then
     ok "Removed /etc/keyd/quickshell.conf"
     # Remove the directory only if it's now empty
     sudo rmdir /etc/keyd 2>/dev/null || true
+fi
+
+# Vicinae was unpacked from upstream's tarball, so pacman/dnf/apt do not know
+# about it — the files it laid down under /usr/local are listed out by hand.
+if [[ -x /usr/local/bin/vicinae ]]; then
+    sudo rm -rf /usr/local/bin/vicinae \
+                /usr/local/libexec/vicinae \
+                /usr/local/share/vicinae \
+                /usr/local/share/applications/vicinae.desktop \
+                /usr/local/share/applications/vicinae-url-handler.desktop \
+                /usr/local/share/icons/hicolor/512x512/apps/vicinae.png \
+                /usr/local/lib/systemd/user/vicinae.service \
+                /usr/local/lib/modules-load.d/vicinae.conf
+    sudo systemctl daemon-reload 2>/dev/null || true
+    ok "Removed Vicinae from /usr/local"
+else
+    skip "Vicinae not installed under /usr/local"
 fi
 
 # udev rule for uinput


### PR DESCRIPTION
Replaces KRunner with [Vicinae](https://github.com/vicinaehq/vicinae) and wires its colours to the shell's palette.

## KRunner keeps its key until the shell takes it

Vicinae goes on `Alt+Space` as an ordinary `CustomShortcut` in `Shortcuts.qml`. Nothing is disabled: the shell's `GlobalShortcut` already takes a key off whoever holds it when it binds one and gives it back on exit, so KRunner simply loses `Alt+Space` for as long as Caelestia is running. The shell keeps `Meta` and `Meta+Space` for its own launcher, so the two never fight over one.

Confirmed on a live session — with KRunner running, its `_launch` shortcut goes to no keys while the shell is up and comes back as `Alt+F2`, `Search` and `Alt+Space` when the shell quits, with the three recorded in `stolen-shortcuts.json` in between. A crashed session restores them on next start.

Two approaches were tried and dropped on the way. A `.desktop` entry under `[services]` in `kglobalshortcutsrc` never registers — `kglobalacceld` only reads those at login, and rebuilding ksycoca, restarting the daemon and clearing `NoDisplay` all left the component absent. And masking `plasma-krunner.service` turned out to be worse than redundant: it disables KRunner outright and is only undone by the uninstaller, so anyone who stopped running Caelestia without uninstalling would be left without it.

## Colours follow the wallpaper

The shell already publishes the scheme it generated to `~/.local/state/caelestia/scheme.json`, and Vicinae reads themes from its data directory and *watches* it. So the two only needed a translation: `shell/scripts/vicinae-theme.py` writes the Material palette out as a Vicinae theme, and a path unit reruns it whenever the scheme changes. Nothing restarts — the launcher repaints on its own.

Only the colours Vicinae cannot derive itself are written, so there is less to drift when either palette changes.

## Installing it

Upstream publishes no `.deb` or `.rpm`, only AppImages and a tarball. The tarball is laid out as a prefix (`bin/`, `libexec/`, `share/`, `lib/systemd/user/`) and resolves its helpers relative to the binary, so it unpacks into `/usr/local` — already on systemd's user unit search path, so the service it ships is found as-is. All three distros use it, so the only party trusted for the binary is the project itself.

What the AUR package was doing for us moves into the script:

- the download is **verified** against the digest upstream published, and refuses to install on a mismatch
- the input helper gets `cap_dac_override` and `uinput` is loaded, without which snippets and paste silently do not work
- the eight runtime dependencies stay with the package manager on Arch, where the names are known; on Fedora and Debian, where guessing them across releases is its own source of breakage, the binary is asked what it cannot resolve and the missing libraries are named

x86_64 only, since that is all upstream builds; other architectures are told to fetch the AppImage rather than failing halfway through.

## Uninstall

Losing the package manager means losing its file tracking, so `uninstall.sh` does that by hand — every path the tarball lays down under `/usr/local`, checked against the archive, all 58 files covered.

The generated theme, its regenerator and path unit go too. Nothing needs to be done about KRunner — the shortcut steal restores itself. The runtime dependencies deliberately are not removed: that list holds applications, not shared Qt and KDE libraries, and dropping `nodejs` or `qt6-svg` would take unrelated software with it.

## Tested

Live, end to end: service up, `Alt+Space` invoked over KGlobalAccel's D-Bus interface with the launcher coming up, the key taken from KRunner and handed back on exit, theme applied and regenerating when the scheme file changes.

The theme was checked against pixels rather than by eye — background `#131317` matches the theme exactly, the selected row `#2a292e` is the palette's `surfaceContainerHigh`, the accent reads `#c5c4ff` against `#c2c1ff`.

**Not tested:** the `/usr/local` install path itself. My test install went to `~/.local` because I had no way to authenticate for `sudo`; the tarball is relocatable so everything above still exercised, but `setcap`, `modprobe` and the `/usr/local` layout were verified by unpacking and inspection rather than by running the script. Worth a real run before merge.
