### PR TITLE
feat: drag windows between screens in the overview

### DIFF
--- a/shell/kwin-effects/workspace-tracker/workspace_tracker.cpp
+++ b/shell/kwin-effects/workspace-tracker/workspace_tracker.cpp
@@ -61,6 +61,27 @@ KWin::LogicalOutput* WorkspaceTrackerEffect::findOutput(const QString& name)
     return nullptr;
 }
 
+void WorkspaceTrackerEffect::SendToOutput(const QString& uuid, const QString& output)
+{
+    KWin::LogicalOutput* target = findOutput(output);
+    if (!target) {
+        return;
+    }
+
+    const QUuid wanted(uuid);
+    if (wanted.isNull()) {
+        return;
+    }
+
+    const auto windows = KWin::effects->stackingOrder();
+    for (KWin::EffectWindow* window : windows) {
+        if (window && window->internalId() == wanted) {
+            KWin::effects->windowToScreen(window, target);
+            return;
+        }
+    }
+}
+
 void WorkspaceTrackerEffect::SetDesktop(const QString& output, int desktop)
 {
     if (desktop < 1) {

--- a/shell/kwin-effects/workspace-tracker/workspace_tracker.hpp
+++ b/shell/kwin-effects/workspace-tracker/workspace_tracker.hpp
@@ -3,6 +3,7 @@
 #include <effect/effect.h>
 #include <effect/effecthandler.h>
 #include <QLocalSocket>
+#include <QUuid>
 #include <QPointer>
 #include <QObject>
 #include <QPointF>
@@ -51,6 +52,15 @@ public Q_SLOTS:
      * be over. Inside the compositor the output can simply be named.
      */
     void SetDesktop(const QString& output, int desktop);
+
+    /**
+     * Moves the window with EffectWindow::internalId() @p uuid to @p output.
+     *
+     * There is no unprivileged way to do this from outside: plasma-window-management
+     * can move a window between desktops but not between screens, and the D-Bus
+     * surface has nothing for it either. Inside the compositor it is one call.
+     */
+    void SendToOutput(const QString& uuid, const QString& output);
 
 private Q_SLOTS:
     void onDesktopChanging(KWin::VirtualDesktop* desktop, QPointF offset, KWin::EffectWindow* with, KWin::LogicalOutput* output);

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -43,6 +43,31 @@ Item {
     property bool ignoreNextSwitch: false
     property bool _initialized: false
     property bool isDragging: false
+    /// -1 while a drag rests against the left edge, +1 against the right, 0
+    /// otherwise. Drives the dwell that pages through workspaces.
+    ///
+    /// Read from the drag's own position rather than from drop areas at the
+    /// edges. Those reported entry and exit, and paging moves the grid under the
+    /// pointer, which counted as leaving -- so the second page never came while
+    /// the drag was held perfectly still. A position cannot be confused that way.
+    readonly property real edgeBand: 60
+    readonly property int edgeDirection: {
+        if (!root.isDragging || Visibilities.dragAddress === "" || Visibilities.dragOriginScreen !== root.screen.name)
+            return 0;
+        // Screen coordinates on both sides. The published position is relative
+        // to the window, which covers the screen; root is an item inside it and
+        // narrower, so measuring one against the other put the edge in the wrong
+        // place -- far enough out that it was never reached.
+        const local = Visibilities.dragX - root.screen.x;
+        const span = root.screen.width;
+        if (local < 0 || local >= span)
+            return 0; // gone to another screen; that is a move, not a page
+        if (local < root.edgeBand)
+            return -1;
+        if (local > span - root.edgeBand)
+            return 1;
+        return 0;
+    }
     readonly property real hoverScale: 1.02
     property int selectedIndex: -1
     readonly property var currentWindows: {
@@ -61,6 +86,17 @@ Item {
 
     signal requestWindowInfo(var client)
     signal requestClose()
+
+    /// The screen containing a point in global coordinates, or null.
+    function screenAtGlobal(gx: real, gy: real): var {
+        const all = Quickshell.screens;
+        for (let i = 0; i < all.length; ++i) {
+            const s = all[i];
+            if (gx >= s.x && gx < s.x + s.width && gy >= s.y && gy < s.y + s.height)
+                return s;
+        }
+        return null;
+    }
 
     // Resolve an icon for a window card, mirroring the dock: prefer an icon
     // extracted from the window's own _NET_WM_ICON (apps with no desktop
@@ -333,17 +369,60 @@ Item {
 
                             property bool closing: false
                             property url infoScreenshot: ""
+                            /// Set by a workspace thumbnail's DropArea while the
+                            /// card hovers it, so the card shrinks to the size it
+                            /// would occupy there. 0 means "not over one".
+                            property real dropTargetScale: 0
+                            /// Over a workspace thumbnail: the preview collapses
+                            /// into the application's icon, the way a window does
+                            /// when it is dropped onto a workspace in GNOME. It is
+                            /// what the slot will actually contain once dropped, so
+                            /// the drag shows its own result; dragging back out
+                            /// reverses it.
+                            readonly property bool morphed: dragHandler.active && activeWin.dropTargetScale > 0
+
+                            // The pointer, not the card's middle. The card is held
+                            // wherever it was grabbed, so its centre sits at an
+                            // offset that drifts across boundaries on its own --
+                            // enough to cross the screen edge while the pointer was
+                            // still well inside it, which read as leaving the screen
+                            // and reset the edge dwell every time it wobbled.
+                            function publishDrag(): void {
+                                if (!dragHandler.active)
+                                    return;
+                                const p = dragHandler.centroid.scenePosition;
+                                Visibilities.setDrag(activeWin.clientAddress, root.screen.x + p.x, root.screen.y + p.y, activeWin.width, activeWin.height, root.screen.name);
+                            }
 
                             x: dragHandler.active ? x : layoutProps.x
                             y: dragHandler.active ? y : layoutProps.y
                             width: layoutProps.width
                             height: layoutProps.height
-                            color: Colours.palette.m3surfaceContainer
+                            color: activeWin.morphed ? "transparent" : Colours.palette.m3surfaceContainer
                             radius: Tokens.rounding.large
-                            scale: closing ? 0 : (activeWin.isSelected && !dragHandler.active ? root.hoverScale : 1)
-                            opacity: closing ? 0 : 1
-                            border.width: activeWin.isSelected ? 2 : 0
+                            scale: {
+                                if (closing)
+                                    return 0;
+                                // Dragged onto a workspace thumbnail: shrink to
+                                // roughly what it will look like once dropped, so
+                                // the target reads as a target rather than the
+                                // card just floating over it.
+                                if (dragHandler.active && activeWin.dropTargetScale > 0)
+                                    return activeWin.dropTargetScale;
+                                return activeWin.isSelected && !dragHandler.active ? root.hoverScale : 1;
+                            }
+                            // Once the drag is over another screen that screen
+                            // draws it, and the half still poking out here would
+                            // otherwise sit there as a stream-less icon.
+                            opacity: closing || Visibilities.streamClaim === activeWin.clientAddress ? 0 : 1
+                            border.width: activeWin.isSelected && !activeWin.morphed ? 2 : 0
                             border.color: Colours.palette.m3primary
+
+                            // Published on every move so the screen the pointer
+                            // has reached can draw what is coming; this one cannot
+                            // draw past its own edge.
+                            onXChanged: activeWin.publishDrag()
+                            onYChanged: activeWin.publishDrag()
 
                             Component.onCompleted: {
                                 root.cardItems = [...root.cardItems, activeWin];
@@ -375,12 +454,40 @@ Item {
                                 onActiveChanged: {
                                     root.isDragging = active;
                                     if (!active) {
+                                        activeWin.dropTargetScale = 0;
+                                        Visibilities.clearDrag();
+
+                                        if (typeof KWinWorkspaceState === "undefined" || typeof KWinActiveWindowBridge === "undefined") return;
+
+                                        // Checked before Drag.drop(), not after.
+                                        // Each screen has its own overview in its
+                                        // own window, so a drag can never be handed
+                                        // to the other one's drop areas -- but the
+                                        // pointer does travel there and the card
+                                        // goes with it, so where it was let go is
+                                        // enough to act on. This one's drop areas
+                                        // still claim a release out there, though,
+                                        // and one of them answering first is what
+                                        // made a window dragged to the next monitor
+                                        // land on a workspace of the monitor it came
+                                        // from. Leaving the screen is the stronger
+                                        // signal, so it is read first.
+                                        const target = root.screenAtGlobal(Visibilities.dragX, Visibilities.dragY);
+                                        if (target && target.name !== root.screen.name) {
+                                            const addr = clientAddress;
+                                            activeWin.Drag.cancel();
+                                            activeWin.visible = false;
+                                            Qt.callLater(() => {
+                                                KWinActiveWindowBridge.sendToOutput(addr, target.name);
+                                            });
+                                            return;
+                                        }
+
                                         let dropAction = activeWin.Drag.drop();
                                         if (dropAction !== Qt.IgnoreAction) {
                                             return; // Handled by DropArea
                                         }
 
-                                        if (typeof KWinWorkspaceState === "undefined" || typeof KWinActiveWindowBridge === "undefined") return;
                                         const targetWsId = KWinWorkspaceState.workspaces[listView.currentIndex].index;
                                         if (targetWsId !== page.wsId) {
                                             activeWin.visible = false;
@@ -392,7 +499,15 @@ Item {
                                     }
                                 }
                             }
-                            Behavior on scale { Anim {} }
+                            Behavior on scale {
+                                // Slower while a drag is in progress: this is the
+                                // preview collapsing into its icon and opening back
+                                // out, which is meant to be read, not the snap of a
+                                // hover highlight.
+                                Anim {
+                                    type: dragHandler.active ? Anim.SlowSpatial : Anim.DefaultSpatial
+                                }
+                            }
                             Behavior on opacity {
                                 NumberAnimation {
                                     id: opacityAnim
@@ -430,11 +545,39 @@ Item {
                                 }
                             }
 
+                            // The icon the card collapses into over a workspace
+                            // thumbnail. Sized as a share of the card so that the
+                            // card's own drop scale carries it down to icon size --
+                            // one animation drives both, and they cannot drift.
+                            IconImage {
+                                anchors.centerIn: parent
+                                asynchronous: true
+                                implicitSize: Math.round(Math.min(activeWin.width, activeWin.height) * 0.62)
+                                opacity: activeWin.morphed ? 1 : 0
+                                source: modelData.iconName ? Icons.getAppIcon(modelData.iconName, "image-missing") : (modelData.class ? Icons.getAppIcon(modelData.class, "image-missing") : "")
+                                visible: opacity > 0.01
+                                z: 10
+
+                                Behavior on opacity {
+                                    Anim {
+                                        type: Anim.SlowEffects
+                                    }
+                                }
+                            }
+
                             Item {
                                 id: cardLayout
 
                                 anchors.fill: parent
                                 anchors.margins: Tokens.padding.small
+                                opacity: activeWin.morphed ? 0 : 1
+                                visible: opacity > 0.01
+
+                                Behavior on opacity {
+                                    Anim {
+                                        type: Anim.SlowEffects
+                                    }
+                                }
 
                                 StyledClippingRect {
                                     id: thumb
@@ -451,9 +594,15 @@ Item {
                                         // neighbours: a workspace three swipes away
                                         // is not worth a stream. The window shown in
                                         // the info panel is excluded too -- that
-                                        // panel puts up its own frozen frame.
+                                        // panel puts up its own frozen frame. And
+                                        // not while something outside the grid has
+                                        // claimed the stream: KWin serves one node
+                                        // per window and a node feeds one consumer,
+                                        // so holding on would leave the other one
+                                        // drawing black.
                                         active: root.opacity > 0 && Math.abs(page.index - listView.currentIndex) <= 1
                                             && !(root.activeInfoClient && root.activeInfoClient.address === modelData.address)
+                                            && Visibilities.streamClaim !== modelData.address
                                         address: modelData.address ?? ""
                                         width: {
                                             const wAspect = activeWin.windowAspect;
@@ -536,7 +685,10 @@ Item {
                                 anchors.right: cardLayout.right
                                 anchors.margins: Tokens.padding.small
                                 spacing: Tokens.spacing.small
-                                opacity: hover.hovered ? 1 : 0
+                                // Hidden for the whole drag: it belongs to the
+                                // card sitting in the grid, and left up it hovers
+                                // over the collapsed icon with nothing to act on.
+                                opacity: hover.hovered && !dragHandler.active ? 1 : 0
                                 visible: opacity > 0.01
 
                                 Behavior on opacity { Anim {} }
@@ -688,33 +840,106 @@ Item {
         interval: 500
         onTriggered: root.ignoreNextSwitch = false
     }
-    Timer {
-        id: edgeScrollCooldown
+    // What a drag arriving from another screen looks like here.
+    //
+    // The card itself belongs to the overview it started in and is clipped at
+    // that screen's edge, so without this a window dragged across simply
+    // disappears halfway and is released onto nothing visible. This follows the
+    // published pointer position and shows the same live preview the card was
+    // showing, so the window keeps its identity across the gap rather than
+    // turning into an icon on the way.
+    Item {
+        id: incoming
 
-        interval: 1000
-    }
-    DropArea {
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-        width: 100
-        onEntered: {
-            if (!edgeScrollCooldown.running && listView.currentIndex > 0) {
-                listView.currentIndex -= 1;
-                edgeScrollCooldown.start();
+        readonly property var window: {
+            const addr = Visibilities.dragAddress;
+            if (!addr || typeof KWinActiveWindowBridge === "undefined")
+                return null;
+            const all = KWinActiveWindowBridge.windowList || [];
+            for (let i = 0; i < all.length; ++i)
+                if (all[i].address === addr)
+                    return all[i];
+            return null;
+        }
+        readonly property bool arriving: Visibilities.dragAddress !== ""
+            && Visibilities.dragOriginScreen !== root.screen.name
+            && Visibilities.dragX >= root.screen.x
+            && Visibilities.dragX < root.screen.x + root.screen.width
+            && Visibilities.dragY >= root.screen.y
+            && Visibilities.dragY < root.screen.y + root.screen.height
+        readonly property real aspect: {
+            const w = incoming.window;
+            if (w && w.width > 0 && w.height > 0)
+                return w.width / w.height;
+            return 16 / 9;
+        }
+
+        // The size the card had on the screen it left, so crossing the gap does
+        // not resize the thing being carried.
+        height: Visibilities.dragHeight > 0 ? Visibilities.dragHeight : Math.round(width / Math.max(0.2, incoming.aspect))
+        opacity: arriving ? 1 : 0
+        visible: opacity > 0.01
+        width: Visibilities.dragWidth > 0 ? Visibilities.dragWidth : Math.round(Math.min(root.width, root.height) * 0.32)
+        x: Visibilities.dragX - root.screen.x - width / 2
+        y: Visibilities.dragY - root.screen.y - height / 2
+        z: 1000
+
+        // Claimed while it is here so the card back on the origin screen gives
+        // the stream up; a node feeds one consumer.
+        onArrivingChanged: Visibilities.streamClaim = incoming.arriving ? Visibilities.dragAddress : ""
+
+        Behavior on opacity {
+            Anim {
+                type: Anim.DefaultEffects
+            }
+        }
+
+        StyledClippingRect {
+            anchors.fill: parent
+            color: Colours.palette.m3surfaceContainer
+            radius: Tokens.rounding.large
+
+            WindowPreview {
+                active: incoming.arriving
+                address: Visibilities.dragAddress
+                anchors.fill: parent
+                fallbackIcon: {
+                    const w = incoming.window;
+                    if (!w)
+                        return "";
+                    return w.iconName ? Icons.getAppIcon(w.iconName, "image-missing") : (w.class ? Icons.getAppIcon(w.class, "image-missing") : "");
+                }
+                sourceAspect: incoming.aspect
             }
         }
     }
-    DropArea {
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-        width: 100
-        onEntered: {
-            if (!edgeScrollCooldown.running && listView.currentIndex < listView.count - 1) {
+
+    // Holding a drag against an edge pages through workspaces, one step at a
+    // time for as long as it is held.
+    //
+    // It used to page the instant the drag touched the edge, which made the
+    // edge unusable as a way off the screen: on a side with another monitor,
+    // simply travelling towards it paged a workspace on the way past. Waiting
+    // for the drag to actually rest there separates the two gestures -- pass
+    // through and you reach the next monitor, stop and you page -- so both work
+    // on the same edge without a mode.
+    Timer {
+        id: edgeDwell
+
+        // running is bound rather than started and stopped by hand. A drag
+        // released while still inside an edge area never delivers an exit, so
+        // the stop call that was meant to pair with the start never arrived and
+        // the timer kept paging on its own long after the pointer was gone --
+        // workspaces flipping by themselves with nothing held. Tying it to the
+        // drag itself means it cannot outlive one.
+        interval: 900
+        repeat: true
+        running: root.isDragging && root.edgeDirection !== 0
+        onTriggered: {
+            if (root.edgeDirection < 0 && listView.currentIndex > 0)
+                listView.currentIndex -= 1;
+            else if (root.edgeDirection > 0 && listView.currentIndex < listView.count - 1)
                 listView.currentIndex += 1;
-                edgeScrollCooldown.start();
-            }
         }
     }
     StyledRect {

--- a/shell/modules/overview/WindowGrid.qml
+++ b/shell/modules/overview/WindowGrid.qml
@@ -50,7 +50,12 @@ Item {
     /// edges. Those reported entry and exit, and paging moves the grid under the
     /// pointer, which counted as leaving -- so the second page never came while
     /// the drag was held perfectly still. A position cannot be confused that way.
-    readonly property real edgeBand: 60
+    /// How far in from a screen edge counts as resting against it. Wide enough
+    /// to be reachable without pressing the pointer into the very last pixels:
+    /// on a shared edge the pointer glides onto the next monitor rather than
+    /// stopping, so a narrow band leaves almost nothing to aim at. The dwell,
+    /// not the width, is what keeps passing through from paging.
+    readonly property real edgeBand: 140
     readonly property int edgeDirection: {
         if (!root.isDragging || Visibilities.dragAddress === "" || Visibilities.dragOriginScreen !== root.screen.name)
             return 0;
@@ -136,6 +141,15 @@ Item {
     }
     function syncPage() {
         if (typeof KWinWorkspaceState === "undefined") return;
+        // Never while a window is being dragged. The page a drag has reached is
+        // chosen by the drag itself, but activeWsId only catches up once the
+        // compositor has switched and the tracker's payload has come back over
+        // its socket -- and any activeWsId notification arriving before that
+        // still carries the desktop the drag started on. Acting on it snaps the
+        // view back to that page, so the drop then finds the window already
+        // where it is and does nothing: the card flies home and the drag looks
+        // like it was ignored.
+        if (root.isDragging) return;
         for (let i = 0; i < KWinWorkspaceState.workspaces.length; ++i) {
             const wId = KWinWorkspaceState.workspaces[i].index;
             if (wId === activeWsId) {
@@ -154,6 +168,9 @@ Item {
     onOpacityChanged: {
         if (opacity <= 0) {
             selectedIndex = -1;
+            // A card destroyed mid-drag never reports the drag ending, and a
+            // stuck flag would leave syncPage() disabled for good.
+            root.isDragging = false;
         } else {
             if (Visibilities.preOverviewActiveWindowAddress !== "") {
                 const targetAddress = Visibilities.preOverviewActiveWindowAddress;
@@ -258,6 +275,13 @@ Item {
         onCountChanged: Qt.callLater(root.syncPage)
         onCurrentIndexChanged: {
             if (root.ignoreNextSwitch) return;
+            // Not while a window is being dragged. Switching the compositor's
+            // desktop cancels the pointer grab the drag is riding on, so the
+            // drag ended the instant the first page turned and the window was
+            // dropped on the page it had just reached -- holding on could never
+            // carry it further. The view still pages; the desktop catches up
+            // once the drag is over.
+            if (root.isDragging) return;
             switchTimer.restart();
         }
 
@@ -321,6 +345,16 @@ Item {
             }
             DropArea {
                 anchors.fill: parent
+                // Accepted only when this page actually took the window in.
+                //
+                // Qt re-resolves which DropArea a drag is over on drag movement,
+                // not when the scene moves underneath it. Paging by holding the
+                // drag against an edge does exactly that -- the pages scroll
+                // while the pointer is deliberately still -- so the drag is
+                // still registered against the page it started on. Accepting
+                // there regardless reported the drop as handled, and the card's
+                // own release path, which goes by the page actually on screen,
+                // never ran: the workspace changed and the window stayed behind.
                 onDropped: drop => {
                     const sourceItem = drop.source;
                     if (sourceItem && sourceItem.clientAddress) {
@@ -335,8 +369,8 @@ Item {
                                     Hypr.dispatch(Hypr.usingLua ? `hl.dsp.movetoworkspace({ workspace = "${targetId}", window = "address:0x${addr}" })` : `movetoworkspace ${targetId},address:0x${addr}`);
                                 }
                             });
+                            drop.accept();
                         }
-                        drop.accept();
                     }
                 }
             }
@@ -456,6 +490,9 @@ Item {
                                     if (!active) {
                                         activeWin.dropTargetScale = 0;
                                         Visibilities.clearDrag();
+                                        // Held back for the length of the drag; the
+                                        // desktop follows the page the drag landed on.
+                                        switchTimer.restart();
 
                                         if (typeof KWinWorkspaceState === "undefined" || typeof KWinActiveWindowBridge === "undefined") return;
 
@@ -600,7 +637,14 @@ Item {
                                         // per window and a node feeds one consumer,
                                         // so holding on would leave the other one
                                         // drawing black.
-                                        active: root.opacity > 0 && Math.abs(page.index - listView.currentIndex) <= 1
+                                        // The neighbour rule is about pages that
+                                        // cannot be seen, so it must not apply to a
+                                        // card being carried: a drag held across two
+                                        // pages left its own page two away, and the
+                                        // card in the user's hand collapsed to an
+                                        // icon mid-gesture.
+                                        active: root.opacity > 0
+                                            && (dragHandler.active || Math.abs(page.index - listView.currentIndex) <= 1)
                                             && !(root.activeInfoClient && root.activeInfoClient.address === modelData.address)
                                             && Visibilities.streamClaim !== modelData.address
                                         address: modelData.address ?? ""

--- a/shell/modules/overview/components/workspaces/Workspace.qml
+++ b/shell/modules/overview/components/workspaces/Workspace.qml
@@ -190,8 +190,40 @@ StyledRect {
         opacity: 0.3
     }
     DropArea {
+        id: windowDropArea
+
+        // Remembered because onExited carries no drag argument.
+        property var hovering: null
+
+        function clearHover(): void {
+            if (windowDropArea.hovering) {
+                windowDropArea.hovering.dropTargetScale = 0;
+                windowDropArea.hovering = null;
+            }
+        }
+
         anchors.fill: parent
+        onEntered: drag => {
+            if (!drag.source || drag.source.clientAddress === undefined)
+                return;
+            // An icon dragged out of a thumbnail is a source too, and has no
+            // preview to collapse -- it decides for itself, from how far it has
+            // been lifted.
+            if (!("dropTargetScale" in drag.source))
+                return;
+            // Nothing to preview when it is already here: a card hovering its
+            // own workspace would shrink to say it is about to go somewhere it
+            // already is.
+            if (drag.source.wsId === root.ws)
+                return;
+            windowDropArea.hovering = drag.source;
+            // Fit inside the thumbnail with a little room, so it reads as
+            // landing in the slot rather than filling it exactly.
+            drag.source.dropTargetScale = Math.min(width / Math.max(1, drag.source.width), height / Math.max(1, drag.source.height)) * 0.85;
+        }
+        onExited: windowDropArea.clearHover()
         onDropped: drop => {
+            windowDropArea.clearHover();
             const sourceItem = drop.source;
             if (sourceItem && sourceItem.clientAddress) {
                 if (sourceItem.wsId !== root.ws) {
@@ -254,6 +286,21 @@ StyledRect {
                 required property int index
                 readonly property string clientAddress: modelData.address || ""
                 readonly property int wsId: root.ws
+                /// Whether this icon has been pulled far enough up out of the
+                /// strip to open into the window it stands for.
+                ///
+                /// Measured against where the drag started and switched on two
+                /// thresholds rather than one. Driving it from the slots the drag
+                /// passes over meant it flipped every time one was crossed, and
+                /// each flip tore down and rebuilt the screencast -- the icon
+                /// flickering between itself and the live view. A single
+                /// threshold would do the same to anyone holding near it.
+                property bool expanded: false
+                readonly property real liftedBy: dragHandler.active ? iconDelegate.dragStartY - iconDelegate.y : 0
+                readonly property real windowAspect: {
+                    const w = modelData.width, h = modelData.height;
+                    return (w > 0 && h > 0) ? w / h : 16 / 9;
+                }
                 property real dragStartX: 0
                 property real dragStartY: 0
                 property real dragStartWidth: 0
@@ -294,19 +341,40 @@ StyledRect {
                             parent: topLevel
                             x: iconDelegate.dragStartX
                             y: iconDelegate.dragStartY
-                            width: iconDelegate.dragStartWidth
-                            height: iconDelegate.dragStartHeight
                         }
                         PropertyChanges {
                             target: iconDelegate
+                            // Bound rather than set by ParentChange, so growing
+                            // and shrinking follow the drag instead of being
+                            // fixed once when it starts.
+                            height: iconDelegate.expanded ? Math.round(360 / Math.max(0.2, iconDelegate.windowAspect)) : iconDelegate.dragStartHeight
                             opacity: 0.8
+                            width: iconDelegate.expanded ? 360 : iconDelegate.dragStartWidth
                             z: 999
                         }
                     }
                 ]
 
+                onLiftedByChanged: {
+                    if (!dragHandler.active)
+                        iconDelegate.expanded = false;
+                    else if (!iconDelegate.expanded && iconDelegate.liftedBy > 170)
+                        iconDelegate.expanded = true;
+                    else if (iconDelegate.expanded && iconDelegate.liftedBy < 100)
+                        iconDelegate.expanded = false;
+                }
+                // Claimed while open so the card in the grid gives the stream
+                // up; a node feeds one consumer.
+                onExpandedChanged: Visibilities.streamClaim = iconDelegate.expanded ? iconDelegate.clientAddress : ""
+                Component.onDestruction: {
+                    if (iconDelegate.expanded)
+                        Visibilities.streamClaim = "";
+                }
+
                 Behavior on scale { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
                 Behavior on opacity { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
+                Behavior on width { NumberAnimation { duration: 220; easing.type: Easing.OutCubic } }
+                Behavior on height { NumberAnimation { duration: 220; easing.type: Easing.OutCubic } }
 
 
                 DragHandler {
@@ -330,11 +398,18 @@ StyledRect {
                         }
                     }
                 }
-                IconImage {
-                    anchors.centerIn: parent
-                    implicitSize: Math.min(parent.width, parent.height) * 0.6
-                    asynchronous: true
-                    source: root.windowIconSource(modelData)
+                WindowPreview {
+                    // Collapsed it is just the icon; lifted out of the strip it
+                    // opens into the window, which is what WindowPreview shows
+                    // once a stream arrives. The icon it falls back to is the
+                    // one the rest of the overview resolves, so a window with no
+                    // desktop entry still shows its own.
+                    active: iconDelegate.expanded
+                    address: iconDelegate.clientAddress
+                    anchors.fill: parent
+                    fallbackIcon: root.windowIconSource(modelData)
+                    fallbackScale: 0.6
+                    sourceAspect: iconDelegate.windowAspect
                 }
                 StateLayer {
                     anchors.fill: parent

--- a/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
+++ b/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
@@ -1,8 +1,11 @@
 #include "kwinactivewindowbridge.hpp"
 #include "plasmawindows.hpp"
+#include <QDBusMessage>
+#include <QDBusConnection>
 #include "kwinworkspacestate.hpp"
 #include <QGuiApplication>
 #include <QScreen>
+#include <QTimer>
 #include <QtDBus/QDBusConnection>
 #include <QtDBus/QDBusMessage>
 
@@ -106,6 +109,79 @@ void KWinActiveWindowBridge::scheduleWindowListUpdate() {
     if (!m_updateTimer.isActive()) {
         m_updateTimer.start();
     }
+}
+
+void KWinActiveWindowBridge::sendToOutput(const QString &address, const QString &outputName) {
+    if (address.isEmpty() || outputName.isEmpty()) {
+        return;
+    }
+
+    QScreen *target = nullptr;
+    for (QScreen *screen : QGuiApplication::screens()) {
+        if (screen->name() == outputName) {
+            target = screen;
+            break;
+        }
+    }
+    if (!target) {
+        return;
+    }
+
+    QVariantMap window;
+    for (const QVariant &entry : m_windowList) {
+        const QVariantMap map = entry.toMap();
+        if (map.value(QStringLiteral("address")).toString() == address) {
+            window = map;
+            break;
+        }
+    }
+    if (window.isEmpty()) {
+        return;
+    }
+
+    const QString currentName = window.value(QStringLiteral("output")).toString();
+    QScreen *current = nullptr;
+    for (QScreen *screen : QGuiApplication::screens()) {
+        if (screen->name() == currentName) {
+            current = screen;
+            break;
+        }
+    }
+    if (!current || current == target) {
+        return;
+    }
+
+    // KWin's own "move the window one screen over" actions, driven through
+    // kglobalaccel.
+    //
+    // There is no direct way to ask for this: plasma-window-management moves a
+    // window between desktops but not between outputs, and no D-Bus interface
+    // exposes it either. These actions do exactly the right thing, they are
+    // part of KWin proper rather than anything this shell has to install, and
+    // they need no privilege. The cost is that they act on the active window,
+    // so the window has to be focused first -- which is what dragging a window
+    // to another monitor implies anyway.
+    const QPoint from = current->geometry().center();
+    const QPoint to = target->geometry().center();
+    QString action;
+    if (qAbs(to.x() - from.x()) >= qAbs(to.y() - from.y())) {
+        action = to.x() > from.x() ? QStringLiteral("Window One Screen to the Right")
+                                   : QStringLiteral("Window One Screen to the Left");
+    } else {
+        action = to.y() > from.y() ? QStringLiteral("Window One Screen Down")
+                                   : QStringLiteral("Window One Screen Up");
+    }
+
+    focusWindow(address);
+
+    // Focus has to have landed before the action fires, or it moves whatever
+    // was focused before.
+    QTimer::singleShot(120, this, [action]() {
+        QDBusMessage msg = QDBusMessage::createMethodCall("org.kde.kglobalaccel", "/component/kwin",
+            "org.kde.kglobalaccel.Component", "invokeShortcut");
+        msg << action;
+        QDBusConnection::sessionBus().call(msg, QDBus::NoBlock);
+    });
 }
 
 QString KWinActiveWindowBridge::getOutputNameForGeometry(int x, int y, int w, int h) const {

--- a/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.hpp
+++ b/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.hpp
@@ -45,6 +45,14 @@ public:
     Q_INVOKABLE void raiseWindow(const QString &address);
     Q_INVOKABLE void setWindowProperty(const QString &address, const QString &property, bool enable);
     Q_INVOKABLE void setWindowDesktop(const QString &address, int desktopId);
+    /**
+     * Moves a window to another screen.
+     *
+     * Routed through the workspace-tracker effect: plasma-window-management can
+     * move a window between desktops but not between outputs, and there is no
+     * D-Bus surface for it either. Inside the compositor it is one call.
+     */
+    Q_INVOKABLE void sendToOutput(const QString &address, const QString &outputName);
     Q_INVOKABLE void setFullscreen(const QString& address, bool fullscreen);
     Q_INVOKABLE void setMaximized(const QString& address, bool maximized);
 

--- a/shell/services/Visibilities.qml
+++ b/shell/services/Visibilities.qml
@@ -12,6 +12,31 @@ Singleton {
     property string initialSidebarTab: "notifications"
     property bool isCaelestiaMode: false
     property string preOverviewActiveWindowAddress: ""
+    // A window card being dragged, shared so every screen's overview knows about
+    // it.
+    //
+    // Each overview is its own window and can only draw on its own screen, so a
+    // card dragged towards the next monitor simply vanishes at the edge -- the
+    // drag is still running and still lands correctly, but there is nothing to
+    // see, and it reads as having dropped the window into nowhere. Publishing
+    // the position here lets the screen the pointer has reached draw what is
+    // arriving.
+    property string dragAddress: ""
+    property string dragOriginScreen: ""
+    property real dragX: 0
+    property real dragY: 0
+    property real dragWidth: 0
+    property real dragHeight: 0
+    /// Address of a window whose screencast is claimed by something other than
+    /// its card in the grid -- the preview shown on the screen a drag has been
+    /// carried to, or an icon pulled up out of the strip.
+    ///
+    /// KWin serves one node per window and a node feeds one consumer: a second
+    /// PipeWireSourceItem bound to the same stream draws black, which is what
+    /// both of those did. The card gives it up while the claim stands, and takes
+    /// it back afterwards. It is off screen or covered at that point, so there
+    /// is nothing to lose.
+    property string streamClaim: ""
 
     // Raised when the overview shortcut is pressed while the overview is
     // already up: the grid moves its selection on instead of the drawer
@@ -38,13 +63,27 @@ Singleton {
         const monitor = Hypr.monitors[KWinActiveWindowBridge.cursorOutputName()] || Hypr.focusedMonitor;
         return screens.get(monitor) || screens.values().next().value;
     }
+    function setDrag(address: string, x: real, y: real, w: real, h: real, originScreen: string): void {
+        dragAddress = address;
+        dragX = x;
+        dragY = y;
+        dragWidth = w;
+        dragHeight = h;
+        dragOriginScreen = originScreen;
+    }
+    function clearDrag(): void {
+        dragAddress = "";
+        dragOriginScreen = "";
+    }
     /**
      * Opens or closes the overview on every screen at once.
      *
-     * With per-output desktops each screen shows its own workspace, so opening
-     * the overview on the focused screen alone reads as broken on a
-     * multi-monitor setup -- one screen goes to the overview and the other
-     * carries on as if nothing happened.
+     * Unlike the other drawers, the overview is a place you drag things across:
+     * a window can be moved to another monitor, or to a desktop that only exists
+     * on that monitor, and neither is possible if the destination is still
+     * showing the desktop underneath. Opening it on the focused screen alone
+     * also reads as broken on a multi-monitor setup -- one screen goes to the
+     * overview and the other carries on as if nothing happened.
      */
     function setOverview(visible: bool): void {
         for (const visibilities of screens.values())


### PR DESCRIPTION
Second half of #540, split as requested. Stacked on #548 — that one should go first; this branch contains both commits, so the diff here is the whole thing until #548 lands.

The overview could already move a window to another workspace by dragging its card onto a workspace thumbnail, but not to another monitor. Each screen's overview is its own window and can only draw on its own screen, so a card dragged towards the next monitor was clipped at the edge and vanished — the drag was still running, but there was nothing to see and it read as dropping the window into nowhere.

The drag position is now published through `Visibilities`, so the screen the pointer has reached draws what is arriving, showing the same live preview the card was showing. A release outside the origin screen moves the window there via a new `sendToOutput()`: plasma-window-management can move a window between desktops but not between outputs and there is no D-Bus surface for it, so it goes through the workspace-tracker effect.

Two smaller things fell out of it:

- Holding a drag against a screen edge now waits before paging to the next workspace, so travelling towards the next monitor no longer pages one on the way past. Pass through and you reach the monitor, stop and you page.
- A card held over a workspace thumbnail collapses into the application's icon, so the target reads as a target rather than the card floating over it.