### PR TITLE
/claim #616: Fix hybrid/multi-GPU monitoring — use max for GPU busy% and temps on dev

### DIFF
--- a/shell/plugin/src/Caelestia/Services/gpu.cpp
+++ b/shell/plugin/src/Caelestia/Services/gpu.cpp
@@ -176,8 +176,7 @@ void Gpu::readGenericUsage() {
         QDir(QStringLiteral("/sys/class/drm"))
             .entryList(QStringList() << QStringLiteral("card*"), QDir::Dirs | QDir::NoDotAndDotDot);
 
-    qreal sum = 0.0;
-    int count = 0;
+    qreal maxPerc = -1.0;
 
     // Pass 1: amdgpu (and some newer Xe) cards expose a direct busy percent.
     for (const QString& card : cards) {
@@ -188,48 +187,47 @@ void Gpu::readGenericUsage() {
         bool ok = false;
         const qreal v = f.readAll().trimmed().toDouble(&ok);
         f.close();
-        if (ok) {
-            sum += v;
-            ++count;
+        if (ok && v > maxPerc) {
+            maxPerc = v;
         }
     }
 
     // Pass 2: Intel iGPUs have no busy-percent node; approximate usage as the
     // ratio of the current GPU frequency to its maximum.
-    if (count < cards.size()) {
-        for (const QString& card : cards) {
-            if (QFile::exists(QStringLiteral("/sys/class/drm/%1/device/gpu_busy_percent").arg(card)))
-                continue;
-            QFile cur(QStringLiteral("/sys/class/drm/%1/gt/gt0/rps_cur_freq_mhz").arg(card));
-            if (!cur.open(QIODevice::ReadOnly | QIODevice::Text)) {
-                continue;
-            }
-            QFile max(QStringLiteral("/sys/class/drm/%1/gt/gt0/rps_max_freq_mhz").arg(card));
-            if (!max.open(QIODevice::ReadOnly | QIODevice::Text)) {
-                cur.close();
-                continue;
-            }
-            bool curOk = false;
-            bool maxOk = false;
-            const qreal curV = cur.readAll().trimmed().toDouble(&curOk);
-            const qreal maxV = max.readAll().trimmed().toDouble(&maxOk);
+    for (const QString& card : cards) {
+        if (QFile::exists(QStringLiteral("/sys/class/drm/%1/device/gpu_busy_percent").arg(card)))
+            continue;
+        QFile cur(QStringLiteral("/sys/class/drm/%1/gt/gt0/rps_cur_freq_mhz").arg(card));
+        if (!cur.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            continue;
+        }
+        QFile max(QStringLiteral("/sys/class/drm/%1/gt/gt0/rps_max_freq_mhz").arg(card));
+        if (!max.open(QIODevice::ReadOnly | QIODevice::Text)) {
             cur.close();
-            max.close();
-            if (curOk && maxOk && maxV > 0.0) {
-                qreal ratio = curV / maxV;
-                if (ratio < 0.0) {
-                    ratio = 0.0;
-                }
-                if (ratio > 1.0) {
-                    ratio = 1.0;
-                }
-                sum += ratio * 100.0;
-                ++count;
+            continue;
+        }
+        bool curOk = false;
+        bool maxOk = false;
+        const qreal curV = cur.readAll().trimmed().toDouble(&curOk);
+        const qreal maxV = max.readAll().trimmed().toDouble(&maxOk);
+        cur.close();
+        max.close();
+        if (curOk && maxOk && maxV > 0.0) {
+            qreal ratio = curV / maxV;
+            if (ratio < 0.0) {
+                ratio = 0.0;
+            }
+            if (ratio > 1.0) {
+                ratio = 1.0;
+            }
+            const qreal v = ratio * 100.0;
+            if (v > maxPerc) {
+                maxPerc = v;
             }
         }
     }
 
-    const qreal newPerc = count > 0 ? sum / count / 100.0 : 0.0;
+    const qreal newPerc = maxPerc >= 0.0 ? maxPerc / 100.0 : 0.0;
     if (std::abs(newPerc - m_percentage) > 0.0001) {
         m_percentage = newPerc;
         Q_EMIT percentageChanged();

--- a/shell/plugin/src/Caelestia/Services/sensorslib.cpp
+++ b/shell/plugin/src/Caelestia/Services/sensorslib.cpp
@@ -112,10 +112,11 @@ std::optional<double> gpuPciAverageTemp() {
         return std::nullopt;
     }
 
-    double sumPrimary = 0.0;
-    int countPrimary = 0;
-    double sumFallback = 0.0;
-    int countFallback = 0;
+    // On hybrid / multi-GPU systems, averaging yields misleading numbers.
+    // Prefer the maximum primary GPU temperature across all PCI GPU devices;
+    // if none found, fall back to the maximum fallback sensor.
+    double maxPrimary = -1.0;
+    double maxFallback = -1.0;
 
     int chipNr = 0;
     while (const sensors_chip_name* chip = sensors_get_detected_chips(nullptr, &chipNr)) {
@@ -147,20 +148,22 @@ std::optional<double> gpuPciAverageTemp() {
                 continue;
             }
             if (isPrimary) {
-                sumPrimary += *v;
-                ++countPrimary;
+                if (*v > maxPrimary) {
+                    maxPrimary = *v;
+                }
             } else {
-                sumFallback += *v;
-                ++countFallback;
+                if (*v > maxFallback) {
+                    maxFallback = *v;
+                }
             }
         }
     }
 
-    if (countPrimary > 0) {
-        return sumPrimary / countPrimary;
+    if (maxPrimary >= 0.0) {
+        return maxPrimary;
     }
-    if (countFallback > 0) {
-        return sumFallback / countFallback;
+    if (maxFallback >= 0.0) {
+        return maxFallback;
     }
     return std::nullopt;
 }


### PR DESCRIPTION
## What does this change?

Fixes incorrect averaging of GPU usage and temperatures on hybrid/multi-GPU systems (Closes #616, recreated against `dev` as requested by @ladybug-me in #633).

- `Gpu::readGenericUsage()` now reports the maximum per-card usage across both Pass 1 (`gpu_busy_percent`) and Pass 2 (Intel iGPU frequency ratio) instead of averaging them.
- `sensorslib::gpuPciAverageTemp()` now returns the maximum primary (or fallback) temperature across PCI GPU devices instead of averaging.

## Screenshots (if UI change)
N/A (backend service monitoring calculation)

## How did you test it?
- Verified per-card sysfs nodes `/sys/class/drm/card*/device/gpu_busy_percent` and Intel frequency ratios `/gt/gt0/rps_cur_freq_mhz` under simulated hybrid GPU loads (100% discrete load + 0% idle integrated load), confirming reporting reflects the active GPU (100%) rather than an artificial arithmetic mean (~50%).
- Verified `sensorslib::gpuPciAverageTemp()` selection logic for primary temperature sensors against fallback sensors.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Config / theme
- [ ] Docs
- [ ] Refactor
- [ ] Other

## Notes for reviewers

Per @ladybug-me's feedback on #633, this PR is cleanly built on top of the latest `dev` branch, integrating with both Pass 1 and Pass 2 detection paths.

Closes #616
/claim #616
