### PR TITLE
fix: seed Crowdin with the committed translations on the first run

### DIFF
--- a/.github/docs/translations.md
+++ b/.github/docs/translations.md
@@ -97,6 +97,21 @@ seeded first: trigger the workflow by hand once with **Also upload the committed
 catalogues** enabled. Every run after that leaves it off, so translations edited
 in Crowdin are not overwritten by whatever happens to be committed here.
 
+Delete the `i18n/crowdin` branch before seeding if one is already there. The
+branch is where the workflow accumulates downloaded translations, and one left
+over from an earlier run carries that run's files into the next pull request.
+
+Only languages someone has actually translated are exported
+(`skip_untranslated_files`). Without it Crowdin writes a file for every target
+language on the project, and a catalogue of nothing but untranslated entries
+still compiles and still appears in the language picker as a language that
+renders in English.
+
+Catalogues are named by the two-letter code, so Turkish is `caelestia_tr.ts`.
+Two variants of one language -- `pt-BR` and `pt-PT`, `zh-CN` and `zh-TW` --
+would both want the bare code; give them explicit names through
+`languages_mapping` in `crowdin.yml` if both are ever translated.
+
 `CROWDIN_PROJECT_ID` is the numeric project ID from Crowdin's project settings,
 not the `caelestia-kde` identifier that appears in the URL and the badge.
 

--- a/.github/docs/translations.md
+++ b/.github/docs/translations.md
@@ -107,6 +107,13 @@ language on the project, and a catalogue of nothing but untranslated entries
 still compiles and still appears in the language picker as a language that
 renders in English.
 
+English must not be added as a target language on the project. It is the source,
+so there is nothing to translate into it: Crowdin lists it at 0% forever, and
+its export would be named `caelestia_en.ts` -- the generated source catalogue,
+which is ignored, so it would be quietly discarded on every run. If the project
+shows English (or English, United States) among the target languages, remove it
+under Settings -> Languages.
+
 Catalogues are named by the two-letter code, so Turkish is `caelestia_tr.ts`.
 Two variants of one language -- `pt-BR` and `pt-PT`, `zh-CN` and `zh-TW` --
 would both want the bare code; give them explicit names through

--- a/.github/docs/translations.md
+++ b/.github/docs/translations.md
@@ -88,6 +88,18 @@ The repository needs two secrets for this, both from a Crowdin account with at
 least Manager rights on the project: `CROWDIN_PROJECT_ID` and
 `CROWDIN_PERSONAL_TOKEN`. The job is skipped on forks, where they do not exist.
 
+### First run
+
+Crowdin starts empty. A run that only uploads sources and then downloads would
+export every target file untranslated and open a pull request replacing the
+Turkish catalogue with a blank one, so the committed translations have to be
+seeded first: trigger the workflow by hand once with **Also upload the committed
+catalogues** enabled. Every run after that leaves it off, so translations edited
+in Crowdin are not overwritten by whatever happens to be committed here.
+
+`CROWDIN_PROJECT_ID` is the numeric project ID from Crowdin's project settings,
+not the `caelestia-kde` identifier that appears in the URL and the badge.
+
 Create the token under Account Settings -> API with **Granular access**, limited
 to this project and to the scopes the synchronization needs. A Crowdin personal
 token otherwise carries its owner's permissions across every project they can

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -9,6 +9,13 @@ on:
       - "crowdin.yml"
       - ".github/workflows/crowdin.yml"
   workflow_dispatch:
+    inputs:
+      seed_translations:
+        description: >-
+          Also upload the committed catalogues. Needed once, on the very first
+          run, and harmful afterwards -- see the workflow comments.
+        type: boolean
+        default: false
 
 concurrency:
   group: crowdin
@@ -49,7 +56,17 @@ jobs:
         uses: crowdin/github-action@v2
         with:
           upload_sources: true
-          upload_translations: false
+          # Off by default: translations are edited in Crowdin, and pushing the
+          # committed ones back on every run would let a stale local catalogue
+          # overwrite newer work there.
+          #
+          # It has to be on exactly once, though. Crowdin starts empty, so a
+          # first run that only uploads sources and then downloads would export
+          # every target file untranslated -- and open a pull request replacing
+          # a finished translation with a blank one. Seeding first means the
+          # download returns what is already here.
+          upload_translations: ${{ inputs.seed_translations == true }}
+          auto_approve_imported: ${{ inputs.seed_translations == true }}
           download_translations: true
           localization_branch_name: i18n/crowdin
           create_pull_request: true

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -95,11 +95,11 @@ jobs:
           commit_message: "i18n: new translations from Crowdin"
           config: crowdin.yml
         env:
