### PR TITLE
fix: use strict mode in ollama_setup.sh

### DIFF
--- a/scripts/ollama_setup.sh
+++ b/scripts/ollama_setup.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-# Exit on error
-set -e
+# Strict mode, as required of everything under scripts/.
+#
+# pipefail is the one that changes behaviour here: the Ollama installer is
+# fetched with `curl | sh`, and without it a failed download pipes nothing into
+# a shell that exits 0 quite happily. The script would then carry on to enable a
+# service for a package that was never installed, and die there instead, with an
+# error pointing at the wrong step.
+set -euo pipefail
 
 # Harmonious HSL colors for elegant premium styling output
 BLUE='\033[0;34m'


### PR DESCRIPTION
`scripts/ollama_setup.sh` had `set -e` where everything under `scripts/` is required to use `set -euo pipefail`. `check_shell_quality.sh` has been reporting it.

## Why it matters

`pipefail` is the flag that actually changes behaviour here. The installer is fetched with:

```bash
curl -fsSL https://ollama.com/install.sh | sh
```

Without `pipefail`, a failed download pipes nothing into a shell that exits `0` quite happily. The script then carries on to `systemctl enable --now ollama` for a package that was never installed, and dies there — reporting the wrong step as the failure. With it, the download failure is caught where it happens.

`nounset` is inert: every variable is either assigned at the top or read from the prompt, and a `read` that fails already exited under `set -e`. I checked each reference (`BLUE`, `GREEN`, `NC`, `RED`, `YELLOW`, `MODEL_CHOICE`, and `title`/`$1` in the two functions, both always called with an argument).

## Deliberately left alone

- **The bare `sudo systemctl` on line 28.** Rule 4 in `check_shell_quality.sh` says bare `sudo` under `scripts/` should use the privilege wrapper, but that rule only exists in the header comment — it is not implemented, so nothing flags this. Converting it is a real behaviour change and a separate decision, so it is not bundled here.
- **`read -p` without `-r`** (SC2162). Irrelevant for a single-digit menu choice, and shellcheck is not run by any workflow in this repo. Kept the change minimal.

## Note

`check_shell_quality.sh` is not wired into any workflow — it appears to be a manual/local tool. So this was never gating CI; the script was just quietly reporting a violation nobody saw.
