### PR TITLE
feat(bar): make active-window greeting images configurable

### DIFF
--- a/shell/modules/bar/popouts/ActiveWindow.qml
+++ b/shell/modules/bar/popouts/ActiveWindow.qml
@@ -15,12 +15,21 @@ Item {
     implicitWidth: child.implicitWidth
     implicitHeight: child.implicitHeight
 
+    // Resolve a user-configured greeting image, falling back to the bundled
+    // default for the current time of day when the setting is empty.
+    function resolveGif(custom, fallback) {
+        if (custom && custom.length > 0)
+            return custom.startsWith("/") ? "file://" + custom : custom;
+        return Qt.resolvedUrl(fallback);
+    }
+
     readonly property string gifPath: {
         const hr = new Date().getHours();
-        if (hr >= 5 && hr < 12) return Qt.resolvedUrl("../../../assets/morning.gif");
-        if (hr >= 12 && hr < 17) return Qt.resolvedUrl("../../../assets/afternoon.gif");
-        if (hr >= 17 && hr < 20) return Qt.resolvedUrl("../../../assets/evening.gif");
-        return Qt.resolvedUrl("../../../assets/night.gif");
+        const aw = GlobalConfig.bar.activeWindow;
+        if (hr >= 5 && hr < 12) return resolveGif(aw.morningGif, "../../../assets/morning.gif");
+        if (hr >= 12 && hr < 17) return resolveGif(aw.afternoonGif, "../../../assets/afternoon.gif");
+        if (hr >= 17 && hr < 20) return resolveGif(aw.eveningGif, "../../../assets/evening.gif");
+        return resolveGif(aw.nightGif, "../../../assets/night.gif");
     }
 
     readonly property real masterScale: !isNaN(GlobalConfig.bar.previewScale) ? GlobalConfig.bar.previewScale : 1.0

--- a/shell/modules/nexus/pages/panels/taskbar/BarActiveWindow.qml
+++ b/shell/modules/nexus/pages/panels/taskbar/BarActiveWindow.qml
@@ -1,7 +1,12 @@
 pragma ComponentBehavior: Bound
 
+import QtQuick
 import QtQuick.Layouts
 import Caelestia.Config
+import qs.components
+import qs.components.filedialog
+import qs.services
+import qs.utils
 import qs.modules.nexus.common
 
 PageBase {
@@ -66,11 +71,73 @@ PageBase {
         }
 
         ToggleRow {
-            last: true
             text: qsTr("Popout on hover")
             subtext: qsTr("Show a window details popout when hovering")
             checked: Config.bar.popouts.activeWindow
             onToggled: GlobalConfig.bar.popouts.activeWindow = checked
+        }
+
+        SectionHeader {
+            text: qsTr("Greeting images")
+        }
+
+        StyledText {
+            Layout.fillWidth: true
+            Layout.leftMargin: Tokens.padding.largeIncreased
+            Layout.rightMargin: Tokens.padding.largeIncreased
+            Layout.bottomMargin: Tokens.spacing.extraSmall
+            text: qsTr("Shown in the active-window popout when no window is focused. A different image is used for each time of day; leave empty to use the bundled default.")
+            font: Tokens.font.label.small
+            color: Colours.palette.m3onSurfaceVariant
+            wrapMode: Text.WordWrap
+        }
+
+        // One picker row per time-of-day slot.
+        Repeater {
+            model: [
+                { key: "morningGif", label: qsTr("Morning image"), hint: qsTr("Shown 05:00–12:00") },
+                { key: "afternoonGif", label: qsTr("Afternoon image"), hint: qsTr("Shown 12:00–17:00") },
+                { key: "eveningGif", label: qsTr("Evening image"), hint: qsTr("Shown 17:00–20:00") },
+                { key: "nightGif", label: qsTr("Night image"), hint: qsTr("Shown 20:00–05:00") }
+            ]
+
+            ColumnLayout {
+                id: slot
+
+                required property int index
+                required property var modelData
+                readonly property string currentValue: Config.bar.activeWindow[modelData.key] ?? ""
+
+                Layout.fillWidth: true
+                spacing: 0
+
+                NavRow {
+                    first: slot.index === 0
+                    last: slot.currentValue === ""
+                    icon: "image"
+                    label: slot.modelData.label
+                    status: slot.currentValue !== "" ? slot.currentValue : slot.modelData.hint
+                    onClicked: gifDialog.open()
+
+                    FileDialog {
+                        id: gifDialog
+
+                        title: qsTr("Select a greeting image")
+                        filterLabel: qsTr("Image files")
+                        filters: Images.validImageExtensions
+                        onAccepted: path => GlobalConfig.bar.activeWindow[slot.modelData.key] = path
+                    }
+                }
+
+                // Reset-to-default row, only while a custom image is set.
+                NavRow {
+                    visible: slot.currentValue !== ""
+                    last: true
+                    icon: "restart_alt"
+                    label: qsTr("Reset to default")
+                    onClicked: GlobalConfig.bar.activeWindow[slot.modelData.key] = ""
+                }
+            }
         }
     }
 }

