### PR TITLE
feat: per-monitor workspaces

### DIFF
--- a/shell/kwin-effects/workspace-tracker/workspace_tracker.cpp
+++ b/shell/kwin-effects/workspace-tracker/workspace_tracker.cpp
@@ -3,7 +3,12 @@
 #include <KPluginFactory>
 #include <QStandardPaths>
 #include <QDir>
+#include <QDBusConnection>
+#include <QDBusError>
+#include <effect/effectwindow.h>
 #include <QDebug>
+#include <core/output.h>
+#include <cstring>
 #include <QStandardPaths>
 #include <QDir>
 
@@ -31,9 +36,49 @@ WorkspaceTrackerEffect::WorkspaceTrackerEffect()
 
     connect(m_socket, &QLocalSocket::connected, this, [this]() {
         qDebug() << "WorkspaceTracker: Socket connected!";
+        sendFullState();
     });
 
     connectSocket();
+
+    // Registered on the service KWin already owns; any session client may call
+    // it, and nothing extra has to be granted.
+    if (!QDBusConnection::sessionBus().registerObject(
+            QStringLiteral("/Caelestia/Workspaces"), this, QDBusConnection::ExportAllSlots)) {
+        qWarning() << "WorkspaceTracker: could not register /Caelestia/Workspaces:"
+                   << QDBusConnection::sessionBus().lastError().message();
+    }
+}
+
+KWin::LogicalOutput* WorkspaceTrackerEffect::findOutput(const QString& name)
+{
+    const auto outputs = KWin::effects->screens();
+    for (KWin::LogicalOutput* candidate : outputs) {
+        if (candidate && candidate->name() == name) {
+            return candidate;
+        }
+    }
+    return nullptr;
+}
+
+void WorkspaceTrackerEffect::SetDesktop(const QString& output, int desktop)
+{
+    if (desktop < 1) {
+        return;
+    }
+
+    KWin::LogicalOutput* target = findOutput(output);
+    if (!target) {
+        return;
+    }
+
+    const auto desktops = KWin::effects->desktops();
+    for (KWin::VirtualDesktop* candidate : desktops) {
+        if (candidate && static_cast<int>(candidate->x11DesktopNumber()) == desktop) {
+            KWin::effects->setCurrentDesktop(candidate, target);
+            return;
+        }
+    }
 }
 
 WorkspaceTrackerEffect::~WorkspaceTrackerEffect()
@@ -52,33 +97,59 @@ void WorkspaceTrackerEffect::connectSocket()
     }
 }
 
