### PR TITLE
fix(kwin): sync activeOutputName when active window changes

### DIFF
--- a/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
+++ b/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.cpp
@@ -267,7 +267,14 @@ void KWinActiveWindowBridge::buildWindowList() {
     if (activeWindowFound && m_activeWindow != newActiveWindow) {
         m_activeWindow = newActiveWindow;
         emit activeWindowChanged();
-        
+
+        // Keep activeOutputName in sync so Hypr.focusedMonitor resolves correctly
+        // on multi-monitor setups. Without this it stays empty forever and the QML
+        // fallback always picks monitor index 0.
+        const QString newOutput = newActiveWindow.value("output").toString();
+        if (!newOutput.isEmpty())
+            setActiveOutputName(newOutput);
+
         if (m_activeWindow.value("address").toString() == m_pendingFocusAddress) {
             m_pendingFocusAddress.clear();
             emit pendingFocusAddressChanged();

--- a/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.hpp
+++ b/shell/plugin/src/Caelestia/Services/kwinactivewindowbridge.hpp
@@ -25,7 +25,7 @@ public:
 
     QVariantMap activeWindow() const;
     QString activeOutputName() const;
-    void setActiveOutputName(const QString &outputName);
+    Q_INVOKABLE void setActiveOutputName(const QString &outputName);
 
     QVariantList windowList() const;
     QString pendingFocusAddress() const;


### PR DESCRIPTION
## What does this change?

`buildWindowList()` updates `m_activeWindow` on focus change but never
calls `setActiveOutputName()`, so it stays empty the whole session.
`Hypr.focusedMonitor` falls back to index 0 when it's empty — on
multi-monitor this means the focused monitor is always wrong.

Fix: pass the `output` field (already in `windowToVariant()`) to
`setActiveOutputName()` when the active window changes.

## How did you test it?

Two-monitor setup, verified `activeOutputName` updates on focus change.

## Type

- [x] Bug fix

Related to #613