--- a/shell/modules/nexus/pages/panels/taskbar/BarActiveWindow.qml
+++ b/shell/modules/nexus/pages/panels/taskbar/BarActiveWindow.qml
@@ -2,6 +2,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Layouts
+import Quickshell
 import Caelestia.Config
 import qs.components
 import qs.components.filedialog
@@ -85,39 +86,117 @@ PageBase {
             Layout.fillWidth: true
             Layout.leftMargin: Tokens.padding.largeIncreased
             Layout.rightMargin: Tokens.padding.largeIncreased
-            Layout.bottomMargin: Tokens.spacing.extraSmall
-            text: qsTr("Shown in the active-window popout when no window is focused. A different image is used for each time of day; leave empty to use the bundled default.")
+            Layout.bottomMargin: Tokens.spacing.small
+            text: qsTr("Shown in the active-window popout when no window is focused. Tap a card to pick your own image for that time of day.")
             font: Tokens.font.label.small
             color: Colours.palette.m3onSurfaceVariant
             wrapMode: Text.WordWrap
         }
 
-        // One picker row per time-of-day slot.
-        Repeater {
-            model: [
-                { key: "morningGif", label: qsTr("Morning image"), hint: qsTr("Shown 05:00–12:00") },
-                { key: "afternoonGif", label: qsTr("Afternoon image"), hint: qsTr("Shown 12:00–17:00") },
-                { key: "eveningGif", label: qsTr("Evening image"), hint: qsTr("Shown 17:00–20:00") },
-                { key: "nightGif", label: qsTr("Night image"), hint: qsTr("Shown 20:00–05:00") }
-            ]
+        // Live-preview cards, two per row. Tap a card to pick an image.
+        GridLayout {
+            Layout.fillWidth: true
+            Layout.leftMargin: Tokens.padding.small
+            Layout.rightMargin: Tokens.padding.small
+            columns: 2
+            columnSpacing: Tokens.spacing.small
+            rowSpacing: Tokens.spacing.small
 
-            ColumnLayout {
-                id: slot
+            Repeater {
+                model: [
+                    { key: "morningGif", label: qsTr("Morning"), hint: "05:00 – 12:00", fallback: "morning.gif" },
+                    { key: "afternoonGif", label: qsTr("Afternoon"), hint: "12:00 – 17:00", fallback: "afternoon.gif" },
+                    { key: "eveningGif", label: qsTr("Evening"), hint: "17:00 – 20:00", fallback: "evening.gif" },
+                    { key: "nightGif", label: qsTr("Night"), hint: "20:00 – 05:00", fallback: "night.gif" }
+                ]
 
-                required property int index
-                required property var modelData
-                readonly property string currentValue: Config.bar.activeWindow[modelData.key] ?? ""
+                StyledClippingRect {
+                    id: card
 
-                Layout.fillWidth: true
-                spacing: 0
+                    required property int index
+                    required property var modelData
+                    readonly property string currentValue: Config.bar.activeWindow[modelData.key] ?? ""
+                    readonly property bool isCustom: currentValue !== ""
+                    readonly property string previewSource: isCustom
+                        ? (currentValue.startsWith("/") ? "file://" + currentValue : currentValue)
+                        : `${Quickshell.shellDir}/assets/${modelData.fallback}`
 
-                NavRow {
-                    first: slot.index === 0
-                    last: slot.currentValue === ""
-                    icon: "image"
-                    label: slot.modelData.label
-                    status: slot.currentValue !== "" ? slot.currentValue : slot.modelData.hint
-                    onClicked: gifDialog.open()
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: width * 0.62
+                    radius: Tokens.rounding.large
+                    color: Colours.palette.m3surfaceContainerHigh
+
+                    AnimatedImage {
+                        anchors.fill: parent
+                        source: card.previewSource
+                        fillMode: Image.PreserveAspectCrop
+                        cache: false
+                        asynchronous: true
+                        playing: true
+                    }
+
+                    // Bottom gradient so the label stays readable over any image.
+                    Rectangle {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        height: parent.height * 0.5
+                        gradient: Gradient {
+                            GradientStop { position: 0.0; color: "transparent" }
+                            GradientStop { position: 1.0; color: Qt.alpha(Colours.palette.m3scrim, 0.75) }
+                        }
+                    }
+
+                    ColumnLayout {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        anchors.margins: Tokens.padding.medium
+                        spacing: 0
+
+                        StyledText {
+                            text: card.modelData.label
+                            font: Tokens.font.body.small
+                            color: "white"
+                        }
+
+                        StyledText {
+                            text: card.isCustom ? qsTr("Custom image") : card.modelData.hint
+                            font: Tokens.font.label.small
+                            color: Qt.alpha("white", 0.7)
+                        }
+                    }
+
+                    // Reset badge, top-right, only while a custom image is set.
+                    StyledClippingRect {
+                        anchors.top: parent.top
+                        anchors.right: parent.right
+                        anchors.margins: Tokens.padding.small
+                        visible: card.isCustom
+                        implicitWidth: resetIcon.implicitWidth + Tokens.padding.small * 2
+                        implicitHeight: resetIcon.implicitHeight + Tokens.padding.small * 2
+                        radius: Tokens.rounding.full
+                        color: Qt.alpha(Colours.palette.m3scrim, 0.55)
+
+                        MaterialIcon {
+                            id: resetIcon
+                            anchors.centerIn: parent
+                            text: "restart_alt"
+                            color: "white"
+                            fontStyle: Tokens.font.icon.small
+                        }
+
+                        StateLayer {
+                            radius: parent.radius
+                            onClicked: GlobalConfig.bar.activeWindow[card.modelData.key] = ""
+                        }
+                    }
+
+                    // Whole-card tap opens the picker.
+                    StateLayer {
+                        radius: card.radius
+                        onClicked: gifDialog.open()
+                    }
 
                     FileDialog {
                         id: gifDialog
@@ -125,17 +204,8 @@ PageBase {
                         title: qsTr("Select a greeting image")
                         filterLabel: qsTr("Image files")
                         filters: Images.validImageExtensions
-                        onAccepted: path => GlobalConfig.bar.activeWindow[slot.modelData.key] = path
+                        onAccepted: path => GlobalConfig.bar.activeWindow[card.modelData.key] = path
                     }
-                }
-
-                // Reset-to-default row, only while a custom image is set.
-                NavRow {
-                    visible: slot.currentValue !== ""
-                    last: true
-                    icon: "restart_alt"
-                    label: qsTr("Reset to default")
-                    onClicked: GlobalConfig.bar.activeWindow[slot.modelData.key] = ""
                 }
             }
         }

--- a/shell/plugin/src/Caelestia/Config/barconfig.hpp
+++ b/shell/plugin/src/Caelestia/Config/barconfig.hpp
@@ -74,6 +74,12 @@ class BarActiveWindow : public ConfigObject {
     CONFIG_PROPERTY(bool, compact, false)
     CONFIG_PROPERTY(bool, inverted, false)
     CONFIG_PROPERTY(bool, showOnHover, true)
+    // Custom greeting preview images shown in the active-window popout when no
+    // window is focused. Empty = use the bundled default for that time of day.
+    CONFIG_GLOBAL_PROPERTY(QString, morningGif, u""_s)
+    CONFIG_GLOBAL_PROPERTY(QString, afternoonGif, u""_s)
+    CONFIG_GLOBAL_PROPERTY(QString, eveningGif, u""_s)
+    CONFIG_GLOBAL_PROPERTY(QString, nightGif, u""_s)
 
 public:
     explicit BarActiveWindow(QObject* parent = nullptr)


### PR DESCRIPTION
## Summary

The active-window popout shows a time-of-day greeting image when no window is focused. Those four images (morning / afternoon / evening / night) are currently **hardcoded** to the bundled assets in `popouts/ActiveWindow.qml`, so the only way to change them is to overwrite the shipped `.gif` files in place.

This PR makes them **configurable from a modern, live-preview picker** under **Panels → Taskbar → Active window → "Greeting images"**.

## What it looks like

A 2-column grid of preview cards, one per time-of-day slot. Each card:
- renders the **current image as a live `AnimatedImage`** (the user's custom one, or the bundled default resolved via `Quickshell.shellDir`),
- shows the slot name + time range (or "Custom image") over a bottom scrim so it stays readable on any image,
- **opens the image picker when tapped**,
- gets a small **reset badge** (top-right) while a custom image is set, which clears it back to the bundled default.

## What changed

**1. Config schema — `plugin/src/Caelestia/Config/barconfig.hpp`**
Four new global string properties on `BarActiveWindow`:
```cpp
CONFIG_GLOBAL_PROPERTY(QString, morningGif,   u""_s)
CONFIG_GLOBAL_PROPERTY(QString, afternoonGif, u""_s)
CONFIG_GLOBAL_PROPERTY(QString, eveningGif,   u""_s)
CONFIG_GLOBAL_PROPERTY(QString, nightGif,     u""_s)
```
Empty (the default) means "use the bundled asset", so behaviour is unchanged out of the box.

**2. Resolution — `modules/bar/popouts/ActiveWindow.qml`**
`gifPath` now resolves the configured image for the current slot and falls back to the bundled default when unset. A small `resolveGif()` helper prefixes local paths with `file://`; the existing `Qt.resolvedUrl(...)` defaults are untouched.

**3. Settings UI — `modules/nexus/pages/panels/taskbar/BarActiveWindow.qml`**
The new "Greeting images" section: a `GridLayout` of preview cards built on the existing `StyledClippingRect` / `StateLayer` / `FileDialog` components, reusing the same file-picker approach as the launcher's custom-logo option.

## Backward compatibility

Fully additive — with no config the shipped GIFs are used exactly as before; the new properties just default to empty.

## Testing

On CachyOS / KDE Plasma 6.7.4 / Quickshell 0.3.1:
- The C++ config plugin builds cleanly (no new warnings from this change).
- The shell loads the new settings page with **no QML errors**.
- Verified the config round-trip: a value written to `bar.activeWindow.afternoonGif` is read back through `GlobalConfig.bar.activeWindow.afternoonGif` and resolved both by the popout's `gifPath` and by the preview card's `AnimatedImage`; unset slots stay empty and fall back to the bundled default.

## Note

Branches from `main` and is independent of my i18n PR (#589) — all strings here are plain `qsTr(...)`, so it can be reviewed and merged on its own.
