### PR TITLE
fix: keep keyboard layout indicator in sync with KDE

### DIFF
--- a/shell/modules/bar/popouts/kblayout/KbLayoutModel.qml
+++ b/shell/modules/bar/popouts/kblayout/KbLayoutModel.qml
@@ -4,6 +4,7 @@ import QtQuick
 import Quickshell.Io
 import Caelestia
 import Caelestia.Config
+import qs.services
 
 // TODO: handle this better later
 
@@ -122,6 +123,15 @@ Item {
 
     ListModel {
         id: layoutsModel
+    }
+
+    Connections {
+        target: KbLayout
+
+        function onActiveIndexChanged() {
+            if (!fetchActiveLayouts.running && layoutsModel.count > 0)
+                fetchActiveLayouts.running = true;
+        }
     }
 
     Process {

--- a/shell/modules/bar/popouts/kblayout/KbLayoutModel.qml
+++ b/shell/modules/bar/popouts/kblayout/KbLayoutModel.qml
@@ -126,12 +126,12 @@ Item {
     }
 
     Connections {
-        target: KbLayout
-
         function onActiveIndexChanged() {
             if (!fetchActiveLayouts.running && layoutsModel.count > 0)
                 fetchActiveLayouts.running = true;
         }
+
+        target: KbLayout
     }
 
     Process {

--- a/shell/services/KbLayout.qml
+++ b/shell/services/KbLayout.qml
@@ -64,6 +64,16 @@ Singleton {
         activeIndex = index >= 0 && index < layouts.length ? index : -1;
     }
 
+    Timer {
+        id: pollTimer
+
+        interval: 750
+        repeat: true
+        running: root.started && root.layouts.length > 0
+        onTriggered: if (!activeProc.running)
+            activeProc.running = true
+    }
+
     Component.onCompleted: start()
 
     Process {

--- a/shell/services/KbLayout.qml
+++ b/shell/services/KbLayout.qml
@@ -64,16 +64,6 @@ Singleton {
         activeIndex = index >= 0 && index < layouts.length ? index : -1;
     }
 
-    Timer {
-        id: pollTimer
-
-        interval: 750
-        repeat: true
-        running: root.started && root.layouts.length > 0
-        onTriggered: if (!activeProc.running)
-            activeProc.running = true
-    }
-
     Component.onCompleted: start()
 
     Process {
@@ -99,5 +89,24 @@ Singleton {
 
         onRunningChanged: if (!running)
             activeProc.running = true
+    }
+
+    Process {
+        id: dbusMonitor
+
+        command: ["dbus-monitor", "--session", "type='signal',interface='org.kde.KeyboardLayouts'"]
+        running: root.started
+
+        stdout: SplitParser {
+            onRead: text => {
+                if (text.indexOf("layoutChanged") !== -1) {
+                    if (!activeProc.running)
+                        activeProc.running = true
+                } else if (text.indexOf("layoutListChanged") !== -1) {
+                    if (!layoutsProc.running)
+                        layoutsProc.running = true
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
The KbLayout service reads the active layout from org.kde.keyboard only
once at startup (and after switches initiated from the shell), while the
sidebar KbLayoutModel reads it only when the popout is created. Switching
layouts with Plasma's own shortcut therefore leaves the bar indicator and
the sidebar popout stale.

Changes:
- services/KbLayout.qml: poll the active layout every 750 ms while the
  shell is running (only when the process is idle)
- modules/bar/popouts/kblayout/KbLayoutModel.qml: follow the singleton
  via a Connections handler on activeIndexChanged