### PR TITLE
fix: deploy configs on first install when target already exists

### DIFF
--- a/scripts/03-deploy-configs.sh
+++ b/scripts/03-deploy-configs.sh
@@ -121,7 +121,7 @@ deploy_config() {
             expected="$(<"$stamp")"
         fi
 
-        if [[ -z "$expected" || "$current" != "$expected" ]]; then
+        if [[ -n "$expected" && "$current" != "$expected" ]]; then
             skip "Preserving locally modified config: $config"
             echo "           Backup: $BACKUP_DIR/.config/$config"
             return
@@ -186,7 +186,7 @@ if [[ -f "$DOTS_DIR/starship.toml" ]]; then
         if [[ -f "$starship_stamp" ]]; then
             starship_expected="$(<"$starship_stamp")"
         fi
-        if [[ -z "$starship_expected" || "$starship_current" != "$starship_expected" ]]; then
+        if [[ -n "$starship_expected" && "$starship_current" != "$starship_expected" ]]; then
             skip "Preserving locally modified config: starship.toml"
             echo "           Backup: $BACKUP_DIR/.config/starship.toml"
         else


### PR DESCRIPTION
## Summary

`deploy_config()` and the starship.toml block both use `-z "$expected"` to check whether a stamp file exists.  On first install, if the target config already exists (e.g. user's own `~/.config/btop`), `$expected` is empty (no stamp yet) so the condition is true and deployment is **skipped** instead of proceeding.

The fix flips the guard to `-n "$expected" && "$current" != "$expected"` so that a missing stamp is treated as "no prior Caelestia install → deploy".

Both occurrences are fixed (line 124 for `deploy_config()`, line 189 for `starship.toml`).

## Test plan

- First install, target config does not exist → deployed (unchanged)
- First install, target config already exists → now correctly deployed (was skipped)
- Re-install, config unchanged since last deploy → re-deployed (unchanged)
- Re-install, config locally modified → correctly skipped (unchanged)
- Source directory missing → silently skipped (unchanged)

Fixes #592