### PR TITLE
feat: synchronize translations with Crowdin

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -11,6 +11,7 @@
 [![Debian](https://img.shields.io/badge/Debian-A81D33?logo=debian&logoColor=white&style=flat-square)](https://debian.org)
 [![KDE Plasma](https://img.shields.io/badge/Plasma_6-1D99F3?logo=kde&logoColor=white&style=flat-square)](https://kde.org/plasma-desktop)
 [![License: GPLv3](https://img.shields.io/badge/License-GPLv3-86dbce?style=flat-square)](LICENSE)
+[![Crowdin](https://badges.crowdin.net/caelestia-kde/localized.svg)](https://crowdin.com/project/caelestia-kde)
 
 </div>
 

--- a/.github/docs/translations.md
+++ b/.github/docs/translations.md
@@ -81,9 +81,19 @@ Two details are worth knowing before touching that setup:
   `.qm` would quietly ship the previous translation. The workflow recompiles them
   on the localization branch so the pair always moves together.
 
+The project lives at <https://crowdin.com/project/caelestia-kde>, and the README
+badge reports its progress.
+
 The repository needs two secrets for this, both from a Crowdin account with at
 least Manager rights on the project: `CROWDIN_PROJECT_ID` and
 `CROWDIN_PERSONAL_TOKEN`. The job is skipped on forks, where they do not exist.
+
+Create the token under Account Settings -> API with **Granular access**, limited
+to this project and to the scopes the synchronization needs. A Crowdin personal
+token otherwise carries its owner's permissions across every project they can
+reach, and this one lives in a repository whose write access is not the same set
+of people -- anyone who can add a workflow can read a secret. Scoping it keeps
+that reach to one project.
 
 Adding a language is done in Crowdin's own settings; the catalogue appears here
 on the next synchronization. Nothing about the local workflow changes -- a

--- a/.github/docs/translations.md
+++ b/.github/docs/translations.md
@@ -53,10 +53,42 @@ Catalogues are looked up in this order:
 4. Pick the language in Nexus -> Language & region -> Shell language. It appears
    automatically once the `.qm` file is installed.
 
-Qt's Linguist tools are needed to build catalogues. The installer and
+Qt's Linguist tools are needed to compile catalogues. The installer and
 `caelestia-update` pull them in automatically (`qt6-tools` on Arch,
 `qt6-qttools-devel` on Fedora, `qt6-l10n-tools` + `qt6-tools-dev` on Debian).
-Without them the build still succeeds, it just warns and ships English only.
+Without them the build installs the committed `caelestia_<code>.qm` files as
+they are, so every language still ships; with them the `.ts` files are
+recompiled and take precedence.
+
+## Translating on Crowdin
+
+Translators do not need a checkout. The project is synchronized with Crowdin, so
+a language can be worked on in the browser and arrives here as a pull request.
+
+`crowdin.yml` maps the catalogues; `.github/workflows/crowdin.yml` runs the
+synchronization on every push to `dev` that touches the shell sources, and can
+be triggered by hand.
+
+Two details are worth knowing before touching that setup:
+
+- **The source catalogue is generated, not committed.** Crowdin needs an English
+  `.ts` to slice into the target languages, but a file of several thousand empty
+  translations does not belong in the repository. The workflow rebuilds
+  `caelestia_en.ts` from the QML immediately before uploading and never commits
+  it.
+- **A Crowdin pull request carries `.ts` files only.** Since a build without
+  Linguist tools installs the committed `.qm` as-is, a `.ts` arriving without its
+  `.qm` would quietly ship the previous translation. The workflow recompiles them
+  on the localization branch so the pair always moves together.
+
+The repository needs two secrets for this, both from a Crowdin account with at
+least Manager rights on the project: `CROWDIN_PROJECT_ID` and
+`CROWDIN_PERSONAL_TOKEN`. The job is skipped on forks, where they do not exist.
+
+Adding a language is done in Crowdin's own settings; the catalogue appears here
+on the next synchronization. Nothing about the local workflow changes -- a
+language added by hand with `update-translations.sh` is picked up by Crowdin on
+the next upload just the same.
 
 ## Keeping catalogues current
 

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,121 @@
+name: Crowdin
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - "shell/**/*.qml"
+      - "shell/translations/**"
+      - "crowdin.yml"
+      - ".github/workflows/crowdin.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: crowdin
+  cancel-in-progress: false
+
+jobs:
+  synchronize:
+    runs-on: ubuntu-latest
+    # Skipped on forks: the secrets do not exist there, and the action would
+    # fail on every push rather than simply not running.
+    if: github.repository == 'ladybug-me/caelestia-dots-kde'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Qt Linguist Tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y qt6-l10n-tools qt6-tools-dev
+
+      # English is the source language, so its catalogue is not committed --
+      # it would be thousands of lines of empty translations. Crowdin needs one
+      # to slice into the target languages, so it is rebuilt from the QML here
+      # and left uncommitted.
+      - name: Regenerate the Source Catalogue
+        run: |
+          set -euo pipefail
+          scripts/update-translations.sh en
+          test -s shell/translations/caelestia_en.ts
+
+      - name: Synchronize with Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: i18n/crowdin
+          create_pull_request: true
+          pull_request_title: "i18n: new translations from Crowdin"
+          pull_request_body: |
+            Translations downloaded from Crowdin.
+
+            The compiled `.qm` catalogues are refreshed by the workflow on this
+            branch, so this can be merged as it stands.
+          commit_message: "i18n: new translations from Crowdin"
+          config: crowdin.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+  # A Crowdin pull request carries .ts files only. The compiled catalogues are
+  # committed so that a build without Qt's Linguist tools still ships every
+  # language, and such a build installs them as they are -- so a .ts that
+  # arrives without its .qm would quietly ship the previous translation. This
+  # keeps the pair together.
+  compile:
+    runs-on: ubuntu-latest
+    if: github.repository == 'ladybug-me/caelestia-dots-kde'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Localization Branch
+        uses: actions/checkout@v4
+        with:
+          ref: i18n/crowdin
+          fetch-depth: 0
+        continue-on-error: true
+        id: checkout
+
+      - name: Install Qt Linguist Tools
+        if: steps.checkout.outcome == 'success'
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y qt6-l10n-tools qt6-tools-dev
+
+      - name: Recompile Catalogues
+        if: steps.checkout.outcome == 'success'
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          lrelease=/usr/lib/qt6/bin/lrelease
+          [[ -x "$lrelease" ]] || lrelease=$(command -v lrelease)
+
+          for ts in shell/translations/caelestia_*.ts; do
+            "$lrelease" -silent "$ts" -qm "${ts%.ts}.qm"
+          done
+
+      - name: Commit Compiled Catalogues
+        if: steps.checkout.outcome == 'success'
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- shell/translations; then
+            echo "Catalogues already match their sources."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add shell/translations
+          git commit -m "i18n: recompile catalogues"
+          git push
+    needs: synchronize

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,17 @@
+# Crowdin project mapping. Credentials come from the environment; see
+# .github/workflows/crowdin.yml and .github/docs/translations.md.
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+base_path: "."
+preserve_hierarchy: true
+
+files:
+  # English is the source language and its catalogue is not committed: the
+  # workflow regenerates it from the QML sources right before uploading, so the
+  # repository carries translations and never a file of empty strings.
+  #
+  # %locale_with_underscore% rather than %two_letters_code% so a language that
+  # needs a region (pt_BR, zh_CN) lands on the name Qt expects. For a plain
+  # language the two are the same, so tr stays caelestia_tr.ts.
+  - source: /shell/translations/caelestia_en.ts
+    translation: /shell/translations/caelestia_%locale_with_underscore%.ts

--- a/shell/translations/README.md
+++ b/shell/translations/README.md
@@ -16,5 +16,8 @@ scripts/update-translations.sh          # update every catalogue here
 scripts/update-translations.sh es       # add Spanish
 ```
 
+Translations are also synchronized with Crowdin, so a language can be worked on
+in the browser instead; it arrives here as a pull request.
+
 See [../../.github/docs/translations.md](../../.github/docs/translations.md) for
 the full guide.


### PR DESCRIPTION
Follow-up to #550. Translating currently means a checkout, Qt Linguist and a pull request, which is a lot to ask of someone who just wants to contribute a language. Crowdin reads Qt `.ts` natively, so catalogues can be worked on in the browser and arrive here as a pull request instead.

`crowdin.yml` maps the catalogues, `.github/workflows/crowdin.yml` runs the synchronization on pushes to `dev` that touch the shell sources, and it can be triggered by hand.

Two things about this repository needed accommodating, and both are worth knowing before changing anything here:

- **The English source catalogue is generated, not committed.** Crowdin needs one to slice into the target languages, but it is several thousand lines of empty translations and does not belong in the repo — it is what we removed during review of #550. The workflow rebuilds it from the QML immediately before uploading and never commits it.
- **A Crowdin pull request carries `.ts` only.** Since a build without Linguist tools installs the committed `.qm` as it stands, a `.ts` arriving without its `.qm` would quietly ship the previous translation. The workflow recompiles them on the localization branch so the pair always moves together.

The file mapping uses `%locale_with_underscore%` rather than `%two_letters_code%`, so a language needing a region (`pt_BR`, `zh_CN`) lands on the name Qt expects. For a plain language they are identical, so `tr` stays `caelestia_tr.ts`.

**This needs two things from you before it can run**, and I cannot do either:

1. A Crowdin project. It is free for open source through their OSS programme.
2. Two repository secrets from an account with at least Manager rights on that project: `CROWDIN_PROJECT_ID` and `CROWDIN_PERSONAL_TOKEN`.

Until those exist the workflow is inert — it is gated on `github.repository`, so it does not run on forks and will not fail anyone's PR.

**On verification**, so it is not assumed: `actionlint` passes with the same invocation and ignores the validate workflow uses, the YAML parses, and the local CI checks pass. I could not exercise the workflow end to end, because that needs the Crowdin project and secrets above. The parts I could check independently are that Crowdin supports Qt TS natively and that `update-translations.sh en` regenerates the source catalogue from the QML — that script path is the one #550 already ships.

Also corrects a line in `translations.md` that says a build without Linguist tools "ships English only". That stopped being true when the compiled catalogues started being committed; it now installs them as they are.