-void WorkspaceTrackerEffect::sendPayload(int desktop, float x, float y)
+void WorkspaceTrackerEffect::sendPayload(int desktop, float x, float y, KWin::LogicalOutput* output)
 {
-    if (m_socket->state() == QLocalSocket::ConnectedState) {
-        DesktopTransition payload{desktop, x, y};
-        m_socket->write(reinterpret_cast<const char*>(&payload), sizeof(payload));
+    if (m_socket->state() != QLocalSocket::ConnectedState) {
+        return;
+    }
+
+    DesktopReport payload;
+    payload.desktop = desktop;
+    payload.x = x;
+    payload.y = y;
+
+    // An unnamed output means "whichever screen is active", which is what the
+    // signals report when per-output desktops are switched off. The shell
+    // applies those to every screen.
+    const QByteArray name = output ? output->name().toUtf8() : QByteArray();
+    const int copied = qMin(name.size(), static_cast<qsizetype>(sizeof(payload.output) - 1));
+    std::memcpy(payload.output, name.constData(), copied);
+    payload.output[copied] = '\0';
+
+    m_socket->write(reinterpret_cast<const char*>(&payload), sizeof(payload));
+}
+
+void WorkspaceTrackerEffect::sendFullState()
+{
+    const auto outputs = KWin::effects->screens();
+    for (KWin::LogicalOutput* output : outputs) {
+        if (KWin::VirtualDesktop* desktop = KWin::effects->currentDesktop(output)) {
+            sendPayload(static_cast<int>(desktop->x11DesktopNumber()), 0.0f, 0.0f, output);
+        }
     }
 }
 
-void WorkspaceTrackerEffect::onDesktopChanging(KWin::VirtualDesktop* desktop, QPointF offset)
+void WorkspaceTrackerEffect::onDesktopChanging(
+    KWin::VirtualDesktop* desktop, QPointF offset, KWin::EffectWindow* with, KWin::LogicalOutput* output)
 {
+    Q_UNUSED(with)
     if (desktop && m_socket->state() == QLocalSocket::ConnectedState) {
-        qDebug() << "WorkspaceTracker: sending offset" << offset << "for desktop" << desktop->x11DesktopNumber();
-        sendPayload(desktop->x11DesktopNumber(), static_cast<float>(offset.x()), static_cast<float>(offset.y()));
-    } else {
-        qDebug() << "WorkspaceTracker: not connected or desktop is null. Socket state:" << m_socket->state();
+        sendPayload(desktop->x11DesktopNumber(), static_cast<float>(offset.x()), static_cast<float>(offset.y()), output);
     }
 }
 
 void WorkspaceTrackerEffect::onDesktopChangingCancelled()
 {
-    sendPayload(0, 0.0f, 0.0f);
+    sendPayload(0, 0.0f, 0.0f, nullptr);
 }
 
-void WorkspaceTrackerEffect::onDesktopChanged(KWin::VirtualDesktop* oldDesktop, KWin::VirtualDesktop* newDesktop)
+void WorkspaceTrackerEffect::onDesktopChanged(
+    KWin::VirtualDesktop* oldDesktop, KWin::VirtualDesktop* newDesktop, KWin::EffectWindow* with, KWin::LogicalOutput* output)
 {
+    Q_UNUSED(oldDesktop)
+    Q_UNUSED(with)
     if (newDesktop && m_socket->state() == QLocalSocket::ConnectedState) {
-        sendPayload(newDesktop->x11DesktopNumber(), 0.0f, 0.0f);
+        sendPayload(newDesktop->x11DesktopNumber(), 0.0f, 0.0f, output);
     }
 }
 

--- a/shell/kwin-effects/workspace-tracker/workspace_tracker.hpp
+++ b/shell/kwin-effects/workspace-tracker/workspace_tracker.hpp
@@ -10,27 +10,60 @@
 
 namespace caelestia {
 
-struct DesktopTransition {
-    int desktop;
-    float x;
-    float y;
+// Reported to the shell over the local socket.
+//
+// The original record was three fields and said nothing about which screen it
+// described, which was fine while KWin had one current desktop for the whole
+// session. With PerOutputVirtualDesktops each screen has its own, so a report
+// that omits the output is not just incomplete -- it is wrong on every screen
+// but the one it came from.
+//
+// magic exists so the shell can tell this apart from the old 12-byte record: a
+// stale effect can outlive a shell update, because a rebuilt effect does not
+// load until the session restarts. The first field of the old record was a
+// small desktop number, so it can never collide.
+struct DesktopReport {
+    static constexpr quint32 kMagic = 0x43414557; // 'CAEW'
+
+    quint32 magic = kMagic;
+    qint32 desktop = 0;
+    float x = 0.0f;
+    float y = 0.0f;
+    char output[64] = {};
 };
 
 class WorkspaceTrackerEffect : public KWin::Effect
 {
     Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.caelestia.Workspaces")
 public:
     WorkspaceTrackerEffect();
     ~WorkspaceTrackerEffect() override;
 
+public Q_SLOTS:
+    /**
+     * Switches @p output to virtual desktop @p desktop, counting from 1.
+     *
+     * KWin's D-Bus only exposes VirtualDesktopManager.current, and setting it
+     * always applies to whichever output is active. That is unusable once each
+     * screen has its own desktop and more than one thing wants to switch: a
+     * request meant for one monitor lands on whichever the pointer happens to
+     * be over. Inside the compositor the output can simply be named.
+     */
+    void SetDesktop(const QString& output, int desktop);
+
 private Q_SLOTS:
-    void onDesktopChanging(KWin::VirtualDesktop* desktop, QPointF offset);
+    void onDesktopChanging(KWin::VirtualDesktop* desktop, QPointF offset, KWin::EffectWindow* with, KWin::LogicalOutput* output);
     void onDesktopChangingCancelled();
-    void onDesktopChanged(KWin::VirtualDesktop* oldDesktop, KWin::VirtualDesktop* newDesktop);
+    void onDesktopChanged(KWin::VirtualDesktop* oldDesktop, KWin::VirtualDesktop* newDesktop, KWin::EffectWindow* with, KWin::LogicalOutput* output);
     void connectSocket();
 
 private:
-    void sendPayload(int desktop, float x, float y);
+    void sendPayload(int desktop, float x, float y, KWin::LogicalOutput* output);
+    /// Reports every output's current desktop, so a shell that just connected
+    /// starts from the truth instead of waiting for someone to switch.
+    void sendFullState();
+    static KWin::LogicalOutput* findOutput(const QString& name);
 
     QLocalSocket* m_socket;
 };

--- a/shell/modules/Shortcuts.qml
+++ b/shell/modules/Shortcuts.qml
@@ -56,14 +56,14 @@ Scope {
         onPressed: {
             const visibilities = Visibilities.getForActive();
             if (visibilities.overview) {
-                visibilities.overview = false;
+                Visibilities.setOverview(false);
             } else {
                 if (typeof KWinActiveWindowBridge !== "undefined" && KWinActiveWindowBridge.activeWindow && KWinActiveWindowBridge.activeWindow.address) {
                     Visibilities.preOverviewActiveWindowAddress = KWinActiveWindowBridge.activeWindow.address;
                 } else {
                     Visibilities.preOverviewActiveWindowAddress = "";
                 }
-                visibilities.overview = true;
+                Visibilities.setOverview(true);
             }
         }
     }
@@ -378,7 +378,11 @@ Scope {
                 if (root.hasFullscreen && ["launcher", "session", "dashboard"].includes(drawer))
                     return;
                 const visibilities = Visibilities.getForActive();
-                visibilities[drawer] = !visibilities[drawer];
+                // The overview spans every screen; see Visibilities.setOverview.
+                if (drawer === "overview")
+                    Visibilities.setOverview(!visibilities.overview);
+                else
+                    visibilities[drawer] = !visibilities[drawer];
             } else {
                 console.warn(lc, `Drawer "${drawer}" does not exist`);
             }
@@ -394,7 +398,10 @@ Scope {
                     return;
                 }
                 const visibilities = Visibilities.getForActive();
-                visibilities[drawer] = !visibilities[drawer];
+                if (drawer === "overview")
+                    Visibilities.setOverview(!visibilities.overview);
+                else
+                    visibilities[drawer] = !visibilities[drawer];
             } else {
                 console.warn(lc, `Drawer "${drawer}" does not exist`);
             }

--- a/shell/modules/bar/components/workspaces/Workspace.qml
+++ b/shell/modules/bar/components/workspaces/Workspace.qml
@@ -15,6 +15,9 @@ GridLayout {
 
     required property int index
     required property int activeWsId
+    /// Name of the screen this bar is on. Window icons are limited to it: the
+    /// desktop is shared across screens, but the pill is not.
+    required property string screenName
     required property var occupied
     required property int groupOffset
 
@@ -335,6 +338,8 @@ GridLayout {
                             const wins = KWinActiveWindowBridge.windowList;
                             for (let i = 0; i < wins.length; ++i) {
                                 const w = wins[i];
+                                if (w.output !== root.screenName)
+                                    continue;
                                 if (w.workspace && w.workspace.id === ws && w["class"] !== "quickshell" && w["class"] !== "plasmashell") {
                                     windows.push(w);
                                 }
@@ -403,6 +408,8 @@ GridLayout {
                             const wins = KWinActiveWindowBridge.windowList;
                             for (let i = 0; i < wins.length; ++i) {
                                 const w = wins[i];
+                                if (w.output !== root.screenName)
+                                    continue;
                                 if (w.workspace && w.workspace.id === ws && w["class"] !== "quickshell" && w["class"] !== "plasmashell") {
                                     windows.push(w);
                                 }

--- a/shell/modules/bar/components/workspaces/Workspaces.qml
+++ b/shell/modules/bar/components/workspaces/Workspaces.qml
@@ -33,9 +33,20 @@ Item {
             return Config.bar.workspaces.shown;
         }
         property int activeWsId: {
-            if (typeof KWinWorkspaceState !== "undefined" && KWinWorkspaceState.activeId > 0) {
+            if (typeof KWinWorkspaceState === "undefined")
+                return 1;
+            // With KWin's per-output virtual desktops each screen has its own
+            // current desktop, and activeId -- which comes from D-Bus -- only
+            // ever reports the focused screen's. Reading it here showed that one
+            // on every bar, and made all of them appear to switch whenever the
+            // pointer crossed to another monitor.
+            const perOutput = KWinWorkspaceState.activeByOutput[root.screen.name];
+            if (perOutput > 0)
+                return perOutput;
+            // Nothing from the tracker yet, or per-output desktops are off, in
+            // which case one current desktop is the truth for every screen.
+            if (KWinWorkspaceState.activeId > 0)
                 return KWinWorkspaceState.activeId;
-            }
             return 1;
         }
         readonly property var occupied: {
@@ -48,6 +59,14 @@ Item {
             if (kwinList) {
                 for (let i = 0; i < kwinList.length; ++i) {
                     const w = kwinList[i];
+                    // KDE's virtual desktops span every screen, so a desktop is
+                    // "occupied" globally the moment anything is on it anywhere.
+                    // This bar belongs to one screen, and saying a desktop is
+                    // busy because of a window the user cannot see from here is
+                    // not useful -- it reports a full desktop as full and an
+                    // empty one as full too.
+                    if (w.output !== root.screen.name)
+                        continue;
                     if (w.workspace && typeof w.workspace.id === "number") {
                         occ[w.workspace.id] = true;
                     }
@@ -121,8 +140,9 @@ Item {
 
                     Workspace {
                         activeWsId: container.activeWsId
-                        occupied: container.occupied
                         groupOffset: container.groupOffset
+                        occupied: container.occupied
+                        screenName: root.screen.name
                     }
                 }
             }

--- a/shell/modules/drawers/ContentWindow.qml
+++ b/shell/modules/drawers/ContentWindow.qml
@@ -240,7 +240,7 @@ StyledWindow {
             visibilities.sidebar = false;
             visibilities.dashboard = false;
             visibilities.utilities = false;
-            visibilities.overview = false;
+            Visibilities.setOverview(false);
             panels.popouts.hasCurrent = false;
             panels.popouts.detachedMode = "";
             bar.closeTray();
@@ -647,7 +647,7 @@ StyledWindow {
         MouseArea {
             anchors.fill: parent
             visible: visibilities.overview
-            onClicked: visibilities.overview = false
+            onClicked: Visibilities.setOverview(false)
         }
         Panels {
             id: panels

--- a/shell/modules/drawers/Interactions.qml
+++ b/shell/modules/drawers/Interactions.qml
@@ -4,6 +4,7 @@ import Quickshell
 import Caelestia.Config
 import qs.components
 import qs.components.controls
+import qs.services
 import qs.modules.bar as Bar
 import qs.modules.bar.popouts as BarPopouts
 
@@ -372,12 +373,12 @@ CustomMouseArea {
         if (Config.overview.enabled && !visibilities.overview) {
             if (Config.overview.showOnHover) {
                 if (inOverviewCorner(x, y) !== "") {
-                    visibilities.overview = true;
+                    Visibilities.setOverview(true);
                 }
             } else if (pressed) {
                 if (inOverviewCorner(dragStart.x, dragStart.y) !== "") {
                     if (Math.hypot(dragX, dragY) > Config.overview.dragThreshold) {
-                        visibilities.overview = true;
+                        Visibilities.setOverview(true);
                     }
                 }
             }

--- a/shell/modules/overview/Content.qml
+++ b/shell/modules/overview/Content.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import Quickshell
 import qs.components
 import qs.services
 import qs.modules.windowinfo as WInfo
@@ -8,6 +9,7 @@ import qs.modules.windowinfo as WInfo
 Item {
     id: root
 
+    required property ShellScreen screen
     required property DrawerVisibilities visibilities
     required property var panels
     property var animConfig
@@ -26,6 +28,7 @@ Item {
         id: windowGrid
 
         panels: root.panels
+        screen: root.screen
         anchors.fill: parent
         opacity: root.visibilities.overview ? 1 : 0
         // activeInfoClient is managed manually to ensure synchronous release before WindowInfo requests it
@@ -35,14 +38,14 @@ Item {
             windowInfoOverlay.isOpen = true
         }
         onRequestClose: {
-            root.visibilities.overview = false
+            Visibilities.setOverview(false)
         }
 
         Behavior on opacity { NumberAnimation { duration: root.animConfig ? root.animConfig.gridDuration : 1500; easing.type: root.animConfig ? root.animConfig.easingType : Easing.OutCubic } }
     }
     Shortcut {
         sequence: "Escape"
-        onActivated: root.visibilities.overview = false
+        onActivated: Visibilities.setOverview(false)
         enabled: root.visibilities.overview
     }
     Item {

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -19,12 +19,27 @@ Item {
     property var cardItems: []
     property var activeInfoClient: null
     property var panels: null
+    /// The screen this overview belongs to. Everything below is scoped to it:
+    /// KWin gives each output its own current desktop, and each window lives on
+    /// one output, so an overview that ignores this shows the other monitor's
+    /// desktop and the other monitor's windows.
+    required property ShellScreen screen
     property var closingWindows: []
     property alias indicatorContainer: indicatorContainer
     readonly property real overviewBorderThickness: Math.min(width, height) * 0.15
     readonly property real indicatorSpace: indicatorContainer.height + Tokens.padding.large * 2
     readonly property real verticalOffset: indicatorSpace - overviewBorderThickness
-    readonly property int activeWsId: typeof KWinWorkspaceState !== "undefined" ? KWinWorkspaceState.activeId : 1
+    readonly property int activeWsId: {
+        if (typeof KWinWorkspaceState === "undefined")
+            return 1;
+        // activeId comes from D-Bus, which exposes a single current desktop and
+        // reports whichever output is focused. Per screen, only the tracker
+        // knows.
+        const perOutput = KWinWorkspaceState.activeByOutput[root.screen.name];
+        if (perOutput > 0)
+            return perOutput;
+        return KWinWorkspaceState.activeId > 0 ? KWinWorkspaceState.activeId : 1;
+    }
     property bool ignoreNextSwitch: false
     property bool _initialized: false
     property bool isDragging: false
@@ -37,8 +52,10 @@ Item {
         if (listView.currentIndex >= wsList.length)
             return [];
         const wsId = wsList[listView.currentIndex].index;
+        // windowsForWorkspace already scopes to the workspace; the overview is
+        // per-screen, so drop anything living on another output.
         return typeof KWinActiveWindowBridge !== "undefined"
-            ? KWinActiveWindowBridge.windowsForWorkspace(wsId, false)
+            ? KWinActiveWindowBridge.windowsForWorkspace(wsId, false).filter(w => w.output === root.screen.name)
             : [];
     }
 
@@ -78,7 +95,7 @@ Item {
         if (typeof KWinActiveWindowBridge !== "undefined")
             KWinActiveWindowBridge.focusWindow(addr);
         if (typeof KWinWorkspaceState !== "undefined" && listView.currentIndex >= 0)
-            KWinWorkspaceState.switchTo(KWinWorkspaceState.workspaces[listView.currentIndex].index);
+            KWinWorkspaceState.switchTo(KWinWorkspaceState.workspaces[listView.currentIndex].index, root.screen.name);
         root.requestClose();
     }
     function syncPage() {
@@ -224,7 +241,7 @@ Item {
 
                 let arr = [];
                 if (kwinList) {
-                    arr = KWinActiveWindowBridge.windowsForWorkspace(wsId, false);
+                    arr = KWinActiveWindowBridge.windowsForWorkspace(wsId, false).filter(w => w.output === root.screen.name);
                 } else if (hyprList) {
                     for (let i = 0; i < hyprList.length; ++i) {
                         const w = hyprList[i];
@@ -506,11 +523,11 @@ Item {
                                             Hypr.dispatch(Hypr.usingLua ? `hl.dsp.focus({ window = "address:0x${modelData.address}" })` : `focuswindow address:0x${modelData.address}`);
                                         }
                                         if (typeof KWinWorkspaceState !== "undefined") {
-                                            KWinWorkspaceState.switchTo(page.wsId);
+                                            KWinWorkspaceState.switchTo(page.wsId, root.screen.name);
                                         }
                                     }
-                                    const v = typeof Visibilities !== "undefined" ? Visibilities.getForActive() : null;
-                                    if (v) v.overview = false;
+                                    if (typeof Visibilities !== "undefined")
+                                        Visibilities.setOverview(false);
                                 }
                             }
 
@@ -591,8 +608,13 @@ Item {
             onTriggered: {
                 if (typeof KWinWorkspaceState !== "undefined" && KWinWorkspaceState.workspaces.length > listView.currentIndex) {
                     const wId = KWinWorkspaceState.workspaces[listView.currentIndex].index;
-                    if (KWinWorkspaceState.activeId !== wId) {
-                        KWinWorkspaceState.switchTo(wId);
+                    // Compared against this screen's desktop, not the global
+                    // activeId: with per-output desktops the global one belongs
+                    // to whichever screen is focused, so testing against it made
+                    // this fire on the screen that had not moved and stay quiet
+                    // on the one that had.
+                    if (root.activeWsId !== wId) {
+                        KWinWorkspaceState.switchTo(wId, root.screen.name);
                     }
                 }
             }
@@ -640,6 +662,7 @@ Item {
 
             anchors.centerIn: parent
             maxWidth: Math.max(200, root.width - 100)
+            screenName: root.screen.name
             count: listView.count
             currentIndex: listView.currentIndex
             closingWindows: root.closingWindows

--- a/shell/modules/overview/WorkspaceIndicator.qml
+++ b/shell/modules/overview/WorkspaceIndicator.qml
@@ -12,6 +12,7 @@ import qs.services
 Item {
     id: root
 
+    required property string screenName
     property int count: 0
     property int currentIndex: 0
     readonly property int activeWsId: currentIndex + 1
@@ -30,6 +31,11 @@ Item {
         if (kwinList) {
             for (let i = 0; i < kwinList.length; ++i) {
                 const w = kwinList[i];
+                // Each window lives on one output; this strip describes one
+                // screen. Counting the other monitor's windows makes a desktop
+                // that is empty here look busy.
+                if (w.output !== root.screenName)
+                    continue;
                 if (w.workspace) {
                     const wid = typeof w.workspace.id === "number" ? w.workspace.id : (typeof w.workspace.index === "number" ? w.workspace.index : null);
                     if (wid !== null) occ[wid] = true;
@@ -122,6 +128,7 @@ Item {
                 WsComponents.Workspace {
                     scaleFactor: root.scaleFactor
                     activeWsId: root.activeWsId
+                    screenName: root.screenName
                     occupied: root.occupied
                     groupOffset: 0
                     swipeOffset: root.swipeOffset
@@ -256,7 +263,7 @@ Item {
                                 }
                                 if (newActId !== actId) {
                                     const targetUuid = KWinWorkspaceState.workspaces[newActId - 1]?.id;
-                                    if (targetUuid) KWinWorkspaceState.switchTo(targetUuid);
+                                    if (targetUuid) KWinWorkspaceState.switchTo(targetUuid, root.screenName);
                                 }
                             }
                         }

--- a/shell/modules/overview/Wrapper.qml
+++ b/shell/modules/overview/Wrapper.qml
@@ -32,6 +32,7 @@ Item {
         active: root.shouldBeActive || root.visible
         sourceComponent: Component {
             Content {
+                screen: root.screen
                 visibilities: root.visibilities
                 panels: root.panels
                 animConfig: root.animConfig

--- a/shell/modules/overview/components/workspaces/Workspace.qml
+++ b/shell/modules/overview/components/workspaces/Workspace.qml
@@ -16,6 +16,8 @@ StyledRect {
 
     required property int index
     required property int activeWsId
+    /// Screen this overview belongs to; window icons are limited to it.
+    required property string screenName
     required property var occupied
     required property int groupOffset
     readonly property bool isWorkspace: true
@@ -134,7 +136,7 @@ StyledRect {
             } else {
                 if (typeof KWinWorkspaceState !== "undefined") {
                     const wId = KWinWorkspaceState.workspaces[root.ws - 1]?.id || root.ws.toString();
-                    KWinWorkspaceState.switchTo(wId);
+                    KWinWorkspaceState.switchTo(wId, root.screenName);
                 } else {
                     const isKWin = typeof KWinActiveWindowBridge !== "undefined" && KWinActiveWindowBridge.windowList;
                     if (isKWin) {
@@ -225,6 +227,10 @@ StyledRect {
                         const wins = KWinActiveWindowBridge.windowsForWorkspace(wsId, false);
                         for (let i = 0; i < wins.length; ++i) {
                             const w = wins[i];
+                            // windowsForWorkspace already filtered by workspace;
+                            // this strip only shows its own screen.
+                            if (w.output !== root.screenName)
+                                continue;
                             if (w["class"] !== "quickshell" && w["class"] !== "plasmashell") {
                                 windows.push(w);
                             }

--- a/shell/modules/windowinfo/Buttons.qml
+++ b/shell/modules/windowinfo/Buttons.qml
@@ -50,7 +50,7 @@ ColumnLayout {
                             KWinWorkspaceState.switchTo(wsId);
                         }
                     }
-                    Visibilities.getForActive().overview = false;
+                    Visibilities.setOverview(false);
                 }
                 color: isCurrent ? Colours.tPalette.m3surfaceContainerHighest : Colours.palette.m3tertiaryContainer
                 onColor: isCurrent ? Colours.palette.m3onSurface : Colours.palette.m3onTertiaryContainer
@@ -78,7 +78,7 @@ ColumnLayout {
                 } else {
                     console.log("KWinActiveWindowBridge is undefined");
                 }
-                Visibilities.getForActive().overview = false;
+                Visibilities.setOverview(false);
             }
         }
         Loader {
@@ -96,7 +96,7 @@ ColumnLayout {
                             KWinActiveWindowBridge.minimizeWindow(root.client?.address);
                         }
                     }
-                    Visibilities.getForActive().overview = false;
+                    Visibilities.setOverview(false);
                 }
             }
             Layout.fillWidth: active
@@ -113,7 +113,7 @@ ColumnLayout {
                     console.log("Calling KWinActiveWindowBridge.closeWindow");
                     KWinActiveWindowBridge.closeWindow(root.client?.address);
                 }
-                Visibilities.getForActive().overview = false;
+                Visibilities.setOverview(false);
             }
         }
         Layout.fillWidth: true
@@ -140,8 +140,8 @@ ColumnLayout {
             onClicked: {
                 parent.clicked()
                 root.closeRequested()
-                const v = typeof Visibilities !== "undefined" ? Visibilities.getForActive() : null;
-                if (v) v.overview = false;
+                if (typeof Visibilities !== "undefined")
+                    Visibilities.setOverview(false);
             }
         }
         StyledText {

--- a/shell/plugin/src/Caelestia/Services/kwinworkspacestate.cpp
+++ b/shell/plugin/src/Caelestia/Services/kwinworkspacestate.cpp
@@ -114,16 +114,57 @@ void KWinWorkspaceState::setupTrackerServer() {
             qDebug() << "KWinWorkspaceState: New connection to tracker server";
             QLocalSocket* clientSocket = m_trackerServer->nextPendingConnection();
             connect(clientSocket, &QLocalSocket::readyRead, this, [this, clientSocket]() {
-                while (clientSocket->bytesAvailable() >= 12) { // sizeof(DesktopTransition) = 12
-                    struct DesktopTransition {
-                        int desktop;
-                        float x;
-                        float y;
-                    } payload;
+                // Two record formats. The current one names the output the
+                // report is about; the older one, which a stale effect still
+                // sends, does not -- and a stale effect is normal after an
+                // update, because a rebuilt one only loads once the session
+                // restarts. They are told apart by the magic in the first
+                // field, which the old format used for a small desktop number
+                // and so can never produce.
+                constexpr quint32 kMagic = 0x43414557; // 'CAEW'
+                struct DesktopReport {
+                    quint32 magic;
+                    qint32 desktop;
+                    float x;
+                    float y;
+                    char output[64];
+                };
+                static_assert(sizeof(DesktopReport) == 80, "must match the effect's layout byte for byte");
 
-                    clientSocket->read(reinterpret_cast<char*>(&payload), sizeof(payload));
+                struct LegacyTransition {
+                    int desktop;
+                    float x;
+                    float y;
+                };
 
-                    double newOffset = static_cast<double>(payload.x);
+                while (clientSocket->bytesAvailable() >= static_cast<qint64>(sizeof(LegacyTransition))) {
+                    quint32 magic = 0;
+                    clientSocket->peek(reinterpret_cast<char*>(&magic), sizeof(magic));
+
+                    double newOffset = 0.0;
+
+                    if (magic == kMagic) {
+                        if (clientSocket->bytesAvailable() < static_cast<qint64>(sizeof(DesktopReport))) {
+                            break; // wait for the rest of the record
+                        }
+                        DesktopReport report;
+                        clientSocket->read(reinterpret_cast<char*>(&report), sizeof(report));
+                        report.output[sizeof(report.output) - 1] = '\0';
+
+                        const QString output = QString::fromUtf8(report.output);
+                        if (!output.isEmpty() && report.desktop > 0) {
+                            if (m_activeByOutput.value(output).toInt() != report.desktop) {
+                                m_activeByOutput.insert(output, report.desktop);
+                                emit activeByOutputChanged();
+                            }
+                        }
+                        newOffset = static_cast<double>(report.x);
+                    } else {
+                        LegacyTransition payload;
+                        clientSocket->read(reinterpret_cast<char*>(&payload), sizeof(payload));
+                        newOffset = static_cast<double>(payload.x);
+                    }
+
                     if (m_swipeOffset != newOffset) {
                         m_swipeOffset = newOffset;
                         emit swipeOffsetChanged();
@@ -220,6 +261,10 @@ void KWinWorkspaceState::updateActiveId() {
     emit workspacesChanged();
 }
 
+QVariantMap KWinWorkspaceState::activeByOutput() const {
+    return m_activeByOutput;
+}
+
 int KWinWorkspaceState::activeId() const {
     return m_activeId;
 }
@@ -240,7 +285,7 @@ QVariantList KWinWorkspaceState::workspaces() const {
     return list;
 }
 
-void KWinWorkspaceState::switchTo(const QString& id) {
+void KWinWorkspaceState::switchTo(const QString& id, const QString& output) {
     QString targetUuid;
     for (const auto& d : m_desktops) {
         if (d.id == id || QString::number(d.position + 1) == id || d.name == id) {
@@ -250,6 +295,38 @@ void KWinWorkspaceState::switchTo(const QString& id) {
     }
 
     if (!targetUuid.isEmpty()) {
+        // Naming the screen needs the workspace-tracker effect, which can target
+        // an output directly; D-Bus can only set the desktop of whichever output
+        // is active. The effect is installed system-wide and a rebuilt one does
+        // not load until the session restarts, so a shell update routinely runs
+        // against a version without this method -- and a fire-and-forget call to
+        // a method that is not there fails silently, which would leave switching
+        // workspaces doing nothing at all. Probed once, then remembered.
+        if (!output.isEmpty()) {
+            if (m_perOutputSwitchAvailable == -1) {
+                QDBusMessage probe = QDBusMessage::createMethodCall("org.kde.KWin",
+                    "/Caelestia/Workspaces", "org.freedesktop.DBus.Introspectable", "Introspect");
+                const QDBusMessage reply = QDBusConnection::sessionBus().call(probe, QDBus::Block, 1000);
+                m_perOutputSwitchAvailable = (reply.type() == QDBusMessage::ReplyMessage
+                                                 && reply.arguments().value(0).toString().contains(
+                                                     QStringLiteral("SetDesktop")))
+                    ? 1
+                    : 0;
+                if (!m_perOutputSwitchAvailable) {
+                    qWarning() << "KWinWorkspaceState: workspace-tracker effect has no SetDesktop; "
+                                  "falling back to switching the active output's desktop";
+                }
+            }
+
+            if (m_perOutputSwitchAvailable == 1) {
+                QDBusMessage msg = QDBusMessage::createMethodCall(
+                    "org.kde.KWin", "/Caelestia/Workspaces", "org.caelestia.Workspaces", "SetDesktop");
+                msg << output << indexForId(targetUuid);
+                QDBusConnection::sessionBus().call(msg, QDBus::NoBlock);
+                return;
+            }
+        }
+
         QDBusMessage msg = QDBusMessage::createMethodCall("org.kde.KWin", "/VirtualDesktopManager", "org.freedesktop.DBus.Properties", "Set");
         msg << "org.kde.KWin.VirtualDesktopManager" << "current" << QVariant::fromValue(QDBusVariant(targetUuid));
         QDBusConnection::sessionBus().call(msg, QDBus::NoBlock);

--- a/shell/plugin/src/Caelestia/Services/kwinworkspacestate.hpp
+++ b/shell/plugin/src/Caelestia/Services/kwinworkspacestate.hpp
@@ -24,6 +24,19 @@ class KWinWorkspaceState : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(int activeId READ activeId NOTIFY activeIdChanged)
+    /**
+     * Current desktop per output name, e.g. { "DP-1": 1, "HDMI-A-2": 3 }.
+     *
+     * KWin's PerOutputVirtualDesktops gives every screen its own current
+     * desktop, but D-Bus still exposes a single VirtualDesktopManager.current,
+     * which follows the active output. A per-screen widget reading that shows
+     * the focused screen's desktop on every screen, and appears to switch on
+     * all of them when the pointer moves. This comes from the workspace-tracker
+     * effect instead, which is inside KWin and can ask per output.
+     *
+     * Empty until the effect connects; fall back to activeId in that case.
+     */
+    Q_PROPERTY(QVariantMap activeByOutput READ activeByOutput NOTIFY activeByOutputChanged)
     Q_PROPERTY(QVariantList workspaces READ workspaces NOTIFY workspacesChanged)
     Q_PROPERTY(uint rows READ rows NOTIFY rowsChanged)
     Q_PROPERTY(double swipeOffset READ swipeOffset NOTIFY swipeOffsetChanged)
@@ -40,12 +53,22 @@ public:
     ~KWinWorkspaceState() override;
 
     int activeId() const;
+    QVariantMap activeByOutput() const;
     QVariantList workspaces() const;
     uint rows() const;
     double swipeOffset() const;
     bool showingDesktop() const;
 
-    Q_INVOKABLE void switchTo(const QString& id);
+    /**
+     * Switches to desktop @p id. With @p output named, only that screen moves.
+     *
+     * KWin's D-Bus setter always applies to whichever output is active, which
+     * is wrong the moment two screens each have their own desktop and both can
+     * ask: a request from one monitor's overview lands on whatever the pointer
+     * is over. Naming the output routes it through the workspace-tracker
+     * effect, which is inside the compositor and can target it directly.
+     */
+    Q_INVOKABLE void switchTo(const QString& id, const QString& output = QString());
     Q_INVOKABLE void createWorkspace(const QString& name = QString());
     Q_INVOKABLE void removeWorkspace(const QString& id);
 
@@ -55,6 +78,7 @@ public:
 
 signals:
     void activeIdChanged();
+    void activeByOutputChanged();
     void workspacesChanged();
     void rowsChanged();
     void swipeOffsetChanged();
@@ -79,6 +103,9 @@ private:
     QList<KWinDesktopData> m_desktops;
     QString m_currentUuid;
     int m_activeId = 0;
+    QVariantMap m_activeByOutput;
+    // -1 unknown, 0 absent, 1 present. See switchTo().
+    int m_perOutputSwitchAvailable = -1;
     uint m_rows = 1;
     double m_swipeOffset = 0.0;
     bool m_showingDesktop = false;

--- a/shell/services/Visibilities.qml
+++ b/shell/services/Visibilities.qml
@@ -38,4 +38,16 @@ Singleton {
         const monitor = Hypr.monitors[KWinActiveWindowBridge.cursorOutputName()] || Hypr.focusedMonitor;
         return screens.get(monitor) || screens.values().next().value;
     }
+    /**
+     * Opens or closes the overview on every screen at once.
+     *
+     * With per-output desktops each screen shows its own workspace, so opening
+     * the overview on the focused screen alone reads as broken on a
+     * multi-monitor setup -- one screen goes to the overview and the other
+     * carries on as if nothing happened.
+     */
+    function setOverview(visible: bool): void {
+        for (const visibilities of screens.values())
+            visibilities.overview = visible;
+    }
 }


### PR DESCRIPTION
First half of #540, split as requested. Rebased on current dev, so the conflicts are gone.

KWin already gives every output its own current virtual desktop, but the shell had no way to see it. The D-Bus `VirtualDesktopManager.current` exposes a single "current" that follows whichever output is focused, and setting it applies to that output too — so the bar, the overview and the workspace indicator all showed the focused screen's desktop on every monitor, and a switch meant for one monitor landed on whichever the pointer happened to be over.

The workspace-tracker effect can answer per output from inside the compositor, so it now reports the desktop for each one and takes a `SetDesktop(output, desktop)`. `KWinWorkspaceState` exposes that as `activeByOutput`, and `switchTo()` takes an optional output name, falling back to the D-Bus path when the effect is not installed.

Everything downstream is scoped to a screen: the overview knows which one it belongs to and filters windows by output, the bar's workspace strip reads its own screen's desktop, and the overview opens on every screen at once rather than only the focused one.

The other half — dragging windows between screens — is stacked on this one and goes up separately.