### PR TITLE
fix: stop the shell's audio capture from getting in other apps' way

### DIFF
--- a/shell/modules/nexus/pages/ServicesPage.qml
+++ b/shell/modules/nexus/pages/ServicesPage.qml
@@ -218,6 +218,13 @@ PageBase {
             onClicked: root.nState.openSubPage(1)
         }
 
+        ToggleRow {
+            text: qsTr("Audio capture")
+            subtext: qsTr("Needed by the visualisers. Turn off if screen sharing or a camera stalls while the shell is running")
+            checked: GlobalConfig.services.audioCapture
+            onToggled: GlobalConfig.services.audioCapture = checked
+        }
+
         StepperRow {
             label: qsTr("Visualiser bars")
             subtext: qsTr("Number of bars in the audio visualisers")

--- a/shell/plugin/src/Caelestia/Config/serviceconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/serviceconfig.hpp
@@ -26,6 +26,13 @@ class ServiceConfig : public ConfigObject {
         bool, useTwelveHourClock, QLocale().timeFormat(QLocale::ShortFormat).toLower().contains(u"a"_s))
     CONFIG_GLOBAL_PROPERTY(QString, gpuType)
     CONFIG_GLOBAL_PROPERTY(int, visualiserBars, 60)
+    // The visualisers and the beat tracker feed off a PipeWire capture of the
+    // sink monitor, which the shell otherwise holds open for as long as
+    // something is drawing them. Some setups cannot share that capture: the
+    // screen shares and camera captures in issue #402 stall while the shell
+    // holds one. Turning this off keeps the shell out of the audio graph
+    // entirely, at the cost of the visualisers.
+    CONFIG_GLOBAL_PROPERTY(bool, audioCapture, true)
     CONFIG_GLOBAL_PROPERTY(qreal, audioIncrement, 0.1)
     CONFIG_GLOBAL_PROPERTY(qreal, brightnessIncrement, 0.1)
     CONFIG_GLOBAL_PROPERTY(qreal, maxVolume, 1.0)

--- a/shell/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/shell/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -8,6 +8,8 @@
 #include <spa/param/audio/format-utils.h>
 #include <spa/param/latency-utils.h>
 #include <stop_token>
+#include <qelapsedtimer.h>
+#include <qtimer.h>
 #include <vector>
 
 Q_LOGGING_CATEGORY(lcAc, "caelestia.services.ac", QtInfoMsg)
@@ -240,23 +242,76 @@ AudioCollector::~AudioCollector() {
     AudioCollector::stop();
 }
 
+namespace {
+
+// A capture that dies because the graph moved under it - another client taking
+// over the monitor, the default sink disappearing - should come back. A capture
+// that dies because it cannot work here must not turn into a reconnect loop:
+// hammering the daemon is the failure mode that hurts every other client on it.
+constexpr int maxRestarts = 3;
+constexpr int restartDelayMs = 2000;
+// A capture that held up this long was working; a later failure is a new
+// problem, not a continuation of the one the retry budget is there for.
+constexpr int healthyRunMs = 30000;
+
+} // namespace
+
 void AudioCollector::start() {
-    if (m_thread.joinable()) {
+    if (m_workerRunning.load(std::memory_order_acquire)) {
         return;
     }
 
-    clearBuffer();
-
-    m_thread = std::jthread([this](std::stop_token token) {
-        PipeWireWorker worker(token, this);
-    });
-}
-
-void AudioCollector::stop() {
+    // Reap a worker that already returned; jthread stays joinable until it is
+    // joined, so without this a single stream error would leave the collector
+    // permanently unable to start again.
     if (m_thread.joinable()) {
         m_thread.request_stop();
         m_thread.join();
     }
+
+    clearBuffer();
+
+    m_workerRunning.store(true, std::memory_order_release);
+    m_ran.start();
+    m_thread = std::jthread([this](std::stop_token token) {
+        PipeWireWorker worker(token, this);
+        m_workerRunning.store(false, std::memory_order_release);
+        QMetaObject::invokeMethod(this, [this]() { onWorkerFinished(); }, Qt::QueuedConnection);
+    });
+}
+
+void AudioCollector::stop() {
+    m_restarts = 0;
+    if (m_thread.joinable()) {
+        m_thread.request_stop();
+        m_thread.join();
+    }
+    m_workerRunning.store(false, std::memory_order_release);
+}
+
+void AudioCollector::onWorkerFinished() {
+    // Only an unexpected exit is worth retrying; stop() joins the thread itself
+    // and clears the reference count first.
+    if (!referenced() || m_workerRunning.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    if (m_ran.isValid() && m_ran.elapsed() >= healthyRunMs) {
+        m_restarts = 0;
+    }
+
+    if (m_restarts >= maxRestarts) {
+        qCWarning(lcAc) << "worker exited" << m_restarts << "times, giving up until something references it again";
+        return;
+    }
+
+    m_restarts++;
+    qCInfo(lcAc) << "capture stream ended unexpectedly, restarting in" << restartDelayMs << "ms";
+    QTimer::singleShot(restartDelayMs, this, [this]() {
+        if (referenced()) {
+            start();
+        }
+    });
 }
 
 } // namespace caelestia::services

--- a/shell/plugin/src/Caelestia/Services/audiocollector.hpp
+++ b/shell/plugin/src/Caelestia/Services/audiocollector.hpp
@@ -8,6 +8,8 @@
 #include <spa/param/audio/format-utils.h>
 #include <stop_token>
 #include <thread>
+#include <qelapsedtimer.h>
+#include <qtimer.h>
 #include <vector>
 
 namespace caelestia::services {
@@ -62,6 +64,12 @@ private:
     ~AudioCollector();
 
     std::jthread m_thread;
+    // The worker sets this false on its way out. std::jthread stays joinable
+    // after its function returns, so the thread object alone cannot tell a
+    // running capture from one that died on a PipeWire error.
+    std::atomic<bool> m_workerRunning{ false };
+    int m_restarts = 0;
+    QElapsedTimer m_ran;
     std::vector<float> m_buffer1;
     std::vector<float> m_buffer2;
     std::atomic<std::vector<float>*> m_readBuffer;
@@ -70,6 +78,8 @@ private:
     void reload();
     void start() override;
     void stop() override;
+
+    void onWorkerFinished();
 };
 
 } // namespace caelestia::services

--- a/shell/plugin/src/Caelestia/Services/service.cpp
+++ b/shell/plugin/src/Caelestia/Services/service.cpp
@@ -8,7 +8,7 @@ Service::Service(QObject* parent)
     : QObject(parent) {}
 
 void Service::ref(QObject* sender) {
-    if (m_refs.isEmpty()) {
+    if (m_refs.isEmpty() && m_enabled) {
         start();
     }
 
@@ -17,9 +17,36 @@ void Service::ref(QObject* sender) {
 }
 
 void Service::unref(QObject* sender) {
-    if (m_refs.remove(sender) && m_refs.isEmpty()) {
+    if (m_refs.remove(sender) && m_refs.isEmpty() && m_enabled) {
         stop();
     }
+}
+
+bool Service::enabled() const {
+    return m_enabled;
+}
+
+void Service::setEnabled(bool enabled) {
+    if (m_enabled == enabled) {
+        return;
+    }
+
+    m_enabled = enabled;
+    emit enabledChanged();
+
+    if (m_refs.isEmpty()) {
+        return;
+    }
+
+    if (m_enabled) {
+        start();
+    } else {
+        stop();
+    }
+}
+
+bool Service::referenced() const {
+    return !m_refs.isEmpty() && m_enabled;
 }
 
 } // namespace caelestia::services

--- a/shell/plugin/src/Caelestia/Services/service.hpp
+++ b/shell/plugin/src/Caelestia/Services/service.hpp
@@ -1,12 +1,20 @@
 #pragma once
 
 #include <qobject.h>
+#include <qqmlintegration.h>
 #include <qset.h>
 
 namespace caelestia::services {
 
 class Service : public QObject {
     Q_OBJECT
+    QML_ANONYMOUS
+
+    // Whether this service may run at all. A disabled service holds no
+    // resources even while consumers are referencing it, and picks up again
+    // when it is re-enabled - which is how the audio capture is turned off
+    // without every consumer having to know about the setting.
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
 
 public:
     explicit Service(QObject* parent = nullptr);
@@ -14,8 +22,18 @@ public:
     void ref(QObject* sender);
     void unref(QObject* sender);
 
+    [[nodiscard]] bool enabled() const;
+    void setEnabled(bool enabled);
+
+signals:
+    void enabledChanged();
+
+protected:
+    [[nodiscard]] bool referenced() const;
+
 private:
     QSet<QObject*> m_refs;
+    bool m_enabled = true;
 
     virtual void start() = 0;
     virtual void stop() = 0;

--- a/shell/services/Audio.qml
+++ b/shell/services/Audio.qml
@@ -30,6 +30,15 @@ Singleton {
     readonly property PwNode sink: Pipewire.defaultAudioSink
     readonly property PwNode source: Pipewire.defaultAudioSource
 
+    // The default node object is replaced whenever the graph moves - another
+    // client adding a stream is enough - and a replacement arrives before its
+    // description does. Reacting to the object meant announcing a device change
+    // that never happened, sometimes as "Now using: Unknown Device", every time
+    // something like OBS started (issue #402). Track the device's own name
+    // instead, and say nothing until it is actually known.
+    readonly property string sinkId: sink?.ready ? (sink.name ?? "") : ""
+    readonly property string sourceId: source?.ready ? (source.name ?? "") : ""
+
     readonly property bool muted: !!sink?.audio?.muted
     readonly property real volume: sink?.audio?.volume ?? 0
 
@@ -260,11 +269,11 @@ Singleton {
         root.streams = newStreams;
     }
 
-    onSinkChanged: {
-        if (!sink?.ready)
+    onSinkIdChanged: {
+        if (!sinkId)
             return;
 
-        const newSinkName = sink.description || sink.name || qsTr("Unknown Device");
+        const newSinkName = sink.description || sink.name;
 
         if (previousSinkName && previousSinkName !== newSinkName && GlobalConfig.utilities.toasts.audioOutputChanged)
             Toaster.toast(qsTr("Audio output changed"), qsTr("Now using: %1").arg(newSinkName), "volume_up");
@@ -272,11 +281,11 @@ Singleton {
         previousSinkName = newSinkName;
     }
 
-    onSourceChanged: {
-        if (!source?.ready)
+    onSourceIdChanged: {
+        if (!sourceId)
             return;
 
-        const newSourceName = source.description || source.name || qsTr("Unknown Device");
+        const newSourceName = source.description || source.name;
 
         if (previousSourceName && previousSourceName !== newSourceName && GlobalConfig.utilities.toasts.audioInputChanged)
             Toaster.toast(qsTr("Audio input changed"), qsTr("Now using: %1").arg(newSourceName), "mic");
@@ -288,8 +297,11 @@ Singleton {
     // lazily-loaded singleton is created, so onValuesChanged would never fire.
     Component.onCompleted: {
         refreshNodes();
-        previousSinkName = sink?.description || sink?.name || qsTr("Unknown Device");
-        previousSourceName = source?.description || source?.name || qsTr("Unknown Device");
+        // Seed only from a device that is actually known. A placeholder here
+        // would read as the previous device and announce a change the moment
+        // the real name arrived.
+        previousSinkName = sinkId ? (sink.description || sink.name) : "";
+        previousSourceName = sourceId ? (source.description || source.name) : "";
 
         // CavaProvider is only registered when the plugin was built with
         // libcava available (see shell/plugin/CMakeLists.txt); create it
@@ -319,6 +331,18 @@ Singleton {
 
     BeatTracker {
         id: beatTracker
+
+        // Both providers feed off the same PipeWire capture of the sink
+        // monitor. Disabling them here is what releases it: consumers keep
+        // their references and their bindings, the capture simply stops.
+        enabled: GlobalConfig.services.audioCapture
+    }
+
+    Binding {
+        when: !!root.cava
+        target: root.cava
+        property: "enabled"
+        value: GlobalConfig.services.audioCapture
     }
 
 


### PR DESCRIPTION
Towards #402.

## What does this change?

The screencast half of #402 already got a switch and a stream cap. The audio half had neither, and the most recent report in the thread is an audio one: @Lycham's OBS cannot capture, and starting or closing it makes the shell announce that the microphone and speaker changed when nothing did.

Verified on a running session with `pw-dump`: the shell holds a PipeWire capture of the sink monitor (`stream.capture.sink=true`, `node.passive=true`, state `running`) for as long as anything draws a visualiser - and `background.visualiser.enabled` defaults to true, so on a normal session that is always. Spectacle, which captures no audio, is unaffected; that matches what the thread reports.

- **`services.audioCapture` (default on), with a toggle in Services settings.** Off means the shell holds no capture stream at all - the audio-graph equivalent of `bar.livePreviews`. Users hitting this now have a supported way out instead of turning off the whole visualiser and hoping.
- **`Service` gains an `enabled` gate**, so the switch releases the stream without every consumer having to know about the setting: references and bindings stay exactly as they are, the capture just stops.
- **`AudioCollector` can restart after a PipeWire error.** `std::jthread` stays joinable once its function returns, so the `joinable()` check in `start()` meant a single `PW_STREAM_STATE_ERROR` - exactly what another client taking the monitor or the default sink disappearing causes - left the capture dead for the rest of the session. Restarts are budgeted (3, 2s apart, reset after 30s of healthy capture) so a capture that cannot work never turns into a reconnect loop on the daemon.
- **No more phantom device-change toasts.** The default node object is replaced whenever the graph moves, and its `description` arrives after the object does, so reacting to the object announced a change - sometimes as "Now using: Unknown Device" - every time something like OBS started. It now tracks the device's own name and says nothing until that is known, including at startup where the placeholder used to seed a change on the first real name.

## How did you test it?

Built the plugin clean, then drove the provider standalone with `qml` while counting sink-monitor captures in `pw-dump`:

| case | capture nodes |
|---|---|
| baseline (shell only) | 2 |
| `enabled: true` + `ServiceRef` | 3 |
| `enabled: false` + `ServiceRef` | 2 |
| toggled true -> false at runtime | 3 -> 2 |
| after the test app exits | 2 |

So the switch really does release the stream, at startup and at runtime, and the reference counting still tears it down cleanly.

`check_qml_syntax.py`, `check_qml_conventions.py` (no new violations), `check_qml_imports.py`, `check_config_references.py` and `test_repo_integrity.py` all pass.

## Type

- [x] Bug fix

## Notes for reviewers

- I could not reproduce the Vesktop freeze itself here, so I have not claimed this closes #402 - it removes the shell from the audio graph on demand, fixes the toasts @Lycham reported, and stops a stream error from silently killing the capture. If a reporter confirms the toggle clears it, that also confirms the audio capture is the remaining half.
- The retry budget is deliberately small. An unbounded reconnect is the failure mode that would hurt every other client on the daemon, which is the opposite of what this issue needs.
- `services.audioCapture` is on by default, so nothing changes for anyone not hitting this.
