### PR TITLE
fix: tier 1 fixes for updater clobber, lockscreen env, window rules

### DIFF
--- a/scripts/03-deploy-configs.sh
+++ b/scripts/03-deploy-configs.sh
@@ -239,7 +239,7 @@ if [[ "${APPLY_LOCKSCREEN:-true}" != "false" ]]; then
 
     if $PLUGIN_OK && command -v kwriteconfig6 >/dev/null 2>&1; then
         kwriteconfig6 --file kscreenlockerrc --group Greeter --key WallpaperPlugin net.dosowisko.PlasmaApplicationWallpaper
-        kwriteconfig6 --file kscreenlockerrc --group Greeter --group Wallpaper --group net.dosowisko.PlasmaApplicationWallpaper --group General --key command "quickshell -p $HOME/.config/quickshell/caelestia/lockscreen.qml"
+        kwriteconfig6 --file kscreenlockerrc --group Greeter --group Wallpaper --group net.dosowisko.PlasmaApplicationWallpaper --group General --key command "$HOME/.local/bin/caelestia-lockscreen"
         kwriteconfig6 --file kscreenlockerrc --group Greeter --group Wallpaper --group net.dosowisko.PlasmaApplicationWallpaper --group General --key fps 1
         kwriteconfig6 --file kscreenlockerrc --group Greeter --group LnF --group General --key alwaysShowClock false
         kwriteconfig6 --file kscreenlockerrc --group Greeter --group LnF --group General --key showMediaControls false

--- a/scripts/08-build-shell.sh
+++ b/scripts/08-build-shell.sh
@@ -456,6 +456,10 @@ if [ -d "$BUNDLE_DIR/.git" ]; then
     git -C "$BUNDLE_DIR" rev-parse HEAD > ~/.config/quickshell/caelestia/.current_commit 2>/dev/null || true
     git -C "$BUNDLE_DIR" rev-parse --abbrev-ref HEAD > ~/.config/quickshell/caelestia/.update_branch 2>/dev/null || true
 
+    # Record which checkout deployed this tree so the Nexus updater can
+    # refuse to clobber a dev clone's uncommitted work (issue #565).
+    printf '%s\n' "$BUNDLE_DIR" > ~/.config/quickshell/caelestia/.bundle_source 2>/dev/null || true
+
     # Persist the installed version too. The update checker resolves
     # unrecognised commits through its bare cache repo, which only mirrors
     # origin branches - a commit that exists only in this local checkout

--- a/scripts/08-build-shell.sh
+++ b/scripts/08-build-shell.sh
@@ -178,7 +178,7 @@ if [[ "${CAELESTIA_SETUP_RUNNING:-0}" == "0" ]]; then
 
         if $PLUGIN_OK && command -v kwriteconfig6 >/dev/null 2>&1; then
             kwriteconfig6 --file kscreenlockerrc --group Greeter --key WallpaperPlugin net.dosowisko.PlasmaApplicationWallpaper
-            kwriteconfig6 --file kscreenlockerrc --group Greeter --group Wallpaper --group net.dosowisko.PlasmaApplicationWallpaper --group General --key command "quickshell -p $HOME/.config/quickshell/caelestia/lockscreen.qml"
+            kwriteconfig6 --file kscreenlockerrc --group Greeter --group Wallpaper --group net.dosowisko.PlasmaApplicationWallpaper --group General --key command "$HOME/.local/bin/caelestia-lockscreen"
             kwriteconfig6 --file kscreenlockerrc --group Greeter --group Wallpaper --group net.dosowisko.PlasmaApplicationWallpaper --group General --key fps 1
             kwriteconfig6 --file kscreenlockerrc --group Greeter --group LnF --group General --key alwaysShowClock false
             kwriteconfig6 --file kscreenlockerrc --group Greeter --group LnF --group General --key showMediaControls false
@@ -427,6 +427,7 @@ install -m 755 "$BUNDLE_DIR/src/bin/caelestia-record" ~/.local/bin/caelestia-rec
 install -m 755 "$BUNDLE_DIR/src/bin/caelestia-screenshot" ~/.local/bin/caelestia-screenshot
 install -m 755 "$BUNDLE_DIR/src/bin/caelestia-shell-ipc" ~/.local/bin/caelestia-shell-ipc
 install -m 755 "$BUNDLE_DIR/src/bin/caelestia" ~/.local/bin/caelestia
+install -m 755 "$BUNDLE_DIR/src/bin/caelestia-lockscreen" ~/.local/bin/caelestia-lockscreen
 install -m 755 "$BUNDLE_DIR/src/bin/caelestia-update" ~/.local/bin/caelestia-update
 install -m 755 "$BUNDLE_DIR/src/bin/caelestia-check-updates" ~/.local/bin/caelestia-check-updates
 ok "Caelestia bin wrappers installed to ~/.local/bin"

