### PR TITLE
fix: auto-hide visualiser behind any maximized window

### DIFF
--- a/shell/modules/background/Visualiser.qml
+++ b/shell/modules/background/Visualiser.qml
@@ -17,9 +17,27 @@ Item {
     readonly property bool windowHidesVisualiser: {
         let isHidden = false;
         if (typeof KWinActiveWindowBridge !== "undefined" && KWinActiveWindowBridge.activeWindow) {
-            isHidden = KWinActiveWindowBridge.activeWindow.fullscreen || KWinActiveWindowBridge.activeWindow.maximized;
-            if (isHidden && !Config.background.visualiser.hideOnAllMonitors) {
-                isHidden = KWinActiveWindowBridge.activeOutputName === screen.name;
+            const windows = KWinActiveWindowBridge.windowList || [];
+            const activeWsId = typeof KWinWorkspaceState !== "undefined" ? KWinWorkspaceState.activeId : -1;
+
+            for (let i = 0; i < windows.length; ++i) {
+                const window = windows[i];
+                if (window.minimized || !(window.fullscreen || window.maximized))
+                    continue;
+                if (activeWsId > 0 && window.workspace?.id !== activeWsId)
+                    continue;
+                if (!Config.background.visualiser.hideOnAllMonitors && window.output !== screen.name)
+                    continue;
+                isHidden = true;
+                break;
+            }
+
+            // Keep the focused-window path as a startup fallback until the
+            // complete window list has arrived from the KWin bridge.
+            if (windows.length === 0) {
+                isHidden = KWinActiveWindowBridge.activeWindow.fullscreen || KWinActiveWindowBridge.activeWindow.maximized;
+                if (isHidden && !Config.background.visualiser.hideOnAllMonitors)
+                    isHidden = KWinActiveWindowBridge.activeOutputName === screen.name;
             }
         } else {
             if (Config.background.visualiser.hideOnAllMonitors) {


### PR DESCRIPTION
## What does this change?

Makes the background visualiser's auto-hide behavior consider every visible maximized or fullscreen window on the active workspace, not only the focused window.

On KDE, `windowHidesVisualiser` previously read `KWinActiveWindowBridge.activeWindow`. A maximized window stopped hiding the visualiser as soon as another non-maximized window received focus. The KWin bridge already publishes a complete `windowList`, so the binding now scans that list, ignores minimized and off-workspace windows, and applies the existing per-monitor / all-monitor preference.

The focused-window check remains as a startup fallback until the complete list arrives.


## Screenshots (if UI change)

Not applicable; this corrects existing auto-hide behavior.

## How did you test it?

- Installed the changed QML file on CachyOS KDE Wayland and restarted the Caelestia user service successfully.
- Confirmed startup logs contain no QML syntax, type, or reference errors from `Visualiser.qml`.
- Kept the visualiser disabled in the user configuration while testing startup behavior.
- Ran `.github/scripts/test_repo_integrity.py`: all 16 tests passed.
- Ran `.github/scripts/check_qml_conventions.py`: no new convention violations.
- Ran `git diff --check` successfully.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Config / theme
- [ ] Docs
- [ ] Refactor
- [ ] Other

## Notes for reviewers

The active-workspace comparison follows the existing KDE window-list convention where `workspace.id` matches `KWinWorkspaceState.activeId`.
