### PR TITLE
fix: land a window on the desktop the target monitor is showing

### DIFF
--- a/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
+++ b/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
@@ -182,6 +182,31 @@ void KWinActiveWindowBridge::sendToOutput(const QString &address, const QString 
         msg << action;
         QDBusConnection::sessionBus().call(msg, QDBus::NoBlock);
     });
+
+    // A window keeps its virtual desktop when it changes screen. With a desktop
+    // per output that is rarely what the other screen is showing, so a window
+    // dragged across arrives on the right monitor and is immediately invisible,
+    // sitting on a desktop that monitor is not currently displaying -- indis-
+    // tinguishable, to whoever dragged it, from the window having been lost.
+    // Put it on the desktop the target output actually shows.
+    //
+    // After the move rather than before: the shortcut acts on the active window,
+    // and sending the window to another desktop first would take it off screen
+    // and out of focus before the move could happen.
+    QTimer::singleShot(260, this, [this, address, outputName]() {
+        auto* wsState = KWinWorkspaceState::instance();
+        if (!wsState) {
+            return;
+        }
+        // Empty without the workspace-tracker effect, which is the only thing
+        // that can report a desktop per output. Nothing to correct then: without
+        // it there is a single current desktop and the window is already on the
+        // one being shown.
+        const int desktop = wsState->activeByOutput().value(outputName).toInt();
+        if (desktop > 0) {
+            setWindowDesktop(address, desktop);
+        }
+    });
 }
 
 QString KWinActiveWindowBridge::getOutputNameForGeometry(int x, int y, int w, int h) const {


### PR DESCRIPTION
Follow-up to #549, from a report that windows dragged to the other monitor disappear entirely — no window, no preview, no icon.

A window keeps its virtual desktop when it changes screen. With a desktop per output that is rarely the desktop the other screen is showing, so the window arrives on the right monitor and is immediately invisible: it is there, on a desktop that monitor is not currently displaying. From the outside that is indistinguishable from having lost it.

`sendToOutput()` now follows the move by putting the window on the desktop the target output actually shows. After the move rather than before — the kglobalaccel shortcut acts on the active window, so sending it to another desktop first would take it off screen and out of focus before the move could happen. Without the workspace-tracker effect `activeByOutput` is empty and nothing is corrected, which is right: there is a single current desktop then and the window already lands on the one being shown.

**On how far this is verified**, since I would rather say it than have it assumed. I instrumented a live shell and captured the drag both ways across a two-monitor setup. That confirmed the move itself is sound — `sendToOutput` fires with the right target, geometry and `output` both update, the workspace is preserved, and the window never leaves the list:

```
RELEASE at=3337,532 target=HDMI-A-2 own=DP-1  -> sendToOutput HDMI-A-2
   foot  out=[HDMI-A-2] geom=3170,256   (was out=[DP-1] geom=930,436)
RELEASE at=1243,436 target=DP-1 own=HDMI-A-2  -> sendToOutput DP-1
   foot  out=[DP-1] geom=930,436
```

What it does not confirm is the failure this fixes: throughout that capture `activeByOutput` was `{"DP-1":1,"HDMI-A-2":1}`, both monitors on the same desktop, which is exactly the case where the bug cannot appear. So the mechanism is read from the code and from the fact that the workspace is carried across unchanged, not from a captured failure. If you can reproduce with the two monitors on different desktops, that is the case to try.