### PR TITLE
fix: stop the dock hover crash — no screencast requests during QML incubation

### DIFF
--- a/shell/modules/bar/popouts/DockHover.qml
+++ b/shell/modules/bar/popouts/DockHover.qml
@@ -193,11 +193,11 @@ StyledRect {
 
                             color: Colours.tPalette.m3surfaceContainerHighest
                             radius: Tokens.rounding.small
-                            Component.onCompleted: {
-                                if (card.modelData.address) {
-                                    streamRequest = ScreencastManager.requestStream(card.modelData.address);
-                                }
-                            }
+                            // Deferred out of incubation: see ScreencastManager.
+                            Component.onCompleted: Qt.callLater(function () {
+                                if (card.modelData?.address)
+                                    thumb.streamRequest = ScreencastManager.requestStream(card.modelData.address);
+                            })
                             Component.onDestruction: {
                                 if (card.modelData.address) {
                                     ScreencastManager.releaseStream(card.modelData.address);

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -442,7 +442,8 @@ Item {
                                     height: parent.height - (caption.opacity * (caption.implicitHeight + Tokens.padding.extraSmall * 2))
                                     color: Colours.tPalette.m3surfaceContainerHighest
                                     radius: Tokens.rounding.medium
-                                    Component.onCompleted: updateStream()
+                                    // Deferred out of incubation: see ScreencastManager.
+                                    Component.onCompleted: Qt.callLater(updateStream)
                                     Component.onDestruction: {
                                         if (streamRequest && modelData.address) {
                                             ScreencastManager.releaseStream(modelData.address);

--- a/shell/modules/windowinfo/Preview.qml
+++ b/shell/modules/windowinfo/Preview.qml
@@ -74,7 +74,8 @@ Item {
             anchors.centerIn: parent
             radius: Tokens.rounding.medium
 
-                        Component.onCompleted: updateStream()
+                        // Deferred out of incubation: see ScreencastManager.
+                        Component.onCompleted: Qt.callLater(updateStream)
                         Component.onDestruction: {
                             if (lastRequestedAddress !== "") {
                                 ScreencastManager.releaseStream(lastRequestedAddress);

--- a/shell/services/ScreencastManager.qml
+++ b/shell/services/ScreencastManager.qml
@@ -76,6 +76,15 @@ Item {
         root._streams = streams;
     }
 
+    // Must not be called while QML is still creating the object that calls it.
+    // Doing so — from a delegate's Component.onCompleted, say — creates a
+    // screencast object and mutates this singleton's bookkeeping in the middle
+    // of QQmlObjectCreator::finalize, and V4 segfaults writing the entry
+    // (insertMember, under StoreElement). It takes a busy dock popout and a
+    // handful of windows to hit, but then it is reliable — four times in five
+    // on a stress that swaps the hovered icon repeatedly. Callers wrap this in
+    // Qt.callLater; WindowSwitcherItem's 20ms timer predates the explanation
+    // and does the same thing.
     function requestStream(uuid: string): var {
         if (!enableStreams) return null;
         if (!uuid) return null;


### PR DESCRIPTION
Hovering along the dock crashed the shell. Not often, but reliably enough to hit in normal use — six crash reports over two weeks, all the same stack.

## What it was

Every report bottoms out identically:

```
QV4::Object::insertMember          <- SIGSEGV
QV4::Object::internalPut
QV4::Object::internalPut
QV4::Runtime::StoreElement::call   <- obj[key] = value
QV4::Runtime::CallPropertyLookup::call
QQmlBoundSignalExpression::evaluate
QQmlNotifier::emitNotify
QQmlObjectCreator::finalize        <- still building the object
```

That is a delegate's `Component.onCompleted` running while QML is still finalising it, calling `ScreencastManager.requestStream()`, which creates a screencast object and writes the entry into the manager's bookkeeping. Doing either from inside `finalize` is what V4 does not survive.

The dock popout hits it hardest: moving between icons swaps `popouts.dockModel`, which regenerates the `Repeater`, tearing delegates down and building new ones in the same turn. The overview and the window-info preview reach the same call the same way.

## Reproducing it

A stress that swaps the hovered icon 50 times with ten windows open:

| | crashes |
|---|---|
| before | **4 of 5** |
| after | 0 of 5 at 50 swaps, 0 of 3 at 200 |

The crash it produced matches the reported ones frame for frame, same offsets. Window count is what makes it reliable — with only the usual handful of windows open the same stress went 0 for 3, which is why it reads as intermittent in normal use.

## The fix

The three call sites that ran during incubation defer past it. `WindowSwitcherItem` already did this with a 20ms timer — the same workaround arrived at without the explanation — so the note now on `requestStream` says why, and the next caller does not have to find it out the hard way.

## What did not work

My first theory was the manager's redundant `root._streams = streams` reassignments, which write the same reference back and fire a change notification for nothing. Removing all eleven made no difference — five crashes in five — so they are left alone. Worth recording, since they still look wrong and are not the problem.

## Not touched

The overview's thumbnails currently come up empty on `dev`. I checked with and without this change and it is the same either way, so it is something else and left alone here.
