### PR TITLE
/claim #616: Fix hybrid/multi-GPU monitoring — use max for GPU busy% and temps

### DIFF
--- a/shell/plugin/src/Caelestia/Services/gpu.cpp
+++ b/shell/plugin/src/Caelestia/Services/gpu.cpp
@@ -174,8 +174,7 @@ void Gpu::readGenericUsage() {
     const QStringList paths =
         QDir(QStringLiteral("/sys/class/drm"))
             .entryList(QStringList() << QStringLiteral("card*"), QDir::Dirs | QDir::NoDotAndDotDot);
-    qreal sum = 0.0;
-    int count = 0;
+    qreal maxVal = -1.0;
     for (const QString& card : paths) {
         QFile f(QStringLiteral("/sys/class/drm/%1/device/gpu_busy_percent").arg(card));
         if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
@@ -185,11 +184,12 @@ void Gpu::readGenericUsage() {
         const qreal v = f.readAll().trimmed().toDouble(&ok);
         f.close();
         if (ok) {
-            sum += v;
-            ++count;
+            if (v > maxVal) {
+                maxVal = v;
+            }
         }
     }
-    const qreal newPerc = count > 0 ? sum / count / 100.0 : 0.0;
+    const qreal newPerc = maxVal >= 0.0 ? maxVal / 100.0 : 0.0;
     if (std::abs(newPerc - m_percentage) > 0.0001) {
         m_percentage = newPerc;
         Q_EMIT percentageChanged();

--- a/shell/plugin/src/Caelestia/Services/sensorslib.cpp
+++ b/shell/plugin/src/Caelestia/Services/sensorslib.cpp
@@ -110,10 +110,11 @@ std::optional<double> gpuPciAverageTemp() {
         return std::nullopt;
     }
 
-    double sumPrimary = 0.0;
-    int countPrimary = 0;
-    double sumFallback = 0.0;
-    int countFallback = 0;
+    // Historically this function averaged all GPU PCI temps. For hybrid / multi-GPU systems
+    // averaging yields misleading numbers. Prefer the maximum "primary" GPU temperature
+    // across all PCI GPU devices; if none found, fall back to the maximum fallback sensor.
+    double maxPrimary = -1.0;
+    double maxFallback = -1.0;
 
     int chipNr = 0;
     while (const sensors_chip_name* chip = sensors_get_detected_chips(nullptr, &chipNr)) {
@@ -145,20 +146,22 @@ std::optional<double> gpuPciAverageTemp() {
                 continue;
             }
             if (isPrimary) {
-                sumPrimary += *v;
-                ++countPrimary;
+                if (*v > maxPrimary) {
+                    maxPrimary = *v;
+                }
             } else {
-                sumFallback += *v;
-                ++countFallback;
+                if (*v > maxFallback) {
+                    maxFallback = *v;
+                }
             }
         }
     }
 
-    if (countPrimary > 0) {
-        return sumPrimary / countPrimary;
+    if (maxPrimary >= 0.0) {
+        return maxPrimary;
     }
-    if (countFallback > 0) {
-        return sumFallback / countFallback;
+    if (maxFallback >= 0.0) {
+        return maxFallback;
     }
     return std::nullopt;
 }


### PR DESCRIPTION
Summary

- Fixes incorrect averaging of GPU usage and temperatures on hybrid/multi‑GPU systems.
- Gpu::readGenericUsage() now reports the maximum per-card gpu_busy_percent instead of the arithmetic mean.
- sensorslib::gpuPciAverageTemp() now returns the maximum primary (or fallback) temperature across PCI GPU devices instead of averaging.

Why

Averaging per-card usage/temperature produces misleading values on systems with multiple GPUs (e.g., an idle iGPU + loaded dGPU). Reporting the maximum matches user expectation and common monitoring tooling: when one GPU is loaded, the displayed usage/temperature should reflect the active GPU, not the mean of all GPUs.

What I changed

- shell/plugin/src/Caelestia/Services/gpu.cpp
  - readGenericUsage(): compute the maximum gpu_busy_percent across /sys/class/drm/card*/device/gpu_busy_percent and publish that value (scaled to 0..1).

- shell/plugin/src/Caelestia/Services/sensorslib.cpp
  - gpuPciAverageTemp(): renamed the internal behavior (API unchanged) to return the maximum primary temperature seen across PCI GPU chips; if none, return the maximum fallback temp; otherwise nullopt.

How to verify locally

1. On a hybrid/multi‑GPU machine, inspect per-card usage:
   for f in /sys/class/drm/card*/device/gpu_busy_percent; do echo "$f: $(cat $f)"; done
   - Note the per-card values (e.g., card0: 0, card1: 100). The Caelestia GPU percentage should match the maximal card value (100%), not the arithmetic mean (50%).

2. GPU temperature verification (example):
   - Install lm-sensors and run: sensors
   - Observe GPU-related sensors for each PCI GPU. The Caelestia GPU temperature should reflect the maximum relevant GPU temp instead of an averaged value.

Notes

- No public API changed; behaviour only improved for Generic detection path and the sensors helper that previously averaged temperatures.
- I could not run integration tests or CI here; the changes are small and narrowly scoped. Please run your normal CI/build on this PR.

Closes #616


Closes #616

_Enviado por un agente Monexa; revisión humana: no._