### PR TITLE
fix: register the notification server before user applications start

### DIFF
--- a/scripts/10-autostart.sh
+++ b/scripts/10-autostart.sh
@@ -59,6 +59,13 @@ exec stdbuf -oL -eL "$QUICKSHELL_PATH" -d -n -p "\$HOME/.config/quickshell/caele
 EOF
 chmod +x "$HOME/.local/bin/caelestia-autostart.sh"
 
+# Phase 1 (DesktopServices), not 2 (Applications). The shell registers
+# org.freedesktop.Notifications, and applications decide once, when they start,
+# whether a notification server exists -- one that finds none draws its own
+# popups for the rest of the session, in its own corner, ignoring every setting
+# here. In phase 2 the shell starts alongside the user's autostarted apps with
+# no ordering between them, so which apps end up talking to it is a coin toss
+# per login. Phase 1 finishes before any of them begin.
 cat > "$AUTOSTART_DIR/caelestiashell.desktop" << EOF
 [Desktop Entry]
 Type=Application
@@ -69,7 +76,7 @@ Icon=quickshell
 Hidden=false
 NoDisplay=false
 X-GNOME-Autostart-enabled=true
-X-KDE-AutostartPhase=2
+X-KDE-AutostartPhase=1
 X-KDE-Wayland-Interfaces=zkde_screencast_unstable_v1
 EOF
 echo "  [OK]  Quickshell autostart created."


### PR DESCRIPTION
Some notifications arrived as the application's own popup, in a corner the shell does not control, and which applications did that varied between logins.

> Split at review request: the Panels change that was in here is now #544, which stands on its own. This PR is the autostart phase alone.

## What is actually happening

Applications decide **once, when they start**, whether a notification server exists. One that finds none falls back to drawing its own popups for the rest of the session, ignoring every setting on this side. That is why the effect is per-application and sticky rather than per-notification — it looks random, but it is decided at each application's launch.

The shell's autostart entry was `X-KDE-AutostartPhase=2`. That is the Applications phase — the same phase the user's own autostarted applications run in, with no ordering between them. Whether a given application saw a notification server was settled by whichever won the race that login.

Phase 1, DesktopServices, completes before any of them begin.

## Steps to reproduce

**The gap and what it costs — no logout needed:**

```bash
# stop the shell
pkill -x quickshell

# nobody owns the service now
qdbus6 org.freedesktop.DBus /org/freedesktop/DBus \
  org.freedesktop.DBus.GetNameOwner org.freedesktop.Notifications
#   Error: org.freedesktop.DBus.Error.NameHasNoOwner

# send one and time it
time notify-send test test
```

| | result |
|---|---|
| shell stopped | hangs **~85s**, then `Failed to show notification: Error calling StartServiceByName for org.freedesktop.Notifications: Timeout was reached` |
| shell running | returns in **~28ms** |

So a call landing in that window does not merely go unstyled — it blocks the caller for over a minute. The hang is `/usr/share/dbus-1/services/org.kde.plasma.Notifications.service` (`Exec=/usr/bin/plasma_waitforname org.freedesktop.Notifications`): D-Bus activates it, it waits for plasmashell to claim the name, plasmashell never does, and it times out — `WaitForName: Service was not registered within timeout` in the journal.

**Why the window exists at login:**

```bash
grep -H 'X-KDE-AutostartPhase' ~/.config/autostart/*.desktop
```

On this machine, before the change, `caelestiashell.desktop` was phase 2 and the other entries — Ferdium, EasyEffects, a download manager — had no phase line at all, which also means 2.

## Being straight about what is measured

The gap and the 85s failure above are measured. The "keeps drawing its own for the rest of the session" part comes from observing the affected applications and from restarting one fixing it — I did not instrument any application to confirm it caches the lookup at startup. Happy to reword the commit message to claim only the measured part if you would rather.

## Scope

Phase 1 closes the window at login, before applications start. It does nothing for a gap opened later — if the shell exits mid-session, the same failure is there until it re-registers. Worth knowing, but a different problem from the one this fixes.

**Applications already running have made their decision** and need restarting once; from the next login it takes care of itself.
