### PR TITLE
fix(shell): initialize Qt app identifiers before settings

### DIFF
--- a/shell/lockscreen.qml
+++ b/shell/lockscreen.qml
@@ -6,9 +6,16 @@ import Quickshell
 import Caelestia.Config
 
 ShellRoot {
-    Component.onCompleted: {
+    readonly property bool _appIdentifiersSet: (function() {
+        Qt.application.organization = "Caelestia";
+        Qt.application.domain = "caelestia.dots";
         Qt.application.name = "caelestia-lockscreen";
-    }
+        return true;
+    })()
+
+    // Force application identifiers to be set before imported singletons and
+    // child components initialize any QtCore.Settings backends.
+    settings.watchFiles: _appIdentifiersSet && false
 
     Variants {
         model: Quickshell.screens

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -28,8 +28,6 @@ import qs.services
 import qs.utils
 
 ShellRoot {
-    settings.watchFiles: false
-
     // Several QtCore.Settings {} elements throughout the codebase (BlurOffsets,
     // ContentWindow, UpdateChecker) rely on QCoreApplication's organization/app
     // identifiers to build their QSettings storage path. Quickshell's host
@@ -46,6 +44,11 @@ ShellRoot {
         Qt.application.name = "caelestia-shell";
         return true;
     })()
+
+    // Reading _appIdentifiersSet here forces the lazy binding above to run
+    // while ShellRoot itself is being constructed. This happens before child
+    // Settings objects complete and try to open their QSettings backends.
+    settings.watchFiles: _appIdentifiersSet && false
 
     GSFLoader {}
 


### PR DESCRIPTION
## What does this change?

Initializes `Qt.application` organization, domain, and application name before child components complete construction.

The existing `_appIdentifiersSet` property in `shell.qml` was a lazy binding that nothing read, so it never ran before `QtCore.Settings` instances initialized. This caused repeated `QSettings` status-code 1 warnings and prevented those settings backends from opening. Binding `settings.watchFiles` to the initializer forces it to run during root construction. The standalone lock-screen entry point now uses the same early initialization.

## Screenshots (if UI change)

Not applicable; this is an initialization and persistence fix with no visual change.

## How did you test it?

- Ran `.github/scripts/test_repo_integrity.py`: all 16 tests passed.
- Ran `git diff --check` successfully.
- Installed both changed QML entry points and restarted the Caelestia user service on CachyOS KDE Wayland.
- Confirmed the shell remained active and no longer emitted `QSettings` / missing application identifier warnings.
- Confirmed Qt created the expected Caelestia settings file after startup.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Config / theme
- [ ] Docs
- [ ] Refactor
- [ ] Other

## Notes for reviewers

The initializer is deliberately consumed by an early `ShellRoot.settings` binding; leaving it as an unread property preserves the original lazy-evaluation bug.
