### PR TITLE
fix: derive the notification avoidance corner from one place

### DIFF
--- a/shell/modules/drawers/Panels.qml
+++ b/shell/modules/drawers/Panels.qml
@@ -227,8 +227,13 @@ Item {
             const len = Notifs.popupCount;
             // Only act on 0 → 1 transition (fresh batch arrival)
             if (len > 0 && root._prevPopupCount === 0 && GlobalConfig.notifs.position === "auto") {
-                const defV = Config.bar.position === "bottom" ? "bottom" : "top";
-                const defH = Config.bar.position === "left" ? "left" : "right";
+                // Taken from notifAutoPosition rather than worked out again:
+                // the second copy had drifted (it flipped on "left" where the
+                // first flips on "right"), so with a side bar the avoidance
+                // watched the corner opposite the one notifications were in.
+                const defParts = root.notifAutoPosition.split("-");
+                const defV = defParts[0];
+                const defH = defParts[1];
                 const notifW = Tokens.sizes.notifs.width;
                 const notifH = Math.min(root.height / 2, 600);
                 // Corner bounds in Panels-relative coordinates


### PR DESCRIPTION
Split out of #511 at review request — this is the self-contained half.

The corner the notification auto-avoidance watches was worked out a second time inside the `popupCount` handler, and the two copies had drifted apart:

```qml
// notifAutoPosition
const h = barPos === "right" ? "left" : "right";
// the flip trigger
const defH = Config.bar.position === "left" ? "left" : "right";
```

For a left- or right-positioned bar these disagree. The avoidance then watched the corner *opposite* the one notifications actually appear in: it flipped away when the cursor was nowhere near them, and stayed put when the cursor was sitting on top of them — exactly backwards.

Now derived from `notifAutoPosition`, so there is one definition instead of two.

Top and bottom bars were unaffected, which is why this went unnoticed.
