### PR TITLE
fix(discord): make IPC reconnect non-blocking

### DIFF
--- a/shell/plugin/src/Caelestia/Services/discordipc.cpp
+++ b/shell/plugin/src/Caelestia/Services/discordipc.cpp
@@ -18,7 +18,8 @@ enum class Opcode : int32_t {
 };
 
 DiscordIpc::DiscordIpc(QObject* parent)
-    : QObject(parent), m_socket(new QLocalSocket(this)), m_reconnectTimer(new QTimer(this)), m_connected(false)
+    : QObject(parent), m_socket(new QLocalSocket(this)), m_reconnectTimer(new QTimer(this)),
+      m_connectTimeout(new QTimer(this)), m_connected(false)
 {
     connect(m_socket, &QLocalSocket::connected, this, &DiscordIpc::onSocketConnected);
     connect(m_socket, &QLocalSocket::disconnected, this, &DiscordIpc::onSocketDisconnected);
@@ -31,6 +32,15 @@ DiscordIpc::DiscordIpc(QObject* parent)
 
     m_reconnectTimer->setInterval(5000);
     connect(m_reconnectTimer, &QTimer::timeout, this, &DiscordIpc::checkReconnect);
+
+    m_connectTimeout->setSingleShot(true);
+    m_connectTimeout->setInterval(1000);
+    connect(m_connectTimeout, &QTimer::timeout, this, [this]() {
+        if (m_socket->state() == QLocalSocket::ConnectingState) {
+            m_socket->abort();
+            tryNextPath();
+        }
+    });
 }
 
 DiscordIpc::~DiscordIpc() {
@@ -52,6 +62,8 @@ void DiscordIpc::connectIpc(const QString& clientId) {
 
 void DiscordIpc::disconnectIpc() {
     m_reconnectTimer->stop();
+    m_connectTimeout->stop();
+    m_pendingPaths.clear();
     m_clientId.clear();
     m_socket->abort();
     if (m_connected) {
@@ -82,20 +94,27 @@ void DiscordIpc::checkReconnect() {
 }
 
 void DiscordIpc::tryNextPath() {
+    if (m_clientId.isEmpty()) {
+        m_pendingPaths.clear();
+        return;
+    }
+
     while (!m_pendingPaths.isEmpty()) {
         const QString path = m_pendingPaths.takeFirst();
         if (QFile::exists(path)) {
             if (m_socket->state() != QLocalSocket::UnconnectedState)
                 m_socket->abort();
             m_socket->connectToServer(path);
+            m_connectTimeout->start();
             return;
         }
     }
-    // All candidates exhausted — timer retries in 5 s
 }
 
 void DiscordIpc::onSocketConnected() {
-    // Send Handshake
+    m_connectTimeout->stop();
+    m_pendingPaths.clear();
+
     QJsonObject payload;
     payload["v"] = 1;
     payload["client_id"] = m_clientId;
@@ -111,11 +130,9 @@ void DiscordIpc::onSocketDisconnected() {
 }
 
 void DiscordIpc::onError(QLocalSocket::LocalSocketError) {
+    m_connectTimeout->stop();
     emit errorOccurred(m_socket->errorString());
     onSocketDisconnected();
-    // If a reconnect scan is in progress, try the next candidate non-blocking.
-    // Use a queued invoke to avoid re-entering connectToServer() inside its own
-    // error signal, which can recurse on synchronous failures (e.g. ENOENT).
     if (!m_pendingPaths.isEmpty())
         QMetaObject::invokeMethod(this, &DiscordIpc::tryNextPath, Qt::QueuedConnection);
 }

--- a/shell/plugin/src/Caelestia/Services/discordipc.cpp
+++ b/shell/plugin/src/Caelestia/Services/discordipc.cpp
@@ -1,6 +1,7 @@
 #include "discordipc.hpp"
 #include <QStandardPaths>
 #include <QDir>
+#include <QFile>
 #include <QDebug>
 #include <QDataStream>
 #include <QCoreApplication>
@@ -63,31 +64,34 @@ void DiscordIpc::checkReconnect() {
     if (m_clientId.isEmpty()) return;
     if (m_socket->state() == QLocalSocket::ConnectedState || m_socket->state() == QLocalSocket::ConnectingState) return;
 
-    QString runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+    const QString runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
 
-    // Try native Discord IPC paths first: discord-ipc-0 through discord-ipc-9
-    // (multiple concurrent Discord-protocol clients occupy successive slots).
-    for (int slot = 0; slot <= 9; ++slot) {
-        QString pipePath = runtimeDir + "/discord-ipc-" + QString::number(slot);
-        m_socket->connectToServer(pipePath);
-        if (m_socket->waitForConnected(500))
-            return;
-    }
+    m_pendingPaths.clear();
+    for (int slot = 0; slot <= 9; ++slot)
+        m_pendingPaths << runtimeDir + "/discord-ipc-" + QString::number(slot);
 
-    // Flatpak-packaged Discord / Vesktop sandbox the runtime directory.
-    // Try the well-known Flatpak app-ids.
     static const QStringList flatpakIds = {
         "com.discordapp.Discord",
         "dev.vencord.Vesktop",
     };
-    for (const auto& id : flatpakIds) {
-        for (int slot = 0; slot <= 9; ++slot) {
-            QString pipePath = runtimeDir + "/app/" + id + "/discord-ipc-" + QString::number(slot);
-            m_socket->connectToServer(pipePath);
-            if (m_socket->waitForConnected(500))
-                return;
+    for (const auto& id : flatpakIds)
+        for (int slot = 0; slot <= 9; ++slot)
+            m_pendingPaths << runtimeDir + "/app/" + id + "/discord-ipc-" + QString::number(slot);
+
+    tryNextPath();
+}
+
+void DiscordIpc::tryNextPath() {
+    while (!m_pendingPaths.isEmpty()) {
+        const QString path = m_pendingPaths.takeFirst();
+        if (QFile::exists(path)) {
+            if (m_socket->state() != QLocalSocket::UnconnectedState)
+                m_socket->abort();
+            m_socket->connectToServer(path);
+            return;
         }
     }
+    // All candidates exhausted — timer retries in 5 s
 }
 
 void DiscordIpc::onSocketConnected() {
@@ -109,6 +113,11 @@ void DiscordIpc::onSocketDisconnected() {
 void DiscordIpc::onError(QLocalSocket::LocalSocketError) {
     emit errorOccurred(m_socket->errorString());
     onSocketDisconnected();
+    // If a reconnect scan is in progress, try the next candidate non-blocking.
+    // Use a queued invoke to avoid re-entering connectToServer() inside its own
+    // error signal, which can recurse on synchronous failures (e.g. ENOENT).
+    if (!m_pendingPaths.isEmpty())
+        QMetaObject::invokeMethod(this, &DiscordIpc::tryNextPath, Qt::QueuedConnection);
 }
 
 void DiscordIpc::onReadyRead() {

--- a/shell/plugin/src/Caelestia/Services/discordipc.hpp
+++ b/shell/plugin/src/Caelestia/Services/discordipc.hpp
@@ -45,6 +45,7 @@ private:
 
     QLocalSocket* m_socket;
     QTimer* m_reconnectTimer;
+    QTimer* m_connectTimeout;
     QString m_clientId;
     bool m_connected;
     QByteArray m_buffer;

--- a/shell/plugin/src/Caelestia/Services/discordipc.hpp
+++ b/shell/plugin/src/Caelestia/Services/discordipc.hpp
@@ -37,6 +37,7 @@ private slots:
     void onReadyRead();
     void onError(QLocalSocket::LocalSocketError socketError);
     void checkReconnect();
+    void tryNextPath();
 
 private:
     void sendFrame(int opcode, const QJsonObject& payload);
@@ -47,6 +48,7 @@ private:
     QString m_clientId;
     bool m_connected;
     QByteArray m_buffer;
+    QStringList m_pendingPaths;
 };
 
 } // namespace caelestia


### PR DESCRIPTION
## What does this change?

`checkReconnect()` called `waitForConnected(500)` up to 30 times per
invocation — 10 native slots + 2 Flatpak app-ids × 10 slots — all on
the QML thread. With Discord closed, small periodic hitch every 5 s.
With a stale socket file from a crashed Discord/Vesktop, one of those
attempts hard-freezes the shell for 500 ms, every 5 s, until the file
is gone.

Replaces the blocking loop with a signal-driven state machine:
- `checkReconnect()` builds the candidate list and calls `tryNextPath()`
- `tryNextPath()` skips non-existent paths with `QFile::exists()` and
  calls `connectToServer()` without `waitForConnected()`
- `onError()` advances to the next candidate via a queued
  `invokeMethod()` to avoid recursion on synchronous failures

## How did you test it?

Killed Vesktop with `kill -9` to leave a stale socket, confirmed no
freeze. Also verified normal connect/disconnect cycle still works.

## Type

- [x] Bug fix

Closes #615