--- a/src/bin/caelestia-lockscreen
+++ b/src/bin/caelestia-lockscreen
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Launch the Caelestia lock screen from kscreenlocker.
+#
+# kscreenlocker_greet does not inherit the session environment, so the
+# QML2_IMPORT_PATH / CAELESTIA_LIB_DIR variables that live in shell rc files
+# and the autostart script are missing here. Export them before exec'ing
+# quickshell, otherwise the Caelestia imports fail to load and KDE falls back
+# to the default image wallpaper (issue #579).
+
+export QML2_IMPORT_PATH="$HOME/.local/lib/qt6/qml:$HOME/.config/quickshell/caelestia"
+export CAELESTIA_LIB_DIR="$HOME/.local/lib/caelestia"
+export QS_DROP_EXPENSIVE_FONTS=1
+export QS_DISABLE_CRASH_HANDLER=1
+export QSG_RENDER_LOOP=threaded
+
+QUICKSHELL_PATH="$(command -v quickshell 2>/dev/null || true)"
+if [[ -z "$QUICKSHELL_PATH" ]]; then
+    for candidate in /usr/bin/quickshell /usr/local/bin/quickshell "$HOME/.local/bin/quickshell"; do
+        if [[ -x "$candidate" ]]; then
+            QUICKSHELL_PATH="$candidate"
+            break
+        fi
+    done
+fi
+
+if [[ -z "$QUICKSHELL_PATH" ]]; then
+    echo "[FATAL] quickshell not found in PATH" >&2
+    exit 1
+fi
+
+exec "$QUICKSHELL_PATH" -p "$HOME/.config/quickshell/caelestia/lockscreen.qml"

--- a/src/bin/caelestia-update
+++ b/src/bin/caelestia-update
@@ -233,6 +233,21 @@ info "Executing build scripts (GUI prompts will appear if required)..."
 
 export BUNDLE_DIR="$UPD_DIR/repo"
 
+# Refuse to overwrite an install that was deployed from a developer's local
+# clone with uncommitted changes. Alternating between this internal checkout
+# and update.sh (which deploys from the user's actual clone) silently discards
+# live edits, since both write the same state files from different sources of
+# truth (issue #565).
+BUNDLE_SOURCE="$HOME/.config/quickshell/caelestia/.bundle_source"
+if [[ -f "$BUNDLE_SOURCE" ]]; then
+    PREV_BUNDLE="$(cat "$BUNDLE_SOURCE" 2>/dev/null || true)"
+    if [[ -n "$PREV_BUNDLE" && "$PREV_BUNDLE" != "$UPD_DIR/repo" && -d "$PREV_BUNDLE/.git" ]]; then
+        if ! git -C "$PREV_BUNDLE" diff-index --quiet HEAD -- 2>/dev/null; then
+            die "Installed shell was deployed from a local clone with uncommitted changes ($PREV_BUNDLE). Run update.sh from that clone, or commit/stash your changes."
+        fi
+    fi
+fi
+
 # 4. Deploy Configs
 echo "PROGRESS: 3/5: Deploying configuration files..."
 echo

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -298,7 +298,8 @@ for f in \
     "$HOME/.local/bin/caelestia-shell-ipc" \
     "$HOME/.local/bin/ydotoold-wrapper" \
     "$HOME/.local/bin/caelestia-update" \
-    "$HOME/.local/bin/caelestia-check-updates"
+    "$HOME/.local/bin/caelestia-check-updates" \
+    "$HOME/.local/bin/caelestia-lockscreen"
 do
     if [[ -f "$f" ]]; then
         rm -f "$f"


### PR DESCRIPTION
﻿## Summary

Part of the Tier 1 triage. Implements the two fixes that are code-completeable from this checkout, documents the third, and leaves the hardware/repro-gated ones untouched.

## Implemented

- #565: the Nexus updater records which checkout last deployed the shell and refuses to run when that checkout is a local clone with uncommitted changes, instead of silently overwriting live edits.
- #579: the KDE lock screen runs through a session-env wrapper (`caelestia-lockscreen`) so quickshell can load Caelestia imports instead of falling back to the default wallpaper.

## Documented (implementation pending VM validation)

- #430: recorded the window-rule layer design and the decision to defer special-workspace routing in `.github/docs/window-rules.md`. The `kwinrulesrc` deploy script needs the exact rule schema validated against the VM's KWin first.

## Blocked - not addressed in this PR

- #588, #594, #595: need hardware validation (hybrid-GPU polling / NetworkManager connect path).
- #596, #582: need repro details or the lock screen error text.

Closes #565
Closes #579
Refs #430