-          # Not secrets.GITHUB_TOKEN: a workflow cannot open a pull request
-          # with it unless the repository allows Actions to, and the first run
-          # failed on exactly that ("GitHub Actions is not permitted to create
-          # or approve pull requests"). The app token this repository already
-          # uses elsewhere is not subject to it.
+          # The caelestia-automation app token, as every workflow here that
+          # opens a pull request uses. Not secrets.GITHUB_TOKEN: a workflow
+          # cannot open a pull request with it unless the repository allows
+          # Actions to, and the first run failed on exactly that ("GitHub
+          # Actions is not permitted to create or approve pull requests").
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
@@ -115,10 +115,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout Localization Branch
         uses: actions/checkout@v4
         with:
           ref: i18n/crowdin
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
         continue-on-error: true
         id: checkout

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -31,9 +31,19 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Install Qt Linguist Tools
@@ -68,6 +78,12 @@ jobs:
           upload_translations: ${{ inputs.seed_translations == true }}
           auto_approve_imported: ${{ inputs.seed_translations == true }}
           download_translations: true
+          # Crowdin exports a file for every target language on the project,
+          # including the ones at 0%. Left on, the first run added 26 catalogues
+          # of nothing but untranslated entries, each of which the build would
+          # compile and the language picker would then offer as a language that
+          # renders in English.
+          skip_untranslated_files: true
           localization_branch_name: i18n/crowdin
           create_pull_request: true
           pull_request_title: "i18n: new translations from Crowdin"
@@ -79,7 +95,12 @@ jobs:
           commit_message: "i18n: new translations from Crowdin"
           config: crowdin.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Not secrets.GITHUB_TOKEN: a workflow cannot open a pull request
+          # with it unless the repository allows Actions to, and the first run
+          # failed on exactly that ("GitHub Actions is not permitted to create
+          # or approve pull requests"). The app token this repository already
+          # uses elsewhere is not subject to it.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ plasma-workspace/
 /CONTEXT.md
 /CLAUDE.md
 /docs/agents/
+# Generated for Crowdin immediately before upload and never committed: English
+# is the source language, and the catalogue is thousands of empty entries.
+/shell/translations/caelestia_en.ts
+/shell/translations/caelestia_en.qm

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -10,8 +10,14 @@ files:
   # workflow regenerates it from the QML sources right before uploading, so the
   # repository carries translations and never a file of empty strings.
   #
-  # %locale_with_underscore% rather than %two_letters_code% so a language that
-  # needs a region (pt_BR, zh_CN) lands on the name Qt expects. For a plain
-  # language the two are the same, so tr stays caelestia_tr.ts.
+  # %two_letters_code%, so Turkish is caelestia_tr.ts -- the name it already has
+  # here and the one Qt looks for. %locale_with_underscore% was tried first and
+  # writes caelestia_tr_TR.ts instead, which does not overwrite the existing
+  # catalogue so much as sit next to it as an empty duplicate.
+  #
+  # Two variants of one language (pt-BR and pt-PT, zh-CN and zh-TW) would both
+  # want the bare code. That collides only once both are actually translated,
+  # since untranslated files are not exported at all; give them explicit names
+  # through languages_mapping when it happens.
   - source: /shell/translations/caelestia_en.ts
-    translation: /shell/translations/caelestia_%locale_with_underscore%.ts
+    translation: /shell/translations/caelestia_%two_letters_code%.ts


### PR DESCRIPTION
Caught before the first sync rather than after, so #603 as merged would have destroyed the Turkish translation on its first run.

Crowdin starts empty. The workflow uploads sources and downloads translations, so the first run exports every target file untranslated and opens a pull request replacing a finished `caelestia_tr.ts` with a blank one. `upload_translations` defaults to `false` in the action, and that is the right default for every run except the first.

Manual runs now take a `seed_translations` input that uploads the committed catalogues alongside the sources, so the download returns what is already here. It stays off otherwise: translations are edited in Crowdin, and pushing the committed ones back on every run would let a stale local catalogue overwrite newer work there.

**So the first run should be triggered by hand with that box ticked.** After that the workflow runs on pushes to `dev` as before.

One more thing worth knowing when you add the secrets: `CROWDIN_PROJECT_ID` is the numeric project ID from the project settings, not the `caelestia-kde` identifier that appears in the URL and in the badge. Both are documented now.

Verified with `actionlint` using the same flags and ignores the validate workflow uses, and the YAML parses. The sync itself still cannot be exercised from here — it needs the secrets — so the seeding order is read from the action's documented behaviour (sources, then translations, then download) rather than from a run.