### PR TITLE
feat: per-monitor workspaces in the bar and overview, and cross-screen window dragging

### DIFF
--- a/shell/kwin-effects/workspace-tracker/workspace_tracker.cpp
+++ b/shell/kwin-effects/workspace-tracker/workspace_tracker.cpp
@@ -3,7 +3,12 @@
 #include <KPluginFactory>
 #include <QStandardPaths>
 #include <QDir>
+#include <QDBusConnection>
+#include <QDBusError>
+#include <effect/effectwindow.h>
 #include <QDebug>
+#include <core/output.h>
+#include <cstring>
 #include <QStandardPaths>
 #include <QDir>
 
@@ -31,9 +36,70 @@ WorkspaceTrackerEffect::WorkspaceTrackerEffect()
 
     connect(m_socket, &QLocalSocket::connected, this, [this]() {
         qDebug() << "WorkspaceTracker: Socket connected!";
+        sendFullState();
     });
 
     connectSocket();
+
+    // Registered on the service KWin already owns; any session client may call
+    // it, and nothing extra has to be granted.
+    if (!QDBusConnection::sessionBus().registerObject(
+            QStringLiteral("/Caelestia/Workspaces"), this, QDBusConnection::ExportAllSlots)) {
+        qWarning() << "WorkspaceTracker: could not register /Caelestia/Workspaces:"
+                   << QDBusConnection::sessionBus().lastError().message();
+    }
+}
+
+KWin::LogicalOutput* WorkspaceTrackerEffect::findOutput(const QString& name)
+{
+    const auto outputs = KWin::effects->screens();
+    for (KWin::LogicalOutput* candidate : outputs) {
+        if (candidate && candidate->name() == name) {
+            return candidate;
+        }
+    }
+    return nullptr;
+}
+
+void WorkspaceTrackerEffect::SendToOutput(const QString& uuid, const QString& output)
+{
+    KWin::LogicalOutput* target = findOutput(output);
+    if (!target) {
+        return;
+    }
+
+    const QUuid wanted(uuid);
+    if (wanted.isNull()) {
+        return;
+    }
+
+    const auto windows = KWin::effects->stackingOrder();
+    for (KWin::EffectWindow* window : windows) {
+        if (window && window->internalId() == wanted) {
+            KWin::effects->windowToScreen(window, target);
+            return;
+        }
+    }
+}
+
+void WorkspaceTrackerEffect::SetDesktop(const QString& output, int desktop)
+{
+    if (desktop < 1) {
+        return;
+    }
+
+    KWin::LogicalOutput* target = findOutput(output);
+    if (!target) {
+        return;
+    }
+
+    const auto desktops = KWin::effects->desktops();
+    for (KWin::VirtualDesktop* candidate : desktops) {
+        if (candidate && static_cast<int>(candidate->x11DesktopNumber()) == desktop) {
+            KWin::effects->setCurrentDesktop(candidate, target);
+            return;
+        }
+    }
 }
 
 WorkspaceTrackerEffect::~WorkspaceTrackerEffect()
@@ -52,33 +118,59 @@ void WorkspaceTrackerEffect::connectSocket()
     }
 }
 
