### PR TITLE
fix: keep workspace scrolling in visual order

### DIFF
--- a/shell/modules/bar/components/workspaces/Workspaces.qml
+++ b/shell/modules/bar/components/workspaces/Workspaces.qml
@@ -163,16 +163,34 @@ Item {
                 }
                 onWheel: event => {
                     if (!Config.bar.scrollActions.workspaces) return;
-                    
+
+                    let direction = 0;
+                    if (event.angleDelta.y > 0 || event.angleDelta.x > 0)
+                        direction = -1;
+                    else if (event.angleDelta.y < 0 || event.angleDelta.x < 0)
+                        direction = 1;
+                    else
+                        return;
+
+                    if (typeof KWinWorkspaceState !== "undefined" && KWinWorkspaceState.workspaces.length > 0) {
+                        const workspaceList = KWinWorkspaceState.workspaces;
+                        const activeIndex = Math.max(0, Math.min(workspaceList.length - 1, KWinWorkspaceState.activeId - 1));
+                        const targetIndex = (activeIndex + direction + workspaceList.length) % workspaceList.length;
+                        const targetId = workspaceList[targetIndex]?.id;
+                        if (targetId)
+                            KWinWorkspaceState.switchTo(targetId);
+                        return;
+                    }
+
                     const isKWin = typeof KWinActiveWindowBridge !== "undefined" && KWinActiveWindowBridge.windowList;
-                    
-                    if (event.angleDelta.y > 0 || event.angleDelta.x > 0) {
+
+                    if (direction < 0) {
                         if (isKWin) {
                             KWinActiveWindowBridge.previousDesktop();
                         } else {
                             Quickshell.execDetached(["qdbus6", "org.kde.KWin", "/KWin", "previousDesktop"]);
                         }
-                    } else if (event.angleDelta.y < 0 || event.angleDelta.x < 0) {
+                    } else {
                         if (isKWin) {
                             KWinActiveWindowBridge.nextDesktop();
                         } else {


### PR DESCRIPTION
## What does this change?

Makes wheel scrolling on the bar switch to the workspace adjacent in the same ordered model that the bar renders.

Previously, clicks used the position-sorted `KWinWorkspaceState.workspaces` model, but wheel events called `KWinActiveWindowBridge.nextDesktop()` / `previousDesktop()`, which traverse KWin's raw scripting array. After a user reorders virtual desktops, those two orders can diverge and scrolling can jump to a non-adjacent pill.

The handler now calculates a wrapped neighbor from `KWinWorkspaceState.workspaces` and switches by its stable desktop ID. The existing bridge and DBus paths remain as fallbacks when the workspace-state service is unavailable.

Fixes #466.

## Screenshots (if UI change)

Not applicable; the rendered UI is unchanged.

## How did you test it?

- Installed the changed QML file on CachyOS KDE Wayland and restarted the Caelestia user service successfully.
- Confirmed the service logs contain no QML syntax, type, or reference errors from `Workspaces.qml`.
- Ran `.github/scripts/test_repo_integrity.py`: all 16 tests passed.
- Ran `.github/scripts/check_qml_conventions.py`: no new convention violations.
- Ran `git diff --check` successfully.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Config / theme
- [ ] Docs
- [ ] Refactor
- [ ] Other

## Notes for reviewers

The fallback behavior is deliberately retained for environments where `KWinWorkspaceState` is unavailable or has not populated its model.
