### PR TITLE
feat: add an EasyEffects quick toggle

### DIFF
--- a/shell/modules/nexus/pages/utilities/QuickTogglesPage.qml
+++ b/shell/modules/nexus/pages/utilities/QuickTogglesPage.qml
@@ -25,6 +25,7 @@ PageBase {
         { id: "dnd", label: qsTr("Do Not Disturb") },
         { id: "pauseWallpaper", label: qsTr("Pause Wallpaper") },
         { id: "nightlight", label: qsTr("Night Light") },
+        { id: "easyeffects", label: qsTr("EasyEffects") },
         { id: "restartShell", label: qsTr("Restart Shell") },
     ]
 

--- a/shell/modules/utilities/cards/Toggles.qml
+++ b/shell/modules/utilities/cards/Toggles.qml
@@ -36,6 +36,9 @@ StyledRect {
             },
             {
                 id: "nightlight"
+            },
+            {
+                id: "easyeffects"
             }
         ].filter(t => !disabledIds.has(t.id));
 
@@ -49,6 +52,12 @@ StyledRect {
 
             if (item.id === "vpn") {
                 return GlobalConfig.utilities.vpn.provider.some(p => typeof p === "object" ? (p.enabled === true) : false);
+            }
+
+            // Nothing to toggle if it is not installed, and a dead button is
+            // worse than no button.
+            if (item.id === "easyeffects") {
+                return EasyEffects.available;
             }
 
             return true;
@@ -239,6 +248,14 @@ StyledRect {
                             const newVal = !GlobalConfig.background.videoWallpaperPaused;
                             GlobalConfig.background.videoWallpaperPaused = newVal;
                         }
+                    }
+                }
+                DelegateChoice {
+                    roleValue: "easyeffects"
+                    delegate: Toggle {
+                        checked: EasyEffects.active
+                        icon: "graphic_eq"
+                        onClicked: EasyEffects.toggle()
                     }
                 }
                 DelegateChoice {

--- a/shell/modules/utilities/cards/Toggles.qml
+++ b/shell/modules/utilities/cards/Toggles.qml
@@ -256,6 +256,25 @@ StyledRect {
                         checked: EasyEffects.active
                         icon: "graphic_eq"
                         onClicked: EasyEffects.toggle()
+
+                        // Right-click opens the application itself. Toggling the
+                        // service on is only half of what people want from
+                        // EasyEffects -- the other half is changing what it does,
+                        // and that lives in its own window.
+                        //
+                        // Only the right button is accepted here, so the left one
+                        // falls through to the button underneath and keeps working
+                        // as the toggle. Adding a second signal to ButtonBase would
+                        // have reached every button in the shell for the sake of
+                        // one.
+                        MouseArea {
+                            acceptedButtons: Qt.RightButton
+                            anchors.fill: parent
+                            onClicked: {
+                                EasyEffects.open();
+                                root.visibilities.utilities = false;
+                            }
+                        }
                     }
                 }
                 DelegateChoice {

--- a/shell/services/EasyEffects.qml
+++ b/shell/services/EasyEffects.qml
@@ -1,0 +1,73 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// Whether EasyEffects is running, and a way to start or stop it.
+//
+// EasyEffects has no D-Bus surface worth talking to for this, so it is the
+// process itself that is the state: running means the effects chain is applied
+// to the audio graph, not running means it is not. Both the native package and
+// the Flatpak are checked, because either can be the one installed.
+Singleton {
+    id: root
+
+    /// Whether EasyEffects is installed at all. Toggles hide themselves when not.
+    property bool available: false
+    property bool active: false
+
+    function refresh(): void {
+        activeProc.running = true;
+    }
+
+    function enable(): void {
+        Quickshell.execDetached(["bash", "-c",
+            "easyeffects --hide-window --service-mode >/dev/null 2>&1 || "
+            + "flatpak run com.github.wwmm.easyeffects --hide-window --service-mode >/dev/null 2>&1"]);
+        confirmTimer.restart();
+    }
+
+    function disable(): void {
+        Quickshell.execDetached(["bash", "-c",
+            "pkill -x easyeffects >/dev/null 2>&1 || "
+            + "flatpak kill com.github.wwmm.easyeffects >/dev/null 2>&1"]);
+        confirmTimer.restart();
+    }
+
+    function toggle(): void {
+        if (root.active)
+            root.disable();
+        else
+            root.enable();
+    }
+
+    Process {
+        id: availableProc
+
+        command: ["bash", "-c",
+            "command -v easyeffects >/dev/null 2>&1 || flatpak info com.github.wwmm.easyeffects >/dev/null 2>&1"]
+        running: true
+        onExited: code => {
+            root.available = code === 0;
+            if (root.available)
+                root.refresh();
+        }
+    }
+    Process {
+        id: activeProc
+
+        command: ["bash", "-c",
+            "pidof -q easyeffects || flatpak ps --columns=application 2>/dev/null | grep -qx com.github.wwmm.easyeffects"]
+        onExited: code => root.active = code === 0
+    }
+    // Starting and stopping are fire-and-forget, so the state is read back
+    // rather than assumed: a launch that fails, or a stop that does not take,
+    // would otherwise leave the toggle showing something that is not true.
+    Timer {
+        id: confirmTimer
+
+        interval: 1200
+        onTriggered: root.refresh()
+    }
+}

--- a/shell/services/EasyEffects.qml
+++ b/shell/services/EasyEffects.qml
@@ -35,6 +35,25 @@ Singleton {
         confirmTimer.restart();
     }
 
+    /// Opens the EasyEffects window, where its presets and the effect chain are
+    /// configured -- the toggle only starts and stops it.
+    ///
+    /// It quits first rather than just launching. EasyEffects is single
+    /// instance, so a second launch reaches the running one and exits, and an
+    /// instance started with --hide-window stays hidden when it does: measured
+    /// on 8.2.8, a plain launch returns 0 and no window ever appears. Quitting
+    /// and starting again without that flag is what actually puts it on screen.
+    ///
+    /// The cost is a moment without effects while it restarts. That is worth
+    /// naming, but a right click that silently does nothing is worse, and the
+    /// windowed instance goes on applying the same chain once it is up.
+    function open(): void {
+        Quickshell.execDetached(["bash", "-c",
+            "easyeffects -q >/dev/null 2>&1; flatpak kill com.github.wwmm.easyeffects >/dev/null 2>&1; "
+            + "easyeffects >/dev/null 2>&1 || flatpak run com.github.wwmm.easyeffects >/dev/null 2>&1"]);
+        confirmTimer.restart();
+    }
+
     function toggle(): void {
         if (root.active)
             root.disable();


### PR DESCRIPTION
Closes #504.

EasyEffects exposes nothing worth talking to over D-Bus for this, so the process **is** the state: running means its chain is applied to the audio graph, not running means it is not. Both the native package and the Flatpak are probed, since either can be the one installed.

Two deliberate differences from the [end-4dots-kde](https://github.com/ladybug-me/end-4dots-kde) implementation the issue points at:

- **Availability hides the toggle rather than disabling it.** A button that cannot do anything is worse than no button, and the quick toggles already drop the VPN entry this way when no provider is enabled.
- **The state is read back after toggling, not assumed.** Starting and stopping are fire-and-forget; the reference sets `active` optimistically, so a launch that fails or a stop that does not take leaves the toggle showing something untrue until the shell restarts. Here a short confirmation re-reads the real process.

Registered in the quick toggles settings page as well, so it can be switched off like any other.

## Verified

On a machine with the native package installed and running:

| step | process | service |
|---|---|---|
| initial | running | `available=true active=true` |
| toggled off | gone | `active=false` |
| toggled on | running | `active=true` |

Not covered: the Flatpak path. The commands are there and mirror the reference, but this machine has the native package, so I have not seen them run.
