### PR TITLE
fix: open launcher and window switcher on the active monitor

### DIFF
--- a/shell/modules/screenshot/regionSelector/RegionSelector.qml
+++ b/shell/modules/screenshot/regionSelector/RegionSelector.qml
@@ -3,6 +3,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Hyprland
 import Quickshell.Io
+import Caelestia.Services
 import qs.components.misc
 import qs.services
 
@@ -26,7 +27,7 @@ Scope {
 
             required property var modelData
 
-            active: root.screenshotActive && modelData.name === Hypr.focusedMonitor.name
+            active: root.screenshotActive && modelData.name === KWinActiveWindowBridge.cursorOutputName()
 
             sourceComponent: RegionSelection {
                 screen: regionSelectorLoader.modelData

--- a/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
+++ b/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
@@ -45,6 +45,11 @@ QString KWinActiveWindowBridge::pendingFocusAddress() const {
     return m_pendingFocusAddress;
 }
 
+QString KWinActiveWindowBridge::cursorOutputName() const {
+    const auto message = QDBusMessage::createMethodCall("org.kde.KWin", "/KWin", "org.kde.KWin", "activeOutputName");
+    return QDBusConnection::sessionBus().call(message).arguments().value(0).toString();
+}
+
 void KWinActiveWindowBridge::onWindowAdded(const QString& uuid) {
     if (auto* handle = PlasmaWindows::instance()->handleFor(uuid)) {
         connect(handle, &PlasmaWindowHandle::titleChanged, this, &KWinActiveWindowBridge::scheduleWindowListUpdate);

--- a/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.hpp
+++ b/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.hpp
@@ -30,6 +30,7 @@ public:
     QVariantList windowList() const;
     QString pendingFocusAddress() const;
 
+    Q_INVOKABLE QString cursorOutputName() const;
     Q_INVOKABLE void focusWindow(const QString &address);
     Q_INVOKABLE void closeWindow(const QString &address);
     Q_INVOKABLE void minimizeWindow(const QString &address);

--- a/shell/services/Visibilities.qml
+++ b/shell/services/Visibilities.qml
@@ -1,6 +1,7 @@
 pragma Singleton
 
 import Quickshell
+import Caelestia.Services
 import qs.components
 import qs.services
 
@@ -20,12 +21,21 @@ Singleton {
     function load(screen: ShellScreen, visibilities: DrawerVisibilities): void {
         screens.set(Hypr.monitorFor(screen), visibilities);
         screens = new Map(screens); // Force QML property change notification
+        visibilities.launcherChanged.connect(() => {
+            if (!visibilities.launcher)
+                return;
+            for (const other of screens.values()) {
+                if (other !== visibilities)
+                    other.launcher = false;
+            }
+        });
     }
     function registerBar(screen: ShellScreen, barWrapper: var): void {
         bars.set(screen.name, barWrapper);
         bars = new Map(bars); // Force QML property change notification by changing the Map reference
     }
     function getForActive(): DrawerVisibilities {
-        return screens.get(Hypr.focusedMonitor) || screens.values().next().value;
+        const monitor = Hypr.monitors[KWinActiveWindowBridge.cursorOutputName()] || Hypr.focusedMonitor;
+        return screens.get(monitor) || screens.values().next().value;
     }
 }


### PR DESCRIPTION

Thanks for contributing! A few quick things help reviewers give you faster feedback.

## What does this change?

Fixes the launcher and Alt+Tab window switcher always opening on the same monitor in multi-monitor setups.

The active drawer is now selected using KWin's current output when the shortcut is triggered, so it follows the cursor even when the cursor is over another application or the desktop. Launcher visibility is also kept exclusive across outputs, preventing a second launcher or window switcher from remaining open after moving between monitors.

Fixes #442, #513.

## Screenshots (if UI change)

#513: Only opened on the 2nd monitor

Fix:

https://github.com/user-attachments/assets/5bbd58c0-3811-49fc-a72a-0b560429a53f

## How did you test it?

- Rebuilt and installed the shell plugin on KDE Wayland with two monitors.
- Opened the launcher with the cursor over application windows, the desktop, and shell surfaces on both monitors.
- Moved the cursor to the other monitor while the launcher was open and confirmed the panel moved without leaving another instance open.
- Repeated the same check with Alt+Tab and confirmed the window switcher transferred between monitors.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Config / theme
- [ ] Docs
- [ ] Refactor
- [ ] Other

## Notes for reviewers

The monitor lookup uses KWin's `activeOutputName` instead of `QCursor::pos()`, since Wayland only updated the latter while the cursor was over a Quickshell surface. The existing focused-monitor lookup remains as a fallback if KWin does not return a matching output.
