### PR TITLE
fix: keep Alt+F4 off the shell, and give focus back when a drawer closes

### DIFF
--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -10,6 +10,7 @@ import Quickshell.Hyprland
 import Quickshell.Wayland
 import Caelestia.Blobs
 import Caelestia.Config
+import Caelestia.Services
 import qs.components
 import qs.components.containers
 import qs.services
@@ -880,7 +881,37 @@ StyledWindow {
     }
     WlrLayershell.exclusionMode: ExclusionMode.Ignore
     WlrLayershell.layer: hasOpenOverlay || (actualFullscreen && fsTransitionProg < 1) || (fsTransitionProg > 0 && Config.general.showOverFullscreen) || (((monitor?.lastIpcObject?.specialWorkspace?.name?.length ?? 0) > 0) && (monitor?.activeWorkspace?.toplevels?.values?.some(t => (t?.lastIpcObject?.fullscreen ?? 0) > 1) ?? false)) ? WlrLayer.Overlay : WlrLayer.Top
-    WlrLayershell.keyboardFocus: visibilities.launcher || visibilities.session || visibilities.dashboard || visibilities.sidebar || visibilities.overview || panels.popouts.hasCurrent ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
+    // Whether anything on this surface needs the keyboard. Taking it makes the
+    // surface the active window; KWin does not give focus back to what had it
+    // when we stop asking, it just leaves nothing focused, so that has to be
+    // put right by hand below.
+    readonly property bool wantsKeyboard: visibilities.launcher || visibilities.session || visibilities.dashboard || visibilities.sidebar || visibilities.overview || panels.popouts.hasCurrent
+
+    // Remembered on the way in, not read on the way out: as the application
+    // gives up focus KWin passes through a moment with no active window at all,
+    // and the bridge reports that as empty, so by the time the drawer closes
+    // there is often nothing left to read.
+    property string focusReturn: ""
+
+    onWantsKeyboardChanged: {
+        if (typeof KWinActiveWindowBridge === "undefined")
+            return;
+
+        if (wantsKeyboard) {
+            // The bridge ignores the shell taking focus, so this is still the
+            // application that had it.
+            focusReturn = KWinActiveWindowBridge.activeWindow?.address ?? "";
+            return;
+        }
+
+        // Whatever the user switched to while the drawer was open wins, so this
+        // only falls back to what was remembered.
+        const addr = (KWinActiveWindowBridge.activeWindow?.address ?? "") || focusReturn;
+        focusReturn = "";
+        if (addr)
+            KWinActiveWindowBridge.focusWindow(addr);
+    }
+    WlrLayershell.keyboardFocus: wantsKeyboard ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
 
     component PanelBg: BlobRect {
         required property Item panel

--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -104,7 +104,18 @@ StyledWindow {
     // visibly wrong one for left/right, and a degenerate, invisible one for
     // top, since Bottom's math assumes the icon is below the window, the
     // opposite of where it actually is.
-    WlrLayershell.namespace: "panel"
+    //
+    // Reporting as Dock also keeps Alt+F4 off the shell. KWin gates its window
+    // actions behind USABLE_ACTIVE_WINDOW, which is
+    //   m_activeWindow && !(isDesktop() || isDock())
+    // so a dock is skipped before isCloseable() is ever consulted — that returns
+    // an unconditional true for every layer-shell surface, and window rules are
+    // never evaluated for them either, so this type is the only thing standing
+    // between "close window" and the shell losing a surface. The drawers take
+    // keyboard focus while open, which makes this surface the active window, so
+    // without it Alt+F4 over an open dashboard tears one screen's shell down and
+    // leaves the rest of the process running.
+    WlrLayershell.namespace: "dock"
     mask: {
         if (hasOpenOverlay) return fullRegion;
         if (hasFullscreen) return emptyRegion;

--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -906,8 +906,16 @@ StyledWindow {
 
         // Whatever the user switched to while the drawer was open wins, so this
         // only falls back to what was remembered.
+        const pending = KWinActiveWindowBridge.pendingFocusAddress ?? "";
         const addr = (KWinActiveWindowBridge.activeWindow?.address ?? "") || focusReturn;
         focusReturn = "";
+        
+        if (pending) {
+            // A focus switch was explicitly requested by the shell (e.g., clicking
+            // a preview), let it happen.
+            return;
+        }
+
         if (addr)
             KWinActiveWindowBridge.focusWindow(addr);
     }

--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -74,6 +74,18 @@ StyledWindow {
         return Math.max(...thresholds);
     }
 
+    // Whether anything on this surface needs the keyboard. Taking it makes the
+    // surface the active window; KWin does not give focus back to what had it
+    // when we stop asking, it just leaves nothing focused, so that has to be
+    // put right by hand below.
+    readonly property bool wantsKeyboard: visibilities.launcher || visibilities.session || visibilities.dashboard || visibilities.sidebar || visibilities.overview || panels.popouts.hasCurrent
+
+    // Remembered on the way in, not read on the way out: as the application
+    // gives up focus KWin passes through a moment with no active window at all,
+    // and the bridge reports that as empty, so by the time the drawer closes
+    // there is often nothing left to read.
+    property string focusReturn: ""
+
     onHasFullscreenChanged: {
         if (!hasFullscreen)
             return;
@@ -126,6 +138,36 @@ StyledWindow {
     anchors.bottom: true
     anchors.left: true
     anchors.right: true
+    WlrLayershell.exclusionMode: ExclusionMode.Ignore
+    WlrLayershell.layer: hasOpenOverlay || (actualFullscreen && fsTransitionProg < 1) || (fsTransitionProg > 0 && Config.general.showOverFullscreen) || (((monitor?.lastIpcObject?.specialWorkspace?.name?.length ?? 0) > 0) && (monitor?.activeWorkspace?.toplevels?.values?.some(t => (t?.lastIpcObject?.fullscreen ?? 0) > 1) ?? false)) ? WlrLayer.Overlay : WlrLayer.Top
+    WlrLayershell.keyboardFocus: wantsKeyboard ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
+
+    onWantsKeyboardChanged: {
+        if (typeof KWinActiveWindowBridge === "undefined")
+            return;
+
+        if (wantsKeyboard) {
+            // The bridge ignores the shell taking focus, so this is still the
+            // application that had it.
+            focusReturn = KWinActiveWindowBridge.activeWindow?.address ?? "";
+            return;
+        }
+
+        // Whatever the user switched to while the drawer was open wins, so this
+        // only falls back to what was remembered.
+        const pending = KWinActiveWindowBridge.pendingFocusAddress ?? "";
+        const addr = (KWinActiveWindowBridge.activeWindow?.address ?? "") || focusReturn;
+        focusReturn = "";
+
+        if (pending) {
+            // A focus switch was explicitly requested by the shell (e.g., clicking
+            // a preview), let it happen.
+            return;
+        }
+
+        if (addr)
+            KWinActiveWindowBridge.focusWindow(addr);
+    }
 
     Overview.Anim {
         id: animConfig
@@ -879,47 +921,6 @@ StyledWindow {
             hAnchor: "both"
         }
     }
-    WlrLayershell.exclusionMode: ExclusionMode.Ignore
-    WlrLayershell.layer: hasOpenOverlay || (actualFullscreen && fsTransitionProg < 1) || (fsTransitionProg > 0 && Config.general.showOverFullscreen) || (((monitor?.lastIpcObject?.specialWorkspace?.name?.length ?? 0) > 0) && (monitor?.activeWorkspace?.toplevels?.values?.some(t => (t?.lastIpcObject?.fullscreen ?? 0) > 1) ?? false)) ? WlrLayer.Overlay : WlrLayer.Top
-    // Whether anything on this surface needs the keyboard. Taking it makes the
-    // surface the active window; KWin does not give focus back to what had it
-    // when we stop asking, it just leaves nothing focused, so that has to be
-    // put right by hand below.
-    readonly property bool wantsKeyboard: visibilities.launcher || visibilities.session || visibilities.dashboard || visibilities.sidebar || visibilities.overview || panels.popouts.hasCurrent
-
-    // Remembered on the way in, not read on the way out: as the application
-    // gives up focus KWin passes through a moment with no active window at all,
-    // and the bridge reports that as empty, so by the time the drawer closes
-    // there is often nothing left to read.
-    property string focusReturn: ""
-
-    onWantsKeyboardChanged: {
-        if (typeof KWinActiveWindowBridge === "undefined")
-            return;
-
-        if (wantsKeyboard) {
-            // The bridge ignores the shell taking focus, so this is still the
-            // application that had it.
-            focusReturn = KWinActiveWindowBridge.activeWindow?.address ?? "";
-            return;
-        }
-
-        // Whatever the user switched to while the drawer was open wins, so this
-        // only falls back to what was remembered.
-        const pending = KWinActiveWindowBridge.pendingFocusAddress ?? "";
-        const addr = (KWinActiveWindowBridge.activeWindow?.address ?? "") || focusReturn;
-        focusReturn = "";
-        
-        if (pending) {
-            // A focus switch was explicitly requested by the shell (e.g., clicking
-            // a preview), let it happen.
-            return;
-        }
-
-        if (addr)
-            KWinActiveWindowBridge.focusWindow(addr);
-    }
-    WlrLayershell.keyboardFocus: wantsKeyboard ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
 
     component PanelBg: BlobRect {
         required property Item panel

--- a/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
+++ b/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
@@ -41,6 +41,10 @@ QVariantList KWinActiveWindowBridge::windowList() const {
     return m_windowList;
 }
 
+QString KWinActiveWindowBridge::pendingFocusAddress() const {
+    return m_pendingFocusAddress;
+}
+
 void KWinActiveWindowBridge::onWindowAdded(const QString& uuid) {
     if (auto* handle = PlasmaWindows::instance()->handleFor(uuid)) {
         connect(handle, &PlasmaWindowHandle::titleChanged, this, &KWinActiveWindowBridge::scheduleWindowListUpdate);
@@ -146,6 +150,11 @@ void KWinActiveWindowBridge::buildWindowList() {
     if (activeWindowFound && m_activeWindow != newActiveWindow) {
         m_activeWindow = newActiveWindow;
         emit activeWindowChanged();
+        
+        if (m_activeWindow.value("address").toString() == m_pendingFocusAddress) {
+            m_pendingFocusAddress.clear();
+            emit pendingFocusAddressChanged();
+        }
     } else if (!activeWindowFound && !m_activeWindow.isEmpty()) {
         m_activeWindow.clear();
         emit activeWindowChanged();
@@ -154,6 +163,9 @@ void KWinActiveWindowBridge::buildWindowList() {
 
 void KWinActiveWindowBridge::focusWindow(const QString &address) {
     if (auto* handle = PlasmaWindows::instance()->handleFor(address)) {
+        m_pendingFocusAddress = address;
+        emit pendingFocusAddressChanged();
+        
         // To focus a window, we set the active state
         handle->set_state(QtWayland::org_kde_plasma_window_management::state_active, QtWayland::org_kde_plasma_window_management::state_active);
     }

--- a/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.hpp
+++ b/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.hpp
@@ -15,6 +15,7 @@ class KWinActiveWindowBridge : public QObject {
     Q_PROPERTY(QVariantMap activeWindow READ activeWindow NOTIFY activeWindowChanged)
     Q_PROPERTY(QString activeOutputName READ activeOutputName WRITE setActiveOutputName NOTIFY activeOutputNameChanged)
     Q_PROPERTY(QVariantList windowList READ windowList NOTIFY windowListChanged)
+    Q_PROPERTY(QString pendingFocusAddress READ pendingFocusAddress NOTIFY pendingFocusAddressChanged)
     QML_ELEMENT
     QML_SINGLETON
 
@@ -27,6 +28,7 @@ public:
     void setActiveOutputName(const QString &outputName);
 
     QVariantList windowList() const;
+    QString pendingFocusAddress() const;
 
     Q_INVOKABLE void focusWindow(const QString &address);
     Q_INVOKABLE void closeWindow(const QString &address);
@@ -47,6 +49,7 @@ signals:
     void activeWindowChanged();
     void activeOutputNameChanged();
     void windowListChanged();
+    void pendingFocusAddressChanged();
 
 private slots:
     void onWindowAdded(const QString& uuid);
@@ -61,6 +64,7 @@ private:
     QVariantMap m_activeWindow;
     QVariantList m_windowList;
     QString m_activeOutputName;
+    QString m_pendingFocusAddress;
 
     QTimer m_updateTimer;
 };


### PR DESCRIPTION
Two things about the shell surface, found together because they share a cause: the drawers take keyboard focus, which makes the surface the active window.

## Alt+F4 tore the shell down

With a drawer open, Alt+F4 was aimed at the shell and closed that screen's surface, leaving the rest of the process running — Nexus and the services up with no bar or drawers to reach them.

Nothing else stops it. `LayerShellV1Window::isCloseable()` returns an unconditional true for every layer-shell surface, and KWin never evaluates window rules for them at all (`layershellv1window.cpp` has no `evaluateWindowRules` call, where `xdgshellwindow.cpp` has three), so there is no rule to write either. What does stop it is the window type — every one of those actions is gated behind

```c
USABLE_ACTIVE_WINDOW = m_activeWindow && !(isDesktop() || isDock())
```

so a dock is skipped before closeability is ever consulted. `scopeToType()` maps the layer-shell namespace `"dock"` onto `WindowType::Dock`.

The comment already above this line explained why the surface should report as a dock — it is the same classification Magic Lamp needs to find the panel, from #438. The value underneath it said `"panel"`. This makes the two agree.

Measured with the drawers open and KWin's own close action invoked: 13 shell surfaces drop to 12 as `"panel"`, and stay at 13 as `"dock"`. The launcher still takes keyboard focus, so nothing is lost.

## Focus was never handed back

Opening a drawer moved focus to the shell; closing it left **nothing** focused, so the application went dark until something was clicked. Traced through KWin's `windowActivated`:

```
activated=discord              application had focus
activated=quickshell(dock)     drawer opened
                               drawer closed — no activation at all
```

The drawers now refocus the application they took it from. The address is remembered as the drawer opens rather than read as it closes: reading it late looks tidier and does not work, because as the application gives up focus KWin passes through a moment with no active window, the bridge reports that as empty, and there is frequently nothing left to read. Measured — the handler ran with an empty address more often than not.

Whatever the bridge currently reports still wins, so switching to another application while a drawer is open returns focus there rather than to where it started; the remembered address is only the fallback. The bridge deliberately ignores the shell taking focus, which is what makes either reading meaningful.

`ContentWindow` was also missing the `Caelestia.Services` import, so `KWinActiveWindowBridge` was undefined there and the guard for it swallowed the whole thing silently — worth knowing, since that guard pattern is used in a few places.

Same trace after: `quickshell(dock) -> discord` for the dashboard, `quickshell(dock) -> Claude` for the launcher.

## Tested

Live on KDE Wayland, rebased onto current dev and re-verified after the rebase (dev had changed the `WlrLayershell.layer` expression on the adjacent line). Both drawers, both behaviours, plus a check that the launcher still receives keyboard focus as a dock.
