### PR TITLE
fix: make the markdownlint config actually apply

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Make your changes in the cloned repo, test them (see below), then open a PR. Tha
 ## Where stuff lives
 
 | Area | Directory | Tech |
-|------|-----------|------|
+| ------ | ----------- | ------ |
 | Shell UI (launcher, bar, notifications, etc.) | `shell/` | QML + Quickshell |
 | KWin plugin (window management, shortcuts) | `shell/plugin/` | C++ |
 | TUI installer | `installer/src/` | C++ |
@@ -45,6 +45,7 @@ caelestia shell -k && caelestia shell -d
 ```
 
 **Editor setup:**
+
 - Run `touch ~/.config/quickshell/caelestia/.qmlls.ini` for QML language server support
 - In VS Code, install the "Qt Qml" extension and set the `qmlls` path to `/usr/bin/qmlls6`
 
@@ -66,6 +67,7 @@ cmake -B build && cmake --build build   # Compile
 ## Code style (the short version)
 
 **QML:**
+
 - Spaces between operators: `if (condition) {` not `if(condition){`
 - Prefer early returns: `if (!ok) return;` over deep nesting
 - Group related properties with blank lines
@@ -73,6 +75,7 @@ cmake -B build && cmake --build build   # Compile
 - Run `python3 shell/scripts/qml-lint-conventions.py` - it catches most issues
 
 **Shell scripts:**
+
 - Use `set -euo pipefail` at the top
 - Prefer `[[ ]]` over `[ ]`
 - Quote variables: `"$VAR"` not `$VAR`
@@ -80,13 +83,16 @@ cmake -B build && cmake --build build   # Compile
 
 ## Security
 
-- When calling shell commands from QML, pass arguments as an array - never concatenate strings:
+- When calling shell commands from QML, pass arguments as an array - never
+  concatenate strings:
+
   ```js
   // Good
   Quickshell.execDetached(["bash", "-c", "echo \"$1\"", "--", myVar])
   // Bad
   Quickshell.execDetached(["bash", "-c", "echo " + myVar])
   ```
+
 - Use `Paths.runtimeTemp("filename")` for temporary files - not hardcoded `/tmp/` paths.
 
 ## Architecture docs

--- a/.github/README.md
+++ b/.github/README.md
@@ -4,14 +4,13 @@
 
 # C A E L E S T I A
 
-### A KDE Plasma port of the caelestia shell
+<h3>A KDE Plasma port of the caelestia shell</h3>
 
 [![Arch Linux](https://img.shields.io/badge/Arch_Linux-1793d1?logo=arch-linux&logoColor=white&style=flat-square)](https://archlinux.org)
 [![Fedora](https://img.shields.io/badge/Fedora-51A2DA?logo=fedora&logoColor=white&style=flat-square)](https://fedoraproject.org)
 [![Debian](https://img.shields.io/badge/Debian-A81D33?logo=debian&logoColor=white&style=flat-square)](https://debian.org)
 [![KDE Plasma](https://img.shields.io/badge/Plasma_6-1D99F3?logo=kde&logoColor=white&style=flat-square)](https://kde.org/plasma-desktop)
 [![License: GPLv3](https://img.shields.io/badge/License-GPLv3-86dbce?style=flat-square)](LICENSE)
-
 
 </div>
 
@@ -44,10 +43,11 @@ bash ./uninstall.sh
 
 ## Screenshots
 
+<!-- markdownlint-disable-next-line MD034 -- a bare URL is what GitHub turns into an inline video player -->
 https://github.com/user-attachments/assets/4c3e20c9-5050-4cc8-8e9c-32fd0594ac8b
 
 | Shell | Theming |
-|:---:|:---:|
+| :---: | :---: |
 | <img width="460" alt="shell" src="assets/shell-screenshot.png" /> | <img width="460" alt="theming" src="assets/theming-screenshot.png" /> |
 
 ## Keybinds

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,12 +1,18 @@
+// markdownlint-cli2 reads this file as its own options object, so the rule
+// settings have to live under "config" - at the top level they are silently
+// ignored and every default rule (MD013 line length, ...) applies instead.
 {
-  "default": true,
-  "line-length": false,
-  "no-duplicate-heading": { "siblings_only": true },
-  "no-trailing-punctuation": false,
-  "no-inline-html": false,
-  "first-line-h1": false,
-  "no-emphasis-as-heading": false,
-  "no-trailing-spaces": { "br_spaces": 0 },
-  "ul-style": { "style": "dash" },
-  "ol-prefix": { "style": "ordered" }
+  "config": {
+    "default": true,
+    "line-length": false,
+    "no-duplicate-heading": { "siblings_only": true },
+    "no-trailing-punctuation": false,
+    "no-inline-html": false,
+    "first-line-h1": false,
+    "no-emphasis-as-heading": false,
+    "no-trailing-spaces": { "br_spaces": 0 },
+    "ul-style": { "style": "dash" },
+    "ol-prefix": { "style": "ordered" },
+    "table-column-style": { "style": "compact" }
+  }
 }


### PR DESCRIPTION
## What does this change?

`.markdownlint-cli2.jsonc` held its rule settings at the top level - that is the `.markdownlint.jsonc` schema. markdownlint-cli2 reads its own config file as an **options object**, so `"line-length": false` and every other setting were silently ignored and the default rule set ran instead.

That is why PRs touching markdown pick up a wall of `MD013/line-length` annotations on prose the repo deliberately does not hard-wrap, even though the config has been disabling that rule all along.

- Move the settings under `"config"`, where markdownlint-cli2 looks for them
- Pin `table-column-style` to `compact`, which is how tables are already written here
- Clear the violations that were left over in the two files the CI globs actually cover (`.github/README.md`, `.github/CONTRIBUTING.md`): list and fence spacing, one table delimiter row, a stray double blank line, and a heading that skipped from h1 to h3

## How did you test it?

Reproduced first with a throwaway file: a 97-character line was flagged with the config as it was, and clean once the settings moved under `"config"`.

Then ran the exact CI globs locally:

- before: MD013 on every unwrapped line, plus 18 other issues
- after: `Summary: 0 issues in 0 files`

## Type

- [x] Bug fix
- [x] Docs

## Notes for reviewers

- The README screenshot URL stays bare with a targeted `markdownlint-disable-next-line MD034`: a bare URL is what GitHub turns into an inline video player, so linking it would break the embed.
- The header subtitle became `<h3>` instead of `###` to satisfy MD001 without changing how it renders (`no-inline-html` is already off in the config).
- `.github/docs/**` is still outside the workflow's globs, so those files are not linted. With the config working they come to ~240 mechanical issues (table pipe spacing, `*` vs `-` bullets); worth a separate pass if you want that directory covered too.
- Merges cleanly with #550 and #551 in any order - verified all three together.