-void WorkspaceTrackerEffect::sendPayload(int desktop, float x, float y)
+void WorkspaceTrackerEffect::sendPayload(int desktop, float x, float y, KWin::LogicalOutput* output)
 {
-    if (m_socket->state() == QLocalSocket::ConnectedState) {
-        DesktopTransition payload{desktop, x, y};
-        m_socket->write(reinterpret_cast<const char*>(&payload), sizeof(payload));
+    if (m_socket->state() != QLocalSocket::ConnectedState) {
+        return;
+    }
+
+    DesktopReport payload;
+    payload.desktop = desktop;
+    payload.x = x;
+    payload.y = y;
+
+    // An unnamed output means "whichever screen is active", which is what the
+    // signals report when per-output desktops are switched off. The shell
+    // applies those to every screen.
+    const QByteArray name = output ? output->name().toUtf8() : QByteArray();
+    const int copied = qMin(name.size(), static_cast<qsizetype>(sizeof(payload.output) - 1));
+    std::memcpy(payload.output, name.constData(), copied);
+    payload.output[copied] = '\0';
+
+    m_socket->write(reinterpret_cast<const char*>(&payload), sizeof(payload));
+}
+
+void WorkspaceTrackerEffect::sendFullState()
+{
+    const auto outputs = KWin::effects->screens();
+    for (KWin::LogicalOutput* output : outputs) {
+        if (KWin::VirtualDesktop* desktop = KWin::effects->currentDesktop(output)) {
+            sendPayload(static_cast<int>(desktop->x11DesktopNumber()), 0.0f, 0.0f, output);
+        }
     }
 }
 
-void WorkspaceTrackerEffect::onDesktopChanging(KWin::VirtualDesktop* desktop, QPointF offset)
+void WorkspaceTrackerEffect::onDesktopChanging(
+    KWin::VirtualDesktop* desktop, QPointF offset, KWin::EffectWindow* with, KWin::LogicalOutput* output)
 {
+    Q_UNUSED(with)
     if (desktop && m_socket->state() == QLocalSocket::ConnectedState) {
-        qDebug() << "WorkspaceTracker: sending offset" << offset << "for desktop" << desktop->x11DesktopNumber();
-        sendPayload(desktop->x11DesktopNumber(), static_cast<float>(offset.x()), static_cast<float>(offset.y()));
-    } else {
-        qDebug() << "WorkspaceTracker: not connected or desktop is null. Socket state:" << m_socket->state();
+        sendPayload(desktop->x11DesktopNumber(), static_cast<float>(offset.x()), static_cast<float>(offset.y()), output);
     }
 }
 
 void WorkspaceTrackerEffect::onDesktopChangingCancelled()
 {
-    sendPayload(0, 0.0f, 0.0f);
+    sendPayload(0, 0.0f, 0.0f, nullptr);
 }
 
-void WorkspaceTrackerEffect::onDesktopChanged(KWin::VirtualDesktop* oldDesktop, KWin::VirtualDesktop* newDesktop)
+void WorkspaceTrackerEffect::onDesktopChanged(
+    KWin::VirtualDesktop* oldDesktop, KWin::VirtualDesktop* newDesktop, KWin::EffectWindow* with, KWin::LogicalOutput* output)
 {
+    Q_UNUSED(oldDesktop)
+    Q_UNUSED(with)
     if (newDesktop && m_socket->state() == QLocalSocket::ConnectedState) {
-        sendPayload(newDesktop->x11DesktopNumber(), 0.0f, 0.0f);
+        sendPayload(newDesktop->x11DesktopNumber(), 0.0f, 0.0f, output);
     }
 }
 

--- a/shell/kwin-effects/workspace-tracker/workspace_tracker.hpp
+++ b/shell/kwin-effects/workspace-tracker/workspace_tracker.hpp
@@ -3,6 +3,7 @@
 #include <effect/effect.h>
 #include <effect/effecthandler.h>
 #include <QLocalSocket>
+#include <QUuid>
 #include <QPointer>
 #include <QObject>
 #include <QPointF>
@@ -10,27 +11,69 @@
 
 namespace caelestia {
 
-struct DesktopTransition {
-    int desktop;
-    float x;
-    float y;
+// Reported to the shell over the local socket.
+//
+// The original record was three fields and said nothing about which screen it
+// described, which was fine while KWin had one current desktop for the whole
+// session. With PerOutputVirtualDesktops each screen has its own, so a report
+// that omits the output is not just incomplete -- it is wrong on every screen
+// but the one it came from.
+//
+// magic exists so the shell can tell this apart from the old 12-byte record: a
+// stale effect can outlive a shell update, because a rebuilt effect does not
+// load until the session restarts. The first field of the old record was a
+// small desktop number, so it can never collide.
+struct DesktopReport {
+    static constexpr quint32 kMagic = 0x43414557; // 'CAEW'
+
+    quint32 magic = kMagic;
+    qint32 desktop = 0;
+    float x = 0.0f;
+    float y = 0.0f;
+    char output[64] = {};
 };
 
 class WorkspaceTrackerEffect : public KWin::Effect
 {
     Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.caelestia.Workspaces")
 public:
     WorkspaceTrackerEffect();
     ~WorkspaceTrackerEffect() override;
 
+public Q_SLOTS:
+    /**
+     * Switches @p output to virtual desktop @p desktop, counting from 1.
+     *
+     * KWin's D-Bus only exposes VirtualDesktopManager.current, and setting it
+     * always applies to whichever output is active. That is unusable once each
+     * screen has its own desktop and more than one thing wants to switch: a
+     * request meant for one monitor lands on whichever the pointer happens to
+     * be over. Inside the compositor the output can simply be named.
+     */
+    void SetDesktop(const QString& output, int desktop);
+
+    /**
+     * Moves the window with EffectWindow::internalId() @p uuid to @p output.
+     *
+     * There is no unprivileged way to do this from outside: plasma-window-management
+     * can move a window between desktops but not between screens, and the D-Bus
+     * surface has nothing for it either. Inside the compositor it is one call.
+     */
+    void SendToOutput(const QString& uuid, const QString& output);
+
 private Q_SLOTS:
-    void onDesktopChanging(KWin::VirtualDesktop* desktop, QPointF offset);
+    void onDesktopChanging(KWin::VirtualDesktop* desktop, QPointF offset, KWin::EffectWindow* with, KWin::LogicalOutput* output);
     void onDesktopChangingCancelled();
-    void onDesktopChanged(KWin::VirtualDesktop* oldDesktop, KWin::VirtualDesktop* newDesktop);
+    void onDesktopChanged(KWin::VirtualDesktop* oldDesktop, KWin::VirtualDesktop* newDesktop, KWin::EffectWindow* with, KWin::LogicalOutput* output);
     void connectSocket();
 
 private:
-    void sendPayload(int desktop, float x, float y);
+    void sendPayload(int desktop, float x, float y, KWin::LogicalOutput* output);
+    /// Reports every output's current desktop, so a shell that just connected
+    /// starts from the truth instead of waiting for someone to switch.
+    void sendFullState();
+    static KWin::LogicalOutput* findOutput(const QString& name);
 
     QLocalSocket* m_socket;
 };

--- a/shell/modules/Shortcuts.qml
+++ b/shell/modules/Shortcuts.qml
@@ -56,14 +56,14 @@ Scope {
         onPressed: {
             const visibilities = Visibilities.getForActive();
             if (visibilities.overview) {
-                visibilities.overview = false;
+                Visibilities.setOverview(false);
             } else {
                 if (typeof KWinActiveWindowBridge !== "undefined" && KWinActiveWindowBridge.activeWindow && KWinActiveWindowBridge.activeWindow.address) {
                     Visibilities.preOverviewActiveWindowAddress = KWinActiveWindowBridge.activeWindow.address;
                 } else {
                     Visibilities.preOverviewActiveWindowAddress = "";
                 }
-                visibilities.overview = true;
+                Visibilities.setOverview(true);
             }
         }
     }
@@ -378,7 +378,11 @@ Scope {
                 if (root.hasFullscreen && ["launcher", "session", "dashboard"].includes(drawer))
                     return;
                 const visibilities = Visibilities.getForActive();
-                visibilities[drawer] = !visibilities[drawer];
+                // The overview spans every screen; see Visibilities.setOverview.
+                if (drawer === "overview")
+                    Visibilities.setOverview(!visibilities.overview);
+                else
+                    visibilities[drawer] = !visibilities[drawer];
             } else {
                 console.warn(lc, `Drawer "${drawer}" does not exist`);
             }
@@ -394,7 +398,10 @@ Scope {
                     return;
                 }
                 const visibilities = Visibilities.getForActive();
-                visibilities[drawer] = !visibilities[drawer];
+                if (drawer === "overview")
+                    Visibilities.setOverview(!visibilities.overview);
+                else
+                    visibilities[drawer] = !visibilities[drawer];
             } else {
                 console.warn(lc, `Drawer "${drawer}" does not exist`);
             }

--- a/shell/modules/bar/components/workspaces/Workspace.qml
+++ b/shell/modules/bar/components/workspaces/Workspace.qml
@@ -15,6 +15,9 @@ GridLayout {
 
     required property int index
     required property int activeWsId
+    /// Name of the screen this bar is on. Window icons are limited to it: the
+    /// desktop is shared across screens, but the pill is not.
+    required property string screenName
     required property var occupied
     required property int groupOffset
 
@@ -335,6 +338,8 @@ GridLayout {
                             const wins = KWinActiveWindowBridge.windowList;
                             for (let i = 0; i < wins.length; ++i) {
                                 const w = wins[i];
+                                if (w.output !== root.screenName)
+                                    continue;
                                 if (w.workspace && w.workspace.id === ws && w["class"] !== "quickshell" && w["class"] !== "plasmashell") {
                                     windows.push(w);
                                 }
@@ -403,6 +408,8 @@ GridLayout {
                             const wins = KWinActiveWindowBridge.windowList;
                             for (let i = 0; i < wins.length; ++i) {
                                 const w = wins[i];
+                                if (w.output !== root.screenName)
+                                    continue;
                                 if (w.workspace && w.workspace.id === ws && w["class"] !== "quickshell" && w["class"] !== "plasmashell") {
                                     windows.push(w);
                                 }

--- a/shell/modules/bar/components/workspaces/Workspaces.qml
+++ b/shell/modules/bar/components/workspaces/Workspaces.qml
@@ -48,6 +48,14 @@ Item {
             if (kwinList) {
                 for (let i = 0; i < kwinList.length; ++i) {
                     const w = kwinList[i];
+                    // KDE's virtual desktops span every screen, so a desktop is
+                    // "occupied" globally the moment anything is on it anywhere.
+                    // This bar belongs to one screen, and saying a desktop is
+                    // busy because of a window the user cannot see from here is
+                    // not useful -- it reports a full desktop as full and an
+                    // empty one as full too.
+                    if (w.output !== root.screen.name)
+                        continue;
                     if (w.workspace && typeof w.workspace.id === "number") {
                         occ[w.workspace.id] = true;
                     }
@@ -121,8 +129,9 @@ Item {
 
                     Workspace {
                         activeWsId: container.activeWsId
-                        occupied: container.occupied
                         groupOffset: container.groupOffset
+                        occupied: container.occupied
+                        screenName: root.screen.name
                     }
                 }
             }

--- a/shell/modules/bar/components/workspaces/Workspaces.qml
+++ b/shell/modules/bar/components/workspaces/Workspaces.qml
@@ -33,9 +33,20 @@ Item {
             return Config.bar.workspaces.shown;
         }
         property int activeWsId: {
-            if (typeof KWinWorkspaceState !== "undefined" && KWinWorkspaceState.activeId > 0) {
+            if (typeof KWinWorkspaceState === "undefined")
+                return 1;
+            // With KWin's per-output virtual desktops each screen has its own
+            // current desktop, and activeId -- which comes from D-Bus -- only
+            // ever reports the focused screen's. Reading it here showed that one
+            // on every bar, and made all of them appear to switch whenever the
+            // pointer crossed to another monitor.
+            const perOutput = KWinWorkspaceState.activeByOutput[root.screen.name];
+            if (perOutput > 0)
+                return perOutput;
+            // Nothing from the tracker yet, or per-output desktops are off, in
+            // which case one current desktop is the truth for every screen.
+            if (KWinWorkspaceState.activeId > 0)
                 return KWinWorkspaceState.activeId;
-            }
             return 1;
         }
         readonly property var occupied: {

--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -240,7 +240,7 @@ StyledWindow {
             visibilities.sidebar = false;
             visibilities.dashboard = false;
             visibilities.utilities = false;
-            visibilities.overview = false;
+            Visibilities.setOverview(false);
             panels.popouts.hasCurrent = false;
             panels.popouts.detachedMode = "";
             bar.closeTray();
@@ -647,7 +647,7 @@ StyledWindow {
         MouseArea {
             anchors.fill: parent
             visible: visibilities.overview
-            onClicked: visibilities.overview = false
+            onClicked: Visibilities.setOverview(false)
         }
         Panels {
             id: panels

--- a/shell/modules/drawers/Interactions.qml
+++ b/shell/modules/drawers/Interactions.qml
@@ -4,6 +4,7 @@ import Quickshell
 import Caelestia.Config
 import qs.components
 import qs.components.controls
+import qs.services
 import qs.modules.bar as Bar
 import qs.modules.bar.popouts as BarPopouts
 
@@ -372,12 +373,12 @@ CustomMouseArea {
         if (Config.overview.enabled && !visibilities.overview) {
             if (Config.overview.showOnHover) {
                 if (inOverviewCorner(x, y) !== "") {
-                    visibilities.overview = true;
+                    Visibilities.setOverview(true);
                 }
             } else if (pressed) {
                 if (inOverviewCorner(dragStart.x, dragStart.y) !== "") {
                     if (Math.hypot(dragX, dragY) > Config.overview.dragThreshold) {
-                        visibilities.overview = true;
+                        Visibilities.setOverview(true);
                     }
                 }
             }

--- a/shell/modules/overview/Content.qml
+++ b/shell/modules/overview/Content.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import Quickshell
 import qs.components
 import qs.services
 import qs.modules.windowinfo as WInfo
@@ -8,6 +9,7 @@ import qs.modules.windowinfo as WInfo
 Item {
     id: root
 
+    required property ShellScreen screen
     required property DrawerVisibilities visibilities
     required property var panels
     property var animConfig
@@ -26,6 +28,7 @@ Item {
         id: windowGrid
 
         panels: root.panels
+        screen: root.screen
         anchors.fill: parent
         opacity: root.visibilities.overview ? 1 : 0
         // activeInfoClient is managed manually to ensure synchronous release before WindowInfo requests it
@@ -35,14 +38,14 @@ Item {
             windowInfoOverlay.isOpen = true
         }
         onRequestClose: {
-            root.visibilities.overview = false
+            Visibilities.setOverview(false)
         }
 
         Behavior on opacity { NumberAnimation { duration: root.animConfig ? root.animConfig.gridDuration : 1500; easing.type: root.animConfig ? root.animConfig.easingType : Easing.OutCubic } }
     }
     Shortcut {
         sequence: "Escape"
-        onActivated: root.visibilities.overview = false
+        onActivated: Visibilities.setOverview(false)
         enabled: root.visibilities.overview
     }
     Item {

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -43,6 +43,9 @@ Item {
     property bool ignoreNextSwitch: false
     property bool _initialized: false
     property bool isDragging: false
+    /// -1 while a drag rests against the left edge, +1 against the right, 0
+    /// otherwise. Drives the dwell that pages through workspaces.
+    property int edgeDirection: 0
     readonly property real hoverScale: 1.02
     property int selectedIndex: -1
     readonly property var currentWindows: {
@@ -59,30 +62,6 @@ Item {
                 if (all[i].output === root.screen.name && all[i].workspace && (all[i].workspace.id === wsId || all[i].workspace.index === wsId))
                     out.push(all[i]);
         return out;
-    }
-
-    /// Whether another screen sits immediately to this one's left/right.
-    ///
-    /// The edge drop areas below page through workspaces when a drag reaches
-    /// them, which is the only way out of the screen on that side -- so on a
-    /// side that has another monitor, they swallow exactly the gesture that
-    /// means "put this over there". Where there is a neighbour, the edge belongs
-    /// to it; where there is not, paging is still the useful thing to do.
-    readonly property bool hasScreenLeft: {
-        const all = Quickshell.screens;
-        for (let i = 0; i < all.length; ++i)
-            if (all[i].name !== root.screen.name && all[i].x + all[i].width <= root.screen.x + 1
-                && all[i].y < root.screen.y + root.screen.height && all[i].y + all[i].height > root.screen.y)
-                return true;
-        return false;
-    }
-    readonly property bool hasScreenRight: {
-        const all = Quickshell.screens;
-        for (let i = 0; i < all.length; ++i)
-            if (all[i].name !== root.screen.name && all[i].x >= root.screen.x + root.screen.width - 1
-                && all[i].y < root.screen.y + root.screen.height && all[i].y + all[i].height > root.screen.y)
-                return true;
-        return false;
     }
 
     signal requestWindowInfo(var client)
@@ -375,6 +354,13 @@ Item {
                             /// reverses it.
                             readonly property bool morphed: dragHandler.active && activeWin.dropTargetScale > 0
 
+                            function publishDrag(): void {
+                                if (!dragHandler.active)
+                                    return;
+                                const p = activeWin.mapToItem(null, activeWin.width / 2, activeWin.height / 2);
+                                Visibilities.setDrag(activeWin.clientAddress, root.screen.x + p.x, root.screen.y + p.y, root.screen.name);
+                            }
+
                             x: dragHandler.active ? x : layoutProps.x
                             y: dragHandler.active ? y : layoutProps.y
                             width: layoutProps.width
@@ -395,6 +381,12 @@ Item {
                             opacity: closing ? 0 : 1
                             border.width: activeWin.isSelected && !activeWin.morphed ? 2 : 0
                             border.color: Colours.palette.m3primary
+
+                            // Published on every move so the screen the pointer
+                            // has reached can draw what is coming; this one cannot
+                            // draw past its own edge.
+                            onXChanged: activeWin.publishDrag()
+                            onYChanged: activeWin.publishDrag()
 
                             Component.onCompleted: {
                                 root.cardItems = [...root.cardItems, activeWin];
@@ -424,6 +416,7 @@ Item {
                                     root.isDragging = active;
                                     if (!active) {
                                         activeWin.dropTargetScale = 0;
+                                        Visibilities.clearDrag();
 
                                         if (typeof KWinWorkspaceState === "undefined" || typeof KWinActiveWindowBridge === "undefined") return;
 
@@ -468,7 +461,15 @@ Item {
                                     }
                                 }
                             }
-                            Behavior on scale { Anim {} }
+                            Behavior on scale {
+                                // Slower while a drag is in progress: this is the
+                                // preview collapsing into its icon and opening back
+                                // out, which is meant to be read, not the snap of a
+                                // hover highlight.
+                                Anim {
+                                    type: dragHandler.active ? Anim.SlowSpatial : Anim.DefaultSpatial
+                                }
+                            }
                             Behavior on opacity {
                                 NumberAnimation {
                                     id: opacityAnim
@@ -520,7 +521,9 @@ Item {
                                 z: 10
 
                                 Behavior on opacity {
-                                    Anim {}
+                                    Anim {
+                                        type: Anim.SlowEffects
+                                    }
                                 }
                             }
 
@@ -533,7 +536,9 @@ Item {
                                 visible: opacity > 0.01
 
                                 Behavior on opacity {
-                                    Anim {}
+                                    Anim {
+                                        type: Anim.SlowEffects
+                                    }
                                 }
 
                                 StyledClippingRect {
@@ -778,22 +783,98 @@ Item {
         interval: 500
         onTriggered: root.ignoreNextSwitch = false
     }
-    Timer {
-        id: edgeScrollCooldown
+    // What a drag arriving from another screen looks like here.
+    //
+    // The card itself belongs to the overview it started in and is clipped at
+    // that screen's edge, so without this a window dragged across simply
+    // disappears halfway and is released onto nothing visible. This follows the
+    // published pointer position and shows the application it is carrying.
+    Item {
+        id: incoming
 
-        interval: 1000
+        readonly property var window: {
+            const addr = Visibilities.dragAddress;
+            if (!addr || typeof KWinActiveWindowBridge === "undefined")
+                return null;
+            const all = KWinActiveWindowBridge.windowList || [];
+            for (let i = 0; i < all.length; ++i)
+                if (all[i].address === addr)
+                    return all[i];
+            return null;
+        }
+        readonly property bool arriving: Visibilities.dragAddress !== ""
+            && Visibilities.dragOriginScreen !== root.screen.name
+            && Visibilities.dragX >= root.screen.x
+            && Visibilities.dragX < root.screen.x + root.screen.width
+            && Visibilities.dragY >= root.screen.y
+            && Visibilities.dragY < root.screen.y + root.screen.height
+
+        height: Math.round(Math.min(root.width, root.height) * 0.18)
+        opacity: arriving ? 1 : 0
+        visible: opacity > 0.01
+        width: height
+        x: Visibilities.dragX - root.screen.x - width / 2
+        y: Visibilities.dragY - root.screen.y - height / 2
+        z: 1000
+
+        Behavior on opacity {
+            Anim {
+                type: Anim.DefaultEffects
+            }
+        }
+
+        StyledRect {
+            anchors.fill: parent
+            color: Colours.tPalette.m3surfaceContainerHigh
+            radius: Tokens.rounding.large
+
+            IconImage {
+                anchors.centerIn: parent
+                asynchronous: true
+                implicitSize: Math.round(parent.height * 0.62)
+                source: {
+                    const w = incoming.window;
+                    if (!w)
+                        return "";
+                    return w.iconName ? Icons.getAppIcon(w.iconName, "image-missing") : (w.class ? Icons.getAppIcon(w.class, "image-missing") : "");
+                }
+            }
+        }
+    }
+
+    // Holding a drag against an edge pages through workspaces, one step at a
+    // time for as long as it is held.
+    //
+    // It used to page the instant the drag touched the edge, which made the
+    // edge unusable as a way off the screen: on a side with another monitor,
+    // simply travelling towards it paged a workspace on the way past. Waiting
+    // for the drag to actually rest there separates the two gestures -- pass
+    // through and you reach the next monitor, stop and you page -- so both work
+    // on the same edge without a mode.
+    Timer {
+        id: edgeDwell
+
+        interval: 700
+        repeat: true
+        onTriggered: {
+            if (root.edgeDirection < 0 && listView.currentIndex > 0)
+                listView.currentIndex -= 1;
+            else if (root.edgeDirection > 0 && listView.currentIndex < listView.count - 1)
+                listView.currentIndex += 1;
+        }
     }
     DropArea {
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         width: 100
-        enabled: !root.hasScreenLeft
         onEntered: {
-            if (!edgeScrollCooldown.running && listView.currentIndex > 0) {
-                listView.currentIndex -= 1;
-                edgeScrollCooldown.start();
-            }
+            root.edgeDirection = -1;
+            edgeDwell.restart();
+        }
+        onExited: {
+            root.edgeDirection = 0;
+            edgeDwell.stop();
         }
     }
     DropArea {
@@ -801,12 +882,13 @@ Item {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         width: 100
-        enabled: !root.hasScreenRight
         onEntered: {
-            if (!edgeScrollCooldown.running && listView.currentIndex < listView.count - 1) {
-                listView.currentIndex += 1;
-                edgeScrollCooldown.start();
-            }
+            root.edgeDirection = 1;
+            edgeDwell.restart();
+        }
+        onExited: {
+            root.edgeDirection = 0;
+            edgeDwell.stop();
         }
     }
     StyledRect {

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -45,7 +45,29 @@ Item {
     property bool isDragging: false
     /// -1 while a drag rests against the left edge, +1 against the right, 0
     /// otherwise. Drives the dwell that pages through workspaces.
-    property int edgeDirection: 0
+    ///
+    /// Read from the drag's own position rather than from drop areas at the
+    /// edges. Those reported entry and exit, and paging moves the grid under the
+    /// pointer, which counted as leaving -- so the second page never came while
+    /// the drag was held perfectly still. A position cannot be confused that way.
+    readonly property real edgeBand: 60
+    readonly property int edgeDirection: {
+        if (!root.isDragging || Visibilities.dragAddress === "" || Visibilities.dragOriginScreen !== root.screen.name)
+            return 0;
+        // Screen coordinates on both sides. The published position is relative
+        // to the window, which covers the screen; root is an item inside it and
+        // narrower, so measuring one against the other put the edge in the wrong
+        // place -- far enough out that it was never reached.
+        const local = Visibilities.dragX - root.screen.x;
+        const span = root.screen.width;
+        if (local < 0 || local >= span)
+            return 0; // gone to another screen; that is a move, not a page
+        if (local < root.edgeBand)
+            return -1;
+        if (local > span - root.edgeBand)
+            return 1;
+        return 0;
+    }
     readonly property real hoverScale: 1.02
     property int selectedIndex: -1
     readonly property var currentWindows: {
@@ -116,8 +138,6 @@ Item {
         ignoreTimer.stop();
         root._initialized = true;
     }
-
-    onIsDraggingChanged: if (!isDragging) edgeDirection = 0
 
     onOpacityChanged: {
         if (opacity <= 0) {
@@ -356,11 +376,17 @@ Item {
                             /// reverses it.
                             readonly property bool morphed: dragHandler.active && activeWin.dropTargetScale > 0
 
+                            // The pointer, not the card's middle. The card is held
+                            // wherever it was grabbed, so its centre sits at an
+                            // offset that drifts across boundaries on its own --
+                            // enough to cross the screen edge while the pointer was
+                            // still well inside it, which read as leaving the screen
+                            // and reset the edge dwell every time it wobbled.
                             function publishDrag(): void {
                                 if (!dragHandler.active)
                                     return;
-                                const p = activeWin.mapToItem(null, activeWin.width / 2, activeWin.height / 2);
-                                Visibilities.setDrag(activeWin.clientAddress, root.screen.x + p.x, root.screen.y + p.y, root.screen.name);
+                                const p = dragHandler.centroid.scenePosition;
+                                Visibilities.setDrag(activeWin.clientAddress, root.screen.x + p.x, root.screen.y + p.y, activeWin.width, activeWin.height, root.screen.name);
                             }
 
                             x: dragHandler.active ? x : layoutProps.x
@@ -380,7 +406,10 @@ Item {
                                     return activeWin.dropTargetScale;
                                 return activeWin.isSelected && !dragHandler.active ? root.hoverScale : 1;
                             }
-                            opacity: closing ? 0 : 1
+                            // Once the drag is over another screen that screen
+                            // draws it, and the half still poking out here would
+                            // otherwise sit there as a stream-less icon.
+                            opacity: closing || Visibilities.streamClaim === activeWin.clientAddress ? 0 : 1
                             border.width: activeWin.isSelected && !activeWin.morphed ? 2 : 0
                             border.color: Colours.palette.m3primary
 
@@ -435,8 +464,7 @@ Item {
                                         // land on a workspace of the monitor it came
                                         // from. Leaving the screen is the stronger
                                         // signal, so it is read first.
-                                        const centre = activeWin.mapToItem(null, activeWin.width / 2, activeWin.height / 2);
-                                        const target = root.screenAtGlobal(root.screen.x + centre.x, root.screen.y + centre.y);
+                                        const target = root.screenAtGlobal(Visibilities.dragX, Visibilities.dragY);
                                         if (target && target.name !== root.screen.name) {
                                             const addr = clientAddress;
                                             activeWin.Drag.cancel();
@@ -639,7 +667,10 @@ Item {
                                 anchors.right: cardLayout.right
                                 anchors.margins: Tokens.padding.small
                                 spacing: Tokens.spacing.small
-                                opacity: hover.hovered ? 1 : 0
+                                // Hidden for the whole drag: it belongs to the
+                                // card sitting in the grid, and left up it hovers
+                                // over the collapsed icon with nothing to act on.
+                                opacity: hover.hovered && !dragHandler.active ? 1 : 0
                                 visible: opacity > 0.01
 
                                 Behavior on opacity { Anim {} }
@@ -892,22 +923,6 @@ Item {
             else if (root.edgeDirection > 0 && listView.currentIndex < listView.count - 1)
                 listView.currentIndex += 1;
         }
-    }
-    DropArea {
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-        width: 100
-        onEntered: root.edgeDirection = -1
-        onExited: root.edgeDirection = 0
-    }
-    DropArea {
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-        width: 100
-        onEntered: root.edgeDirection = 1
-        onExited: root.edgeDirection = 0
     }
     StyledRect {
         anchors.left: parent.left

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -19,12 +19,27 @@ Item {
     property var cardItems: []
     property var activeInfoClient: null
     property var panels: null
+    /// The screen this overview belongs to. Everything below is scoped to it:
+    /// KWin gives each output its own current desktop, and each window lives on
+    /// one output, so an overview that ignores this shows the other monitor's
+    /// desktop and the other monitor's windows.
+    required property ShellScreen screen
     property var closingWindows: []
     property alias indicatorContainer: indicatorContainer
     readonly property real overviewBorderThickness: Math.min(width, height) * 0.15
     readonly property real indicatorSpace: indicatorContainer.height + Tokens.padding.large * 2
     readonly property real verticalOffset: indicatorSpace - overviewBorderThickness
-    readonly property int activeWsId: typeof KWinWorkspaceState !== "undefined" ? KWinWorkspaceState.activeId : 1
+    readonly property int activeWsId: {
+        if (typeof KWinWorkspaceState === "undefined")
+            return 1;
+        // activeId comes from D-Bus, which exposes a single current desktop and
+        // reports whichever output is focused. Per screen, only the tracker
+        // knows.
+        const perOutput = KWinWorkspaceState.activeByOutput[root.screen.name];
+        if (perOutput > 0)
+            return perOutput;
+        return KWinWorkspaceState.activeId > 0 ? KWinWorkspaceState.activeId : 1;
+    }
     property bool ignoreNextSwitch: false
     property bool _initialized: false
     property bool isDragging: false
@@ -41,13 +56,48 @@ Item {
         const out = [];
         if (all)
             for (let i = 0; i < all.length; ++i)
-                if (all[i].workspace && (all[i].workspace.id === wsId || all[i].workspace.index === wsId))
+                if (all[i].output === root.screen.name && all[i].workspace && (all[i].workspace.id === wsId || all[i].workspace.index === wsId))
                     out.push(all[i]);
         return out;
     }
 
+    /// Whether another screen sits immediately to this one's left/right.
+    ///
+    /// The edge drop areas below page through workspaces when a drag reaches
+    /// them, which is the only way out of the screen on that side -- so on a
+    /// side that has another monitor, they swallow exactly the gesture that
+    /// means "put this over there". Where there is a neighbour, the edge belongs
+    /// to it; where there is not, paging is still the useful thing to do.
+    readonly property bool hasScreenLeft: {
+        const all = Quickshell.screens;
+        for (let i = 0; i < all.length; ++i)
+            if (all[i].name !== root.screen.name && all[i].x + all[i].width <= root.screen.x + 1
+                && all[i].y < root.screen.y + root.screen.height && all[i].y + all[i].height > root.screen.y)
+                return true;
+        return false;
+    }
+    readonly property bool hasScreenRight: {
+        const all = Quickshell.screens;
+        for (let i = 0; i < all.length; ++i)
+            if (all[i].name !== root.screen.name && all[i].x >= root.screen.x + root.screen.width - 1
+                && all[i].y < root.screen.y + root.screen.height && all[i].y + all[i].height > root.screen.y)
+                return true;
+        return false;
+    }
+
     signal requestWindowInfo(var client)
     signal requestClose()
+
+    /// The screen containing a point in global coordinates, or null.
+    function screenAtGlobal(gx: real, gy: real): var {
+        const all = Quickshell.screens;
+        for (let i = 0; i < all.length; ++i) {
+            const s = all[i];
+            if (gx >= s.x && gx < s.x + s.width && gy >= s.y && gy < s.y + s.height)
+                return s;
+        }
+        return null;
+    }
 
     function cycleSelection(backwards: bool): void {
         const n = root.currentWindows.length;
@@ -68,7 +118,7 @@ Item {
         if (typeof KWinActiveWindowBridge !== "undefined")
             KWinActiveWindowBridge.focusWindow(addr);
         if (typeof KWinWorkspaceState !== "undefined" && listView.currentIndex >= 0)
-            KWinWorkspaceState.switchTo(KWinWorkspaceState.workspaces[listView.currentIndex].index);
+            KWinWorkspaceState.switchTo(KWinWorkspaceState.workspaces[listView.currentIndex].index, root.screen.name);
         root.requestClose();
     }
     function syncPage() {
@@ -216,6 +266,8 @@ Item {
                 if (kwinList) {
                     for (let i = 0; i < kwinList.length; ++i) {
                         const w = kwinList[i];
+                        if (w.output !== root.screen.name)
+                            continue;
                         if (w.workspace && (w.workspace.id === wsId || w.workspace.index === wsId)) {
                             arr.push(w);
                         }
@@ -311,16 +363,37 @@ Item {
 
                             property bool closing: false
                             property url infoScreenshot: ""
+                            /// Set by a workspace thumbnail's DropArea while the
+                            /// card hovers it, so the card shrinks to the size it
+                            /// would occupy there. 0 means "not over one".
+                            property real dropTargetScale: 0
+                            /// Over a workspace thumbnail: the preview collapses
+                            /// into the application's icon, the way a window does
+                            /// when it is dropped onto a workspace in GNOME. It is
+                            /// what the slot will actually contain once dropped, so
+                            /// the drag shows its own result; dragging back out
+                            /// reverses it.
+                            readonly property bool morphed: dragHandler.active && activeWin.dropTargetScale > 0
 
                             x: dragHandler.active ? x : layoutProps.x
                             y: dragHandler.active ? y : layoutProps.y
                             width: layoutProps.width
                             height: layoutProps.height
-                            color: Colours.palette.m3surfaceContainer
+                            color: activeWin.morphed ? "transparent" : Colours.palette.m3surfaceContainer
                             radius: Tokens.rounding.large
-                            scale: closing ? 0 : (activeWin.isSelected && !dragHandler.active ? root.hoverScale : 1)
+                            scale: {
+                                if (closing)
+                                    return 0;
+                                // Dragged onto a workspace thumbnail: shrink to
+                                // roughly what it will look like once dropped, so
+                                // the target reads as a target rather than the
+                                // card just floating over it.
+                                if (dragHandler.active && activeWin.dropTargetScale > 0)
+                                    return activeWin.dropTargetScale;
+                                return activeWin.isSelected && !dragHandler.active ? root.hoverScale : 1;
+                            }
                             opacity: closing ? 0 : 1
-                            border.width: activeWin.isSelected ? 2 : 0
+                            border.width: activeWin.isSelected && !activeWin.morphed ? 2 : 0
                             border.color: Colours.palette.m3primary
 
                             Component.onCompleted: {
@@ -350,12 +423,40 @@ Item {
                                 onActiveChanged: {
                                     root.isDragging = active;
                                     if (!active) {
+                                        activeWin.dropTargetScale = 0;
+
+                                        if (typeof KWinWorkspaceState === "undefined" || typeof KWinActiveWindowBridge === "undefined") return;
+
+                                        // Checked before Drag.drop(), not after.
+                                        // Each screen has its own overview in its
+                                        // own window, so a drag can never be handed
+                                        // to the other one's drop areas -- but the
+                                        // pointer does travel there and the card
+                                        // goes with it, so where it was let go is
+                                        // enough to act on. This one's drop areas
+                                        // still claim a release out there, though,
+                                        // and one of them answering first is what
+                                        // made a window dragged to the next monitor
+                                        // land on a workspace of the monitor it came
+                                        // from. Leaving the screen is the stronger
+                                        // signal, so it is read first.
+                                        const centre = activeWin.mapToItem(null, activeWin.width / 2, activeWin.height / 2);
+                                        const target = root.screenAtGlobal(root.screen.x + centre.x, root.screen.y + centre.y);
+                                        if (target && target.name !== root.screen.name) {
+                                            const addr = clientAddress;
+                                            activeWin.Drag.cancel();
+                                            activeWin.visible = false;
+                                            Qt.callLater(() => {
+                                                KWinActiveWindowBridge.sendToOutput(addr, target.name);
+                                            });
+                                            return;
+                                        }
+
                                         let dropAction = activeWin.Drag.drop();
                                         if (dropAction !== Qt.IgnoreAction) {
                                             return; // Handled by DropArea
                                         }
 
-                                        if (typeof KWinWorkspaceState === "undefined" || typeof KWinActiveWindowBridge === "undefined") return;
                                         const targetWsId = KWinWorkspaceState.workspaces[listView.currentIndex].index;
                                         if (targetWsId !== page.wsId) {
                                             activeWin.visible = false;
@@ -405,11 +506,35 @@ Item {
                                 }
                             }
 
+                            // The icon the card collapses into over a workspace
+                            // thumbnail. Sized as a share of the card so that the
+                            // card's own drop scale carries it down to icon size --
+                            // one animation drives both, and they cannot drift.
+                            IconImage {
+                                anchors.centerIn: parent
+                                asynchronous: true
+                                implicitSize: Math.round(Math.min(activeWin.width, activeWin.height) * 0.62)
+                                opacity: activeWin.morphed ? 1 : 0
+                                source: modelData.iconName ? Icons.getAppIcon(modelData.iconName, "image-missing") : (modelData.class ? Icons.getAppIcon(modelData.class, "image-missing") : "")
+                                visible: opacity > 0.01
+                                z: 10
+
+                                Behavior on opacity {
+                                    Anim {}
+                                }
+                            }
+
                             Item {
                                 id: cardLayout
 
                                 anchors.fill: parent
                                 anchors.margins: Tokens.padding.small
+                                opacity: activeWin.morphed ? 0 : 1
+                                visible: opacity > 0.01
+
+                                Behavior on opacity {
+                                    Anim {}
+                                }
 
                                 StyledClippingRect {
                                     id: thumb
@@ -488,11 +613,11 @@ Item {
                                             Hypr.dispatch(Hypr.usingLua ? `hl.dsp.focus({ window = "address:0x${modelData.address}" })` : `focuswindow address:0x${modelData.address}`);
                                         }
                                         if (typeof KWinWorkspaceState !== "undefined") {
-                                            KWinWorkspaceState.switchTo(page.wsId);
+                                            KWinWorkspaceState.switchTo(page.wsId, root.screen.name);
                                         }
                                     }
-                                    const v = typeof Visibilities !== "undefined" ? Visibilities.getForActive() : null;
-                                    if (v) v.overview = false;
+                                    if (typeof Visibilities !== "undefined")
+                                        Visibilities.setOverview(false);
                                 }
                             }
 
@@ -573,8 +698,13 @@ Item {
             onTriggered: {
                 if (typeof KWinWorkspaceState !== "undefined" && KWinWorkspaceState.workspaces.length > listView.currentIndex) {
                     const wId = KWinWorkspaceState.workspaces[listView.currentIndex].index;
-                    if (KWinWorkspaceState.activeId !== wId) {
-                        KWinWorkspaceState.switchTo(wId);
+                    // Compared against this screen's desktop, not the global
+                    // activeId: with per-output desktops the global one belongs
+                    // to whichever screen is focused, so testing against it made
+                    // this fire on the screen that had not moved and stay quiet
+                    // on the one that had.
+                    if (root.activeWsId !== wId) {
+                        KWinWorkspaceState.switchTo(wId, root.screen.name);
                     }
                 }
             }
@@ -622,6 +752,7 @@ Item {
 
             anchors.centerIn: parent
             maxWidth: Math.max(200, root.width - 100)
+            screenName: root.screen.name
             count: listView.count
             currentIndex: listView.currentIndex
             closingWindows: root.closingWindows
@@ -657,6 +788,7 @@ Item {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         width: 100
+        enabled: !root.hasScreenLeft
         onEntered: {
             if (!edgeScrollCooldown.running && listView.currentIndex > 0) {
                 listView.currentIndex -= 1;
@@ -669,6 +801,7 @@ Item {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         width: 100
+        enabled: !root.hasScreenRight
         onEntered: {
             if (!edgeScrollCooldown.running && listView.currentIndex < listView.count - 1) {
                 listView.currentIndex += 1;

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -117,6 +117,8 @@ Item {
         root._initialized = true;
     }
 
+    onIsDraggingChanged: if (!isDragging) edgeDirection = 0
+
     onOpacityChanged: {
         if (opacity <= 0) {
             selectedIndex = -1;
@@ -556,9 +558,15 @@ Item {
                                         // neighbours: a workspace three swipes away
                                         // is not worth a stream. The window shown in
                                         // the info panel is excluded too -- that
-                                        // panel puts up its own frozen frame.
+                                        // panel puts up its own frozen frame. And
+                                        // not while something outside the grid has
+                                        // claimed the stream: KWin serves one node
+                                        // per window and a node feeds one consumer,
+                                        // so holding on would leave the other one
+                                        // drawing black.
                                         active: root.opacity > 0 && Math.abs(page.index - listView.currentIndex) <= 1
                                             && !(root.activeInfoClient && root.activeInfoClient.address === modelData.address)
+                                            && Visibilities.streamClaim !== modelData.address
                                         address: modelData.address ?? ""
                                         anchors.fill: parent
                                         fallbackIcon: modelData.iconName ? Icons.getAppIcon(modelData.iconName, "image-missing") : (modelData.class ? Icons.getAppIcon(modelData.class, "image-missing") : "")
@@ -788,7 +796,9 @@ Item {
     // The card itself belongs to the overview it started in and is clipped at
     // that screen's edge, so without this a window dragged across simply
     // disappears halfway and is released onto nothing visible. This follows the
-    // published pointer position and shows the application it is carrying.
+    // published pointer position and shows the same live preview the card was
+    // showing, so the window keeps its identity across the gap rather than
+    // turning into an icon on the way.
     Item {
         id: incoming
 
@@ -808,14 +818,26 @@ Item {
             && Visibilities.dragX < root.screen.x + root.screen.width
             && Visibilities.dragY >= root.screen.y
             && Visibilities.dragY < root.screen.y + root.screen.height
+        readonly property real aspect: {
+            const w = incoming.window;
+            if (w && w.width > 0 && w.height > 0)
+                return w.width / w.height;
+            return 16 / 9;
+        }
 
-        height: Math.round(Math.min(root.width, root.height) * 0.18)
+        // The size the card had on the screen it left, so crossing the gap does
+        // not resize the thing being carried.
+        height: Visibilities.dragHeight > 0 ? Visibilities.dragHeight : Math.round(width / Math.max(0.2, incoming.aspect))
         opacity: arriving ? 1 : 0
         visible: opacity > 0.01
-        width: height
+        width: Visibilities.dragWidth > 0 ? Visibilities.dragWidth : Math.round(Math.min(root.width, root.height) * 0.32)
         x: Visibilities.dragX - root.screen.x - width / 2
         y: Visibilities.dragY - root.screen.y - height / 2
         z: 1000
+
+        // Claimed while it is here so the card back on the origin screen gives
+        // the stream up; a node feeds one consumer.
+        onArrivingChanged: Visibilities.streamClaim = incoming.arriving ? Visibilities.dragAddress : ""
 
         Behavior on opacity {
             Anim {
@@ -823,21 +845,22 @@ Item {
             }
         }
 
-        StyledRect {
+        StyledClippingRect {
             anchors.fill: parent
-            color: Colours.tPalette.m3surfaceContainerHigh
+            color: Colours.palette.m3surfaceContainer
             radius: Tokens.rounding.large
 
-            IconImage {
-                anchors.centerIn: parent
-                asynchronous: true
-                implicitSize: Math.round(parent.height * 0.62)
-                source: {
+            WindowPreview {
+                active: incoming.arriving
+                address: Visibilities.dragAddress
+                anchors.fill: parent
+                fallbackIcon: {
                     const w = incoming.window;
                     if (!w)
                         return "";
                     return w.iconName ? Icons.getAppIcon(w.iconName, "image-missing") : (w.class ? Icons.getAppIcon(w.class, "image-missing") : "");
                 }
+                sourceAspect: incoming.aspect
             }
         }
     }
@@ -854,8 +877,15 @@ Item {
     Timer {
         id: edgeDwell
 
-        interval: 700
+        // running is bound rather than started and stopped by hand. A drag
+        // released while still inside an edge area never delivers an exit, so
+        // the stop call that was meant to pair with the start never arrived and
+        // the timer kept paging on its own long after the pointer was gone --
+        // workspaces flipping by themselves with nothing held. Tying it to the
+        // drag itself means it cannot outlive one.
+        interval: 900
         repeat: true
+        running: root.isDragging && root.edgeDirection !== 0
         onTriggered: {
             if (root.edgeDirection < 0 && listView.currentIndex > 0)
                 listView.currentIndex -= 1;
@@ -868,28 +898,16 @@ Item {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         width: 100
-        onEntered: {
-            root.edgeDirection = -1;
-            edgeDwell.restart();
-        }
-        onExited: {
-            root.edgeDirection = 0;
-            edgeDwell.stop();
-        }
+        onEntered: root.edgeDirection = -1
+        onExited: root.edgeDirection = 0
     }
     DropArea {
         anchors.right: parent.right
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         width: 100
-        onEntered: {
-            root.edgeDirection = 1;
-            edgeDwell.restart();
-        }
-        onExited: {
-            root.edgeDirection = 0;
-            edgeDwell.stop();
-        }
+        onEntered: root.edgeDirection = 1
+        onExited: root.edgeDirection = 0
     }
     StyledRect {
         anchors.left: parent.left

--- a/shell/modules/overview/WorkspaceIndicator.qml
+++ b/shell/modules/overview/WorkspaceIndicator.qml
@@ -12,6 +12,7 @@ import qs.services
 Item {
     id: root
 
+    required property string screenName
     property int count: 0
     property int currentIndex: 0
     readonly property int activeWsId: currentIndex + 1
@@ -30,6 +31,11 @@ Item {
         if (kwinList) {
             for (let i = 0; i < kwinList.length; ++i) {
                 const w = kwinList[i];
+                // Each window lives on one output; this strip describes one
+                // screen. Counting the other monitor's windows makes a desktop
+                // that is empty here look busy.
+                if (w.output !== root.screenName)
+                    continue;
                 if (w.workspace) {
                     const wid = typeof w.workspace.id === "number" ? w.workspace.id : (typeof w.workspace.index === "number" ? w.workspace.index : null);
                     if (wid !== null) occ[wid] = true;
@@ -122,6 +128,7 @@ Item {
                 WsComponents.Workspace {
                     scaleFactor: root.scaleFactor
                     activeWsId: root.activeWsId
+                    screenName: root.screenName
                     occupied: root.occupied
                     groupOffset: 0
                     swipeOffset: root.swipeOffset
@@ -256,7 +263,7 @@ Item {
                                 }
                                 if (newActId !== actId) {
                                     const targetUuid = KWinWorkspaceState.workspaces[newActId - 1]?.id;
-                                    if (targetUuid) KWinWorkspaceState.switchTo(targetUuid);
+                                    if (targetUuid) KWinWorkspaceState.switchTo(targetUuid, root.screenName);
                                 }
                             }
                         }

--- a/shell/modules/overview/Wrapper.qml
+++ b/shell/modules/overview/Wrapper.qml
@@ -32,6 +32,7 @@ Item {
         active: root.shouldBeActive || root.visible
         sourceComponent: Component {
             Content {
+                screen: root.screen
                 visibilities: root.visibilities
                 panels: root.panels
                 animConfig: root.animConfig

--- a/shell/modules/overview/components/workspaces/Workspace.qml
+++ b/shell/modules/overview/components/workspaces/Workspace.qml
@@ -1,6 +1,5 @@
 pragma ComponentBehavior: Bound
 
-import org.kde.pipewire as Pipewire
 import QtQuick
 import QtQuick.Layouts
 import Quickshell
@@ -288,8 +287,6 @@ StyledRect {
                     const w = modelData.width, h = modelData.height;
                     return (w > 0 && h > 0) ? w / h : 16 / 9;
                 }
-                property var streamRequest: null
-                readonly property int serial: streamRequest ? (streamRequest.objectSerial || streamRequest.nodeId) : 0
                 property real dragStartX: 0
                 property real dragStartY: 0
                 property real dragStartWidth: 0
@@ -301,19 +298,6 @@ StyledRect {
                         if (root.closingWindows[i] === modelData.address) return true;
                     }
                     return false;
-                }
-
-                // Deferred: ScreencastManager must not be reached while QML is
-                // still building the caller.
-                function updateStream(): void {
-                    if (iconDelegate.expanded && !iconDelegate.streamRequest && iconDelegate.clientAddress) {
-                        Visibilities.streamClaim = iconDelegate.clientAddress;
-                        iconDelegate.streamRequest = ScreencastManager.requestStream(iconDelegate.clientAddress);
-                    } else if (!iconDelegate.expanded && iconDelegate.streamRequest) {
-                        ScreencastManager.releaseStream(iconDelegate.clientAddress);
-                        iconDelegate.streamRequest = null;
-                        Visibilities.streamClaim = "";
-                    }
                 }
 
                 radius: Tokens.rounding.small
@@ -360,10 +344,12 @@ StyledRect {
                     else if (iconDelegate.expanded && iconDelegate.liftedBy < 100)
                         iconDelegate.expanded = false;
                 }
-                onExpandedChanged: Qt.callLater(iconDelegate.updateStream)
+                // Claimed while open so the card in the grid gives the stream
+                // up; a node feeds one consumer.
+                onExpandedChanged: Visibilities.streamClaim = iconDelegate.expanded ? iconDelegate.clientAddress : ""
                 Component.onDestruction: {
-                    if (iconDelegate.streamRequest && iconDelegate.clientAddress)
-                        ScreencastManager.releaseStream(iconDelegate.clientAddress);
+                    if (iconDelegate.expanded)
+                        Visibilities.streamClaim = "";
                 }
 
                 Behavior on scale { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
@@ -393,23 +379,16 @@ StyledRect {
                         }
                     }
                 }
-                IconImage {
-                    anchors.centerIn: parent
-                    implicitSize: Math.min(parent.width, parent.height) * 0.6
-                    asynchronous: true
-                    source: modelData.iconName ? Icons.getAppIcon(modelData.iconName, "image-missing") : (modelData.class ? Icons.getAppIcon(modelData.class, "image-missing") : "")
-                    visible: iconDelegate.serial === 0
-                }
-                Pipewire.PipeWireSourceItem {
+                WindowPreview {
+                    // Collapsed it is just the icon; lifted out of the strip it
+                    // opens into the window, which is what WindowPreview shows
+                    // once a stream arrives.
+                    active: iconDelegate.expanded
+                    address: iconDelegate.clientAddress
                     anchors.fill: parent
-                    visible: iconDelegate.serial !== 0
-
-                    Component.onCompleted: {
-                        if ("objectSerial" in this)
-                            this.objectSerial = Qt.binding(() => iconDelegate.streamRequest ? iconDelegate.streamRequest.objectSerial : 0);
-                        else if ("nodeId" in this)
-                            this.nodeId = Qt.binding(() => iconDelegate.streamRequest ? iconDelegate.streamRequest.nodeId : 0);
-                    }
+                    fallbackIcon: modelData.iconName ? Icons.getAppIcon(modelData.iconName, "image-missing") : (modelData.class ? Icons.getAppIcon(modelData.class, "image-missing") : "")
+                    fallbackScale: 0.6
+                    sourceAspect: iconDelegate.windowAspect
                 }
                 StateLayer {
                     anchors.fill: parent

--- a/shell/modules/overview/components/workspaces/Workspace.qml
+++ b/shell/modules/overview/components/workspaces/Workspace.qml
@@ -1,5 +1,6 @@
 pragma ComponentBehavior: Bound
 
+import org.kde.pipewire as Pipewire
 import QtQuick
 import QtQuick.Layouts
 import Quickshell
@@ -182,13 +183,31 @@ StyledRect {
 
         // Remembered because onExited carries no drag argument.
         property var hovering: null
+        property var hoveringIcon: null
+
+        function clearHover(): void {
+            if (windowDropArea.hovering) {
+                windowDropArea.hovering.dropTargetScale = 0;
+                windowDropArea.hovering = null;
+            }
+            if (windowDropArea.hoveringIcon) {
+                windowDropArea.hoveringIcon.overThumbnail = false;
+                windowDropArea.hoveringIcon = null;
+            }
+        }
 
         anchors.fill: parent
         onEntered: drag => {
             if (!drag.source || drag.source.clientAddress === undefined)
                 return;
-            // Icons dragged out of another thumbnail are sources too, and they
-            // have no preview to collapse -- only window cards carry this.
+            // An icon dragged out of a thumbnail is a source too. It has no
+            // preview to collapse -- it is already collapsed -- so being over a
+            // slot is simply what keeps it that way.
+            if ("overThumbnail" in drag.source) {
+                windowDropArea.hoveringIcon = drag.source;
+                drag.source.overThumbnail = true;
+                return;
+            }
             if (!("dropTargetScale" in drag.source))
                 return;
             // Nothing to preview when it is already here: a card hovering its
@@ -201,16 +220,9 @@ StyledRect {
             // landing in the slot rather than filling it exactly.
             drag.source.dropTargetScale = Math.min(width / Math.max(1, drag.source.width), height / Math.max(1, drag.source.height)) * 0.85;
         }
-        onExited: {
-            if (windowDropArea.hovering)
-                windowDropArea.hovering.dropTargetScale = 0;
-            windowDropArea.hovering = null;
-        }
+        onExited: windowDropArea.clearHover()
         onDropped: drop => {
-            if (windowDropArea.hovering) {
-                windowDropArea.hovering.dropTargetScale = 0;
-                windowDropArea.hovering = null;
-            }
+            windowDropArea.clearHover();
             const sourceItem = drop.source;
             if (sourceItem && sourceItem.clientAddress) {
                 if (sourceItem.wsId !== root.ws) {
@@ -271,6 +283,18 @@ StyledRect {
                 required property int index
                 readonly property string clientAddress: modelData.address || ""
                 readonly property int wsId: root.ws
+                /// Whether the drag currently rests on a workspace slot. An icon
+                /// pulled up out of the strip is on its way back to being a
+                /// window, so it opens into the live preview it stands for; put
+                /// back down on a slot it collapses again.
+                property bool overThumbnail: true
+                readonly property bool expanded: dragHandler.active && !iconDelegate.overThumbnail
+                readonly property real windowAspect: {
+                    const w = modelData.width, h = modelData.height;
+                    return (w > 0 && h > 0) ? w / h : 16 / 9;
+                }
+                property var streamRequest: null
+                readonly property int serial: streamRequest ? (streamRequest.objectSerial || streamRequest.nodeId) : 0
                 property real dragStartX: 0
                 property real dragStartY: 0
                 property real dragStartWidth: 0
@@ -282,6 +306,19 @@ StyledRect {
                         if (root.closingWindows[i] === modelData.address) return true;
                     }
                     return false;
+                }
+
+                // Deferred: ScreencastManager must not be reached while QML is
+                // still building the caller.
+                function updateStream(): void {
+                    if (iconDelegate.expanded && !iconDelegate.streamRequest && iconDelegate.clientAddress) {
+                        Visibilities.streamClaim = iconDelegate.clientAddress;
+                        iconDelegate.streamRequest = ScreencastManager.requestStream(iconDelegate.clientAddress);
+                    } else if (!iconDelegate.expanded && iconDelegate.streamRequest) {
+                        ScreencastManager.releaseStream(iconDelegate.clientAddress);
+                        iconDelegate.streamRequest = null;
+                        Visibilities.streamClaim = "";
+                    }
                 }
 
                 radius: Tokens.rounding.small
@@ -306,19 +343,30 @@ StyledRect {
                             parent: topLevel
                             x: iconDelegate.dragStartX
                             y: iconDelegate.dragStartY
-                            width: iconDelegate.dragStartWidth
-                            height: iconDelegate.dragStartHeight
                         }
                         PropertyChanges {
                             target: iconDelegate
+                            // Bound rather than set by ParentChange, so growing
+                            // and shrinking follow the drag instead of being
+                            // fixed once when it starts.
+                            height: iconDelegate.expanded ? Math.round(360 / Math.max(0.2, iconDelegate.windowAspect)) : iconDelegate.dragStartHeight
                             opacity: 0.8
+                            width: iconDelegate.expanded ? 360 : iconDelegate.dragStartWidth
                             z: 999
                         }
                     }
                 ]
 
+                onExpandedChanged: Qt.callLater(iconDelegate.updateStream)
+                Component.onDestruction: {
+                    if (iconDelegate.streamRequest && iconDelegate.clientAddress)
+                        ScreencastManager.releaseStream(iconDelegate.clientAddress);
+                }
+
                 Behavior on scale { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
                 Behavior on opacity { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
+                Behavior on width { NumberAnimation { duration: 220; easing.type: Easing.OutCubic } }
+                Behavior on height { NumberAnimation { duration: 220; easing.type: Easing.OutCubic } }
 
 
                 DragHandler {
@@ -347,6 +395,18 @@ StyledRect {
                     implicitSize: Math.min(parent.width, parent.height) * 0.6
                     asynchronous: true
                     source: modelData.iconName ? Icons.getAppIcon(modelData.iconName, "image-missing") : (modelData.class ? Icons.getAppIcon(modelData.class, "image-missing") : "")
+                    visible: iconDelegate.serial === 0
+                }
+                Pipewire.PipeWireSourceItem {
+                    anchors.fill: parent
+                    visible: iconDelegate.serial !== 0
+
+                    Component.onCompleted: {
+                        if ("objectSerial" in this)
+                            this.objectSerial = Qt.binding(() => iconDelegate.streamRequest ? iconDelegate.streamRequest.objectSerial : 0);
+                        else if ("nodeId" in this)
+                            this.nodeId = Qt.binding(() => iconDelegate.streamRequest ? iconDelegate.streamRequest.nodeId : 0);
+                    }
                 }
                 StateLayer {
                     anchors.fill: parent

--- a/shell/modules/overview/components/workspaces/Workspace.qml
+++ b/shell/modules/overview/components/workspaces/Workspace.qml
@@ -187,6 +187,15 @@ StyledRect {
         onEntered: drag => {
             if (!drag.source || drag.source.clientAddress === undefined)
                 return;
+            // Icons dragged out of another thumbnail are sources too, and they
+            // have no preview to collapse -- only window cards carry this.
+            if (!("dropTargetScale" in drag.source))
+                return;
+            // Nothing to preview when it is already here: a card hovering its
+            // own workspace would shrink to say it is about to go somewhere it
+            // already is.
+            if (drag.source.wsId === root.ws)
+                return;
             windowDropArea.hovering = drag.source;
             // Fit inside the thumbnail with a little room, so it reads as
             // landing in the slot rather than filling it exactly.

--- a/shell/modules/overview/components/workspaces/Workspace.qml
+++ b/shell/modules/overview/components/workspaces/Workspace.qml
@@ -183,16 +183,11 @@ StyledRect {
 
         // Remembered because onExited carries no drag argument.
         property var hovering: null
-        property var hoveringIcon: null
 
         function clearHover(): void {
             if (windowDropArea.hovering) {
                 windowDropArea.hovering.dropTargetScale = 0;
                 windowDropArea.hovering = null;
-            }
-            if (windowDropArea.hoveringIcon) {
-                windowDropArea.hoveringIcon.overThumbnail = false;
-                windowDropArea.hoveringIcon = null;
             }
         }
 
@@ -200,14 +195,9 @@ StyledRect {
         onEntered: drag => {
             if (!drag.source || drag.source.clientAddress === undefined)
                 return;
-            // An icon dragged out of a thumbnail is a source too. It has no
-            // preview to collapse -- it is already collapsed -- so being over a
-            // slot is simply what keeps it that way.
-            if ("overThumbnail" in drag.source) {
-                windowDropArea.hoveringIcon = drag.source;
-                drag.source.overThumbnail = true;
-                return;
-            }
+            // An icon dragged out of a thumbnail is a source too, and has no
+            // preview to collapse -- it decides for itself, from how far it has
+            // been lifted.
             if (!("dropTargetScale" in drag.source))
                 return;
             // Nothing to preview when it is already here: a card hovering its
@@ -283,12 +273,17 @@ StyledRect {
                 required property int index
                 readonly property string clientAddress: modelData.address || ""
                 readonly property int wsId: root.ws
-                /// Whether the drag currently rests on a workspace slot. An icon
-                /// pulled up out of the strip is on its way back to being a
-                /// window, so it opens into the live preview it stands for; put
-                /// back down on a slot it collapses again.
-                property bool overThumbnail: true
-                readonly property bool expanded: dragHandler.active && !iconDelegate.overThumbnail
+                /// Whether this icon has been pulled far enough up out of the
+                /// strip to open into the window it stands for.
+                ///
+                /// Measured against where the drag started and switched on two
+                /// thresholds rather than one. Driving it from the slots the drag
+                /// passes over meant it flipped every time one was crossed, and
+                /// each flip tore down and rebuilt the screencast -- the icon
+                /// flickering between itself and the live view. A single
+                /// threshold would do the same to anyone holding near it.
+                property bool expanded: false
+                readonly property real liftedBy: dragHandler.active ? iconDelegate.dragStartY - iconDelegate.y : 0
                 readonly property real windowAspect: {
                     const w = modelData.width, h = modelData.height;
                     return (w > 0 && h > 0) ? w / h : 16 / 9;
@@ -357,6 +352,14 @@ StyledRect {
                     }
                 ]
 
+                onLiftedByChanged: {
+                    if (!dragHandler.active)
+                        iconDelegate.expanded = false;
+                    else if (!iconDelegate.expanded && iconDelegate.liftedBy > 170)
+                        iconDelegate.expanded = true;
+                    else if (iconDelegate.expanded && iconDelegate.liftedBy < 100)
+                        iconDelegate.expanded = false;
+                }
                 onExpandedChanged: Qt.callLater(iconDelegate.updateStream)
                 Component.onDestruction: {
                     if (iconDelegate.streamRequest && iconDelegate.clientAddress)

--- a/shell/modules/overview/components/workspaces/Workspace.qml
+++ b/shell/modules/overview/components/workspaces/Workspace.qml
@@ -16,6 +16,8 @@ StyledRect {
 
     required property int index
     required property int activeWsId
+    /// Screen this overview belongs to; window icons are limited to it.
+    required property string screenName
     required property var occupied
     required property int groupOffset
     readonly property bool isWorkspace: true
@@ -122,7 +124,7 @@ StyledRect {
             } else {
                 if (typeof KWinWorkspaceState !== "undefined") {
                     const wId = KWinWorkspaceState.workspaces[root.ws - 1]?.id || root.ws.toString();
-                    KWinWorkspaceState.switchTo(wId);
+                    KWinWorkspaceState.switchTo(wId, root.screenName);
                 } else {
                     const isKWin = typeof KWinActiveWindowBridge !== "undefined" && KWinActiveWindowBridge.windowList;
                     if (isKWin) {
@@ -176,8 +178,30 @@ StyledRect {
         opacity: 0.3
     }
     DropArea {
+        id: windowDropArea
+
+        // Remembered because onExited carries no drag argument.
+        property var hovering: null
+
         anchors.fill: parent
+        onEntered: drag => {
+            if (!drag.source || drag.source.clientAddress === undefined)
+                return;
+            windowDropArea.hovering = drag.source;
+            // Fit inside the thumbnail with a little room, so it reads as
+            // landing in the slot rather than filling it exactly.
+            drag.source.dropTargetScale = Math.min(width / Math.max(1, drag.source.width), height / Math.max(1, drag.source.height)) * 0.85;
+        }
+        onExited: {
+            if (windowDropArea.hovering)
+                windowDropArea.hovering.dropTargetScale = 0;
+            windowDropArea.hovering = null;
+        }
         onDropped: drop => {
+            if (windowDropArea.hovering) {
+                windowDropArea.hovering.dropTargetScale = 0;
+                windowDropArea.hovering = null;
+            }
             const sourceItem = drop.source;
             if (sourceItem && sourceItem.clientAddress) {
                 if (sourceItem.wsId !== root.ws) {
@@ -213,6 +237,8 @@ StyledRect {
                         const wins = kwinList;
                         for (let i = 0; i < wins.length; ++i) {
                             const w = wins[i];
+                            if (w.output !== root.screenName)
+                                continue;
                             if (w.workspace && (w.workspace.id === wsId || w.workspace.index === wsId) && w["class"] !== "quickshell" && w["class"] !== "plasmashell") {
                                 windows.push(w);
                             }

--- a/shell/modules/windowinfo/Buttons.qml
+++ b/shell/modules/windowinfo/Buttons.qml
@@ -50,7 +50,7 @@ ColumnLayout {
                             KWinWorkspaceState.switchTo(wsId);
                         }
                     }
-                    Visibilities.getForActive().overview = false;
+                    Visibilities.setOverview(false);
                 }
                 color: isCurrent ? Colours.tPalette.m3surfaceContainerHighest : Colours.palette.m3tertiaryContainer
                 onColor: isCurrent ? Colours.palette.m3onSurface : Colours.palette.m3onTertiaryContainer
@@ -78,7 +78,7 @@ ColumnLayout {
                 } else {
                     console.log("KWinActiveWindowBridge is undefined");
                 }
-                Visibilities.getForActive().overview = false;
+                Visibilities.setOverview(false);
             }
         }
         Loader {
@@ -96,7 +96,7 @@ ColumnLayout {
                             KWinActiveWindowBridge.minimizeWindow(root.client?.address);
                         }
                     }
-                    Visibilities.getForActive().overview = false;
+                    Visibilities.setOverview(false);
                 }
             }
             Layout.fillWidth: active
@@ -113,7 +113,7 @@ ColumnLayout {
                     console.log("Calling KWinActiveWindowBridge.closeWindow");
                     KWinActiveWindowBridge.closeWindow(root.client?.address);
                 }
-                Visibilities.getForActive().overview = false;
+                Visibilities.setOverview(false);
             }
         }
         Layout.fillWidth: true
@@ -140,8 +140,8 @@ ColumnLayout {
             onClicked: {
                 parent.clicked()
                 root.closeRequested()
-                const v = typeof Visibilities !== "undefined" ? Visibilities.getForActive() : null;
-                if (v) v.overview = false;
+                if (typeof Visibilities !== "undefined")
+                    Visibilities.setOverview(false);
             }
         }
         StyledText {

--- a/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
+++ b/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
@@ -5,6 +5,7 @@
 #include "kwinworkspacestate.hpp"
 #include <QGuiApplication>
 #include <QScreen>
+#include <QTimer>
 #include <QtDBus/QDBusConnection>
 #include <QtDBus/QDBusMessage>
 
@@ -78,10 +79,73 @@ void KWinActiveWindowBridge::sendToOutput(const QString &address, const QString 
     if (address.isEmpty() || outputName.isEmpty()) {
         return;
     }
-    QDBusMessage msg = QDBusMessage::createMethodCall(
-        "org.kde.KWin", "/Caelestia/Workspaces", "org.caelestia.Workspaces", "SendToOutput");
-    msg << address << outputName;
-    QDBusConnection::sessionBus().call(msg, QDBus::NoBlock);
+
+    QScreen *target = nullptr;
+    for (QScreen *screen : QGuiApplication::screens()) {
+        if (screen->name() == outputName) {
+            target = screen;
+            break;
+        }
+    }
+    if (!target) {
+        return;
+    }
+
+    QVariantMap window;
+    for (const QVariant &entry : m_windowList) {
+        const QVariantMap map = entry.toMap();
+        if (map.value(QStringLiteral("address")).toString() == address) {
+            window = map;
+            break;
+        }
+    }
+    if (window.isEmpty()) {
+        return;
+    }
+
+    const QString currentName = window.value(QStringLiteral("output")).toString();
+    QScreen *current = nullptr;
+    for (QScreen *screen : QGuiApplication::screens()) {
+        if (screen->name() == currentName) {
+            current = screen;
+            break;
+        }
+    }
+    if (!current || current == target) {
+        return;
+    }
+
+    // KWin's own "move the window one screen over" actions, driven through
+    // kglobalaccel.
+    //
+    // There is no direct way to ask for this: plasma-window-management moves a
+    // window between desktops but not between outputs, and no D-Bus interface
+    // exposes it either. These actions do exactly the right thing, they are
+    // part of KWin proper rather than anything this shell has to install, and
+    // they need no privilege. The cost is that they act on the active window,
+    // so the window has to be focused first -- which is what dragging a window
+    // to another monitor implies anyway.
+    const QPoint from = current->geometry().center();
+    const QPoint to = target->geometry().center();
+    QString action;
+    if (qAbs(to.x() - from.x()) >= qAbs(to.y() - from.y())) {
+        action = to.x() > from.x() ? QStringLiteral("Window One Screen to the Right")
+                                   : QStringLiteral("Window One Screen to the Left");
+    } else {
+        action = to.y() > from.y() ? QStringLiteral("Window One Screen Down")
+                                   : QStringLiteral("Window One Screen Up");
+    }
+
+    focusWindow(address);
+
+    // Focus has to have landed before the action fires, or it moves whatever
+    // was focused before.
+    QTimer::singleShot(120, this, [action]() {
+        QDBusMessage msg = QDBusMessage::createMethodCall("org.kde.kglobalaccel", "/component/kwin",
+            "org.kde.kglobalaccel.Component", "invokeShortcut");
+        msg << action;
+        QDBusConnection::sessionBus().call(msg, QDBus::NoBlock);
+    });
 }
 
 QString KWinActiveWindowBridge::getOutputNameForGeometry(int x, int y, int w, int h) const {

--- a/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
+++ b/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
@@ -1,5 +1,7 @@
 #include "kwinactivewindowbridge.hpp"
 #include "plasmawindows.hpp"
+#include <QDBusMessage>
+#include <QDBusConnection>
 #include "kwinworkspacestate.hpp"
 #include <QGuiApplication>
 #include <QScreen>
@@ -70,6 +72,16 @@ void KWinActiveWindowBridge::scheduleWindowListUpdate() {
     if (!m_updateTimer.isActive()) {
         m_updateTimer.start();
     }
+}
+
+void KWinActiveWindowBridge::sendToOutput(const QString &address, const QString &outputName) {
+    if (address.isEmpty() || outputName.isEmpty()) {
+        return;
+    }
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        "org.kde.KWin", "/Caelestia/Workspaces", "org.caelestia.Workspaces", "SendToOutput");
+    msg << address << outputName;
+    QDBusConnection::sessionBus().call(msg, QDBus::NoBlock);
 }
 
 QString KWinActiveWindowBridge::getOutputNameForGeometry(int x, int y, int w, int h) const {

--- a/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.hpp
+++ b/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.hpp
@@ -38,6 +38,14 @@ public:
     Q_INVOKABLE void raiseWindow(const QString &address);
     Q_INVOKABLE void setWindowProperty(const QString &address, const QString &property, bool enable);
     Q_INVOKABLE void setWindowDesktop(const QString &address, int desktopId);
+    /**
+     * Moves a window to another screen.
+     *
+     * Routed through the workspace-tracker effect: plasma-window-management can
+     * move a window between desktops but not between outputs, and there is no
+     * D-Bus surface for it either. Inside the compositor it is one call.
+     */
+    Q_INVOKABLE void sendToOutput(const QString &address, const QString &outputName);
     Q_INVOKABLE void setFullscreen(const QString& address, bool fullscreen);
     Q_INVOKABLE void setMaximized(const QString& address, bool maximized);
 

--- a/shell/plugin/src/Caelestia/Services/kwinworkspacestate.cpp
+++ b/shell/plugin/src/Caelestia/Services/kwinworkspacestate.cpp
@@ -105,16 +105,57 @@ void KWinWorkspaceState::setupTrackerServer() {
             qDebug() << "KWinWorkspaceState: New connection to tracker server";
             QLocalSocket* clientSocket = m_trackerServer->nextPendingConnection();
             connect(clientSocket, &QLocalSocket::readyRead, this, [this, clientSocket]() {
-                while (clientSocket->bytesAvailable() >= 12) { // sizeof(DesktopTransition) = 12
-                    struct DesktopTransition {
-                        int desktop;
-                        float x;
-                        float y;
-                    } payload;
+                // Two record formats. The current one names the output the
+                // report is about; the older one, which a stale effect still
+                // sends, does not -- and a stale effect is normal after an
+                // update, because a rebuilt one only loads once the session
+                // restarts. They are told apart by the magic in the first
+                // field, which the old format used for a small desktop number
+                // and so can never produce.
+                constexpr quint32 kMagic = 0x43414557; // 'CAEW'
+                struct DesktopReport {
+                    quint32 magic;
+                    qint32 desktop;
+                    float x;
+                    float y;
+                    char output[64];
+                };
+                static_assert(sizeof(DesktopReport) == 80, "must match the effect's layout byte for byte");
 
-                    clientSocket->read(reinterpret_cast<char*>(&payload), sizeof(payload));
+                struct LegacyTransition {
+                    int desktop;
+                    float x;
+                    float y;
+                };
 
-                    double newOffset = static_cast<double>(payload.x);
+                while (clientSocket->bytesAvailable() >= static_cast<qint64>(sizeof(LegacyTransition))) {
+                    quint32 magic = 0;
+                    clientSocket->peek(reinterpret_cast<char*>(&magic), sizeof(magic));
+
+                    double newOffset = 0.0;
+
+                    if (magic == kMagic) {
+                        if (clientSocket->bytesAvailable() < static_cast<qint64>(sizeof(DesktopReport))) {
+                            break; // wait for the rest of the record
+                        }
+                        DesktopReport report;
+                        clientSocket->read(reinterpret_cast<char*>(&report), sizeof(report));
+                        report.output[sizeof(report.output) - 1] = '\0';
+
+                        const QString output = QString::fromUtf8(report.output);
+                        if (!output.isEmpty() && report.desktop > 0) {
+                            if (m_activeByOutput.value(output).toInt() != report.desktop) {
+                                m_activeByOutput.insert(output, report.desktop);
+                                emit activeByOutputChanged();
+                            }
+                        }
+                        newOffset = static_cast<double>(report.x);
+                    } else {
+                        LegacyTransition payload;
+                        clientSocket->read(reinterpret_cast<char*>(&payload), sizeof(payload));
+                        newOffset = static_cast<double>(payload.x);
+                    }
+
                     if (m_swipeOffset != newOffset) {
                         m_swipeOffset = newOffset;
                         emit swipeOffsetChanged();
@@ -185,6 +226,10 @@ void KWinWorkspaceState::updateActiveId() {
     emit workspacesChanged();
 }
 
+QVariantMap KWinWorkspaceState::activeByOutput() const {
+    return m_activeByOutput;
+}
+
 int KWinWorkspaceState::activeId() const {
     return m_activeId;
 }
@@ -205,7 +250,7 @@ QVariantList KWinWorkspaceState::workspaces() const {
     return list;
 }
 
-void KWinWorkspaceState::switchTo(const QString& id) {
+void KWinWorkspaceState::switchTo(const QString& id, const QString& output) {
     QString targetUuid;
     for (const auto& d : m_desktops) {
         if (d.id == id || QString::number(d.position + 1) == id || d.name == id) {
@@ -215,6 +260,15 @@ void KWinWorkspaceState::switchTo(const QString& id) {
     }
 
     if (!targetUuid.isEmpty()) {
+        if (!output.isEmpty()) {
+            // Effect route: names the screen, so the other one stays put.
+            QDBusMessage msg = QDBusMessage::createMethodCall(
+                "org.kde.KWin", "/Caelestia/Workspaces", "org.caelestia.Workspaces", "SetDesktop");
+            msg << output << indexForId(targetUuid);
+            QDBusConnection::sessionBus().call(msg, QDBus::NoBlock);
+            return;
+        }
+
         QDBusMessage msg = QDBusMessage::createMethodCall("org.kde.KWin", "/VirtualDesktopManager", "org.freedesktop.DBus.Properties", "Set");
         msg << "org.kde.KWin.VirtualDesktopManager" << "current" << QVariant::fromValue(QDBusVariant(targetUuid));
         QDBusConnection::sessionBus().call(msg, QDBus::NoBlock);

--- a/shell/plugin/src/Caelestia/Services/kwinworkspacestate.cpp
+++ b/shell/plugin/src/Caelestia/Services/kwinworkspacestate.cpp
@@ -260,13 +260,36 @@ void KWinWorkspaceState::switchTo(const QString& id, const QString& output) {
     }
 
     if (!targetUuid.isEmpty()) {
+        // Naming the screen needs the workspace-tracker effect, which can target
+        // an output directly; D-Bus can only set the desktop of whichever output
+        // is active. The effect is installed system-wide and a rebuilt one does
+        // not load until the session restarts, so a shell update routinely runs
+        // against a version without this method -- and a fire-and-forget call to
+        // a method that is not there fails silently, which would leave switching
+        // workspaces doing nothing at all. Probed once, then remembered.
         if (!output.isEmpty()) {
-            // Effect route: names the screen, so the other one stays put.
-            QDBusMessage msg = QDBusMessage::createMethodCall(
-                "org.kde.KWin", "/Caelestia/Workspaces", "org.caelestia.Workspaces", "SetDesktop");
-            msg << output << indexForId(targetUuid);
-            QDBusConnection::sessionBus().call(msg, QDBus::NoBlock);
-            return;
+            if (m_perOutputSwitchAvailable == -1) {
+                QDBusMessage probe = QDBusMessage::createMethodCall("org.kde.KWin",
+                    "/Caelestia/Workspaces", "org.freedesktop.DBus.Introspectable", "Introspect");
+                const QDBusMessage reply = QDBusConnection::sessionBus().call(probe, QDBus::Block, 1000);
+                m_perOutputSwitchAvailable = (reply.type() == QDBusMessage::ReplyMessage
+                                                 && reply.arguments().value(0).toString().contains(
+                                                     QStringLiteral("SetDesktop")))
+                    ? 1
+                    : 0;
+                if (!m_perOutputSwitchAvailable) {
+                    qWarning() << "KWinWorkspaceState: workspace-tracker effect has no SetDesktop; "
+                                  "falling back to switching the active output's desktop";
+                }
+            }
+
+            if (m_perOutputSwitchAvailable == 1) {
+                QDBusMessage msg = QDBusMessage::createMethodCall(
+                    "org.kde.KWin", "/Caelestia/Workspaces", "org.caelestia.Workspaces", "SetDesktop");
+                msg << output << indexForId(targetUuid);
+                QDBusConnection::sessionBus().call(msg, QDBus::NoBlock);
+                return;
+            }
         }
 
         QDBusMessage msg = QDBusMessage::createMethodCall("org.kde.KWin", "/VirtualDesktopManager", "org.freedesktop.DBus.Properties", "Set");

--- a/shell/plugin/src/Caelestia/Services/kwinworkspacestate.hpp
+++ b/shell/plugin/src/Caelestia/Services/kwinworkspacestate.hpp
@@ -23,6 +23,19 @@ class KWinWorkspaceState : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(int activeId READ activeId NOTIFY activeIdChanged)
+    /**
+     * Current desktop per output name, e.g. { "DP-1": 1, "HDMI-A-2": 3 }.
+     *
+     * KWin's PerOutputVirtualDesktops gives every screen its own current
+     * desktop, but D-Bus still exposes a single VirtualDesktopManager.current,
+     * which follows the active output. A per-screen widget reading that shows
+     * the focused screen's desktop on every screen, and appears to switch on
+     * all of them when the pointer moves. This comes from the workspace-tracker
+     * effect instead, which is inside KWin and can ask per output.
+     *
+     * Empty until the effect connects; fall back to activeId in that case.
+     */
+    Q_PROPERTY(QVariantMap activeByOutput READ activeByOutput NOTIFY activeByOutputChanged)
     Q_PROPERTY(QVariantList workspaces READ workspaces NOTIFY workspacesChanged)
     Q_PROPERTY(uint rows READ rows NOTIFY rowsChanged)
     Q_PROPERTY(double swipeOffset READ swipeOffset NOTIFY swipeOffsetChanged)
@@ -38,11 +51,21 @@ public:
     ~KWinWorkspaceState() override;
 
     int activeId() const;
+    QVariantMap activeByOutput() const;
     QVariantList workspaces() const;
     uint rows() const;
     double swipeOffset() const;
 
-    Q_INVOKABLE void switchTo(const QString& id);
+    /**
+     * Switches to desktop @p id. With @p output named, only that screen moves.
+     *
+     * KWin's D-Bus setter always applies to whichever output is active, which
+     * is wrong the moment two screens each have their own desktop and both can
+     * ask: a request from one monitor's overview lands on whatever the pointer
+     * is over. Naming the output routes it through the workspace-tracker
+     * effect, which is inside the compositor and can target it directly.
+     */
+    Q_INVOKABLE void switchTo(const QString& id, const QString& output = QString());
     Q_INVOKABLE void createWorkspace(const QString& name = QString());
     Q_INVOKABLE void removeWorkspace(const QString& id);
 
@@ -52,6 +75,7 @@ public:
 
 signals:
     void activeIdChanged();
+    void activeByOutputChanged();
     void workspacesChanged();
     void rowsChanged();
     void swipeOffsetChanged();
@@ -72,6 +96,7 @@ private:
     QList<KWinDesktopData> m_desktops;
     QString m_currentUuid;
     int m_activeId = 0;
+    QVariantMap m_activeByOutput;
     uint m_rows = 1;
     double m_swipeOffset = 0.0;
     ::QLocalServer* m_trackerServer = nullptr;

--- a/shell/plugin/src/Caelestia/Services/kwinworkspacestate.hpp
+++ b/shell/plugin/src/Caelestia/Services/kwinworkspacestate.hpp
@@ -97,6 +97,8 @@ private:
     QString m_currentUuid;
     int m_activeId = 0;
     QVariantMap m_activeByOutput;
+    // -1 unknown, 0 absent, 1 present. See switchTo().
+    int m_perOutputSwitchAvailable = -1;
     uint m_rows = 1;
     double m_swipeOffset = 0.0;
     ::QLocalServer* m_trackerServer = nullptr;

--- a/shell/services/Visibilities.qml
+++ b/shell/services/Visibilities.qml
@@ -25,6 +25,8 @@ Singleton {
     property string dragOriginScreen: ""
     property real dragX: 0
     property real dragY: 0
+    property real dragWidth: 0
+    property real dragHeight: 0
     /// Address of a window whose screencast is claimed by something other than
     /// its card in the grid -- the preview shown on the screen a drag has been
     /// carried to, or an icon pulled up out of the strip.
@@ -61,10 +63,12 @@ Singleton {
         const monitor = Hypr.monitors[KWinActiveWindowBridge.cursorOutputName()] || Hypr.focusedMonitor;
         return screens.get(monitor) || screens.values().next().value;
     }
-    function setDrag(address: string, x: real, y: real, originScreen: string): void {
+    function setDrag(address: string, x: real, y: real, w: real, h: real, originScreen: string): void {
         dragAddress = address;
         dragX = x;
         dragY = y;
+        dragWidth = w;
+        dragHeight = h;
         dragOriginScreen = originScreen;
     }
     function clearDrag(): void {

--- a/shell/services/Visibilities.qml
+++ b/shell/services/Visibilities.qml
@@ -25,6 +25,16 @@ Singleton {
     property string dragOriginScreen: ""
     property real dragX: 0
     property real dragY: 0
+    /// Address of a window whose screencast is claimed by something other than
+    /// its card in the grid -- the preview shown on the screen a drag has been
+    /// carried to, or an icon pulled up out of the strip.
+    ///
+    /// KWin serves one node per window and a node feeds one consumer: a second
+    /// PipeWireSourceItem bound to the same stream draws black, which is what
+    /// both of those did. The card gives it up while the claim stands, and takes
+    /// it back afterwards. It is off screen or covered at that point, so there
+    /// is nothing to lose.
+    property string streamClaim: ""
 
     // Raised when the overview shortcut is pressed while the overview is
     // already up: the grid moves its selection on instead of the drawer

--- a/shell/services/Visibilities.qml
+++ b/shell/services/Visibilities.qml
@@ -12,6 +12,19 @@ Singleton {
     property string initialSidebarTab: "notifications"
     property bool isCaelestiaMode: false
     property string preOverviewActiveWindowAddress: ""
+    // A window card being dragged, shared so every screen's overview knows about
+    // it.
+    //
+    // Each overview is its own window and can only draw on its own screen, so a
+    // card dragged towards the next monitor simply vanishes at the edge -- the
+    // drag is still running and still lands correctly, but there is nothing to
+    // see, and it reads as having dropped the window into nowhere. Publishing
+    // the position here lets the screen the pointer has reached draw what is
+    // arriving.
+    property string dragAddress: ""
+    property string dragOriginScreen: ""
+    property real dragX: 0
+    property real dragY: 0
 
     // Raised when the overview shortcut is pressed while the overview is
     // already up: the grid moves its selection on instead of the drawer
@@ -37,6 +50,16 @@ Singleton {
     function getForActive(): DrawerVisibilities {
         const monitor = Hypr.monitors[KWinActiveWindowBridge.cursorOutputName()] || Hypr.focusedMonitor;
         return screens.get(monitor) || screens.values().next().value;
+    }
+    function setDrag(address: string, x: real, y: real, originScreen: string): void {
+        dragAddress = address;
+        dragX = x;
+        dragY = y;
+        dragOriginScreen = originScreen;
+    }
+    function clearDrag(): void {
+        dragAddress = "";
+        dragOriginScreen = "";
     }
     /**
      * Opens or closes the overview on every screen at once.

--- a/shell/services/Visibilities.qml
+++ b/shell/services/Visibilities.qml
@@ -38,4 +38,18 @@ Singleton {
         const monitor = Hypr.monitors[KWinActiveWindowBridge.cursorOutputName()] || Hypr.focusedMonitor;
         return screens.get(monitor) || screens.values().next().value;
     }
+    /**
+     * Opens or closes the overview on every screen at once.
+     *
+     * Unlike the other drawers, the overview is a place you drag things across:
+     * a window can be moved to another monitor, or to a desktop that only exists
+     * on that monitor, and neither is possible if the destination is still
+     * showing the desktop underneath. Opening it on the focused screen alone
+     * also reads as broken on a multi-monitor setup -- one screen goes to the
+     * overview and the other carries on as if nothing happened.
+     */
+    function setOverview(visible: bool): void {
+        for (const visibilities of screens.values())
+            visibilities.overview = visible;
+    }
 }


### PR DESCRIPTION
KWin gives each output its own current desktop when `PerOutputVirtualDesktops` is on, but the shell read the one D-Bus exposes — a single global value that follows whichever screen is focused. Every bar and every overview therefore showed the focused screen's desktop, and appeared to switch on all of them when the pointer crossed to another monitor.

## Per screen

Scoped to the screen it belongs to: the desktop a bar and an overview open on, the windows in the grid, the window icons in the bottom strip, and which desktops that strip counts as occupied. The window data already carried an `output` field, so most of this is a filter rather than new plumbing.

The desktop a screen is on can only be read per output from inside the compositor, so the workspace-tracker effect reports it and `KWinWorkspaceState` exposes `activeByOutput`. Switching goes the same way — D-Bus can only set the active output's desktop, which is wrong once two screens each have one and both can ask. The effect gained `SetDesktop(output, desktop)` for that.

**Version skew is handled.** A rebuilt effect does not load until the session restarts, so a shell update routinely runs against an older one. Switching probes for `SetDesktop` once and falls back to the global setter if it is missing, and the socket format carries a magic so the old 12-byte record is still understood. Without either, a shell update would silently stop workspace switching until the next login.

## The overview opens everywhere

It is a place things get dragged across: a window can be moved to another monitor, or to a desktop that only exists there, and neither works if the destination still shows the desktop underneath. `Visibilities.setOverview()` drives every screen, and all the open and close paths go through it.

That exposed a conflict worth naming: each screen's overview switches desktops as its page changes, and through the global setter one screen's page sync moved whichever monitor the pointer happened to be over. Measured — with the screens on desktops 2 and 1, opening the overview dragged the second one to 2 as well.

## Dragging

- **To another monitor.** The edge areas paged workspaces the instant a drag touched them, which on a side with a neighbouring screen swallowed exactly the gesture meaning "put this over there". They now wait for the drag to rest: pass through and you reach the next monitor, stop and you page, and holding keeps paging. Moving a window between screens has no unprivileged path — plasma-window-management does desktops, not outputs — so the effect gained `SendToOutput` too.
- **The drag does not vanish at the edge.** The card belongs to the overview it started in and is clipped there, so the second half of the gesture used to happen against nothing. The position is published and the screen the pointer reaches draws the same live preview, at the size the card had.
- **Onto a workspace thumbnail** a card collapses into the application's icon and expands back when pulled away, GNOME-style. Not over the workspace it is already on, where the shrink would be announcing a move to where it already is.
- **Out of the strip** an icon opens into the window it stands for. Driven by how far it has been lifted, on two thresholds — following the slots the drag passed over made it flip at every boundary, and each flip tore down and rebuilt the screencast.

One stream claim underpins the last two: a node feeds one consumer, so a preview outside the grid says it wants the stream and the card that holds it lets go, otherwise the new one just draws black.

## Verified

By driving a real pointer through `/dev/uinput` rather than by inspection — each of these was watched on screen or measured:

- desktops diverge per output (`{DP-1:2, HDMI-A-2:1}`) where the global value reports one
- a window dropped on the second monitor arrives there (`out=DP-1` → `out=HDMI-A-2`), and passing through the edge no longer changes the workspace
- holding at an edge advances one workspace, then another, and stops when released
- an icon dragged from the first thumbnail to the third moves that window to desktop 3
- a card reads as a full preview over its own workspace and as a bare icon, with no buttons on it, over another
- an icon held between the two thresholds is pixel-identical a second and a half apart

## Note on the base

Written before #510 and rebased onto it. The last commit ports the two preview sites this branch added onto `WindowPreview` rather than leaving the older inline plumbing behind — worth a look, since that is the part a rebase could have carried through quietly.
