### PR TITLE
fix: security review findings for installer and shell services

### DIFF
--- a/.github/docs/installer_config.md
+++ b/.github/docs/installer_config.md
@@ -255,7 +255,7 @@ In addition to dynamic variables generated from `menu.json` selections, the C++ 
 | Variable | Description |
 |----------|-------------|
 | `PATH` | Prepends the per-run private sudo wrapper dir to enable the custom sudo credential wrapper. |
-| `SUDO_ASKPASS` | Points to the per-run askpass helper that supplies the sudo password. |
+| `SUDO_PASS` | Password exported to step scripts that require it. |
 | `CACHE_DIR` | The primary Caelestia cache directory (usually `~/.cache/caelestia-kde`). |
 | `BUILDDIR` | The directory used for building AUR packages (`makepkg-build`). |
 | `PKGDEST` | The destination for compiled `.pkg.tar.zst` packages. |

--- a/.github/docs/installer_config.md
+++ b/.github/docs/installer_config.md
@@ -254,8 +254,8 @@ In addition to dynamic variables generated from `menu.json` selections, the C++ 
 
 | Variable | Description |
 |----------|-------------|
-| `PATH` | Prepends `/tmp/caelestia_bin` to enable the custom sudo credential wrapper. |
-| `SUDO_ASKPASS` | Points to the custom sudo credential wrapper script. |
+| `PATH` | Prepends the per-run private sudo wrapper dir to enable the custom sudo credential wrapper. |
+| `SUDO_ASKPASS` | Points to the per-run askpass helper that supplies the sudo password. |
 | `CACHE_DIR` | The primary Caelestia cache directory (usually `~/.cache/caelestia-kde`). |
 | `BUILDDIR` | The directory used for building AUR packages (`makepkg-build`). |
 | `PKGDEST` | The destination for compiled `.pkg.tar.zst` packages. |

--- a/installer/src/Globals.cpp
+++ b/installer/src/Globals.cpp
@@ -8,6 +8,7 @@ int g_term_width = 80;
 int g_term_height = 24;
 std::string g_base_distro = "unknown";
 std::string g_bundle_dir = ".";
+std::string g_sudo_bin_dir;
 
 Config g_config;
 bool g_logout = false;

--- a/installer/src/Globals.hpp
+++ b/installer/src/Globals.hpp
@@ -17,6 +17,7 @@ extern int g_term_width;
 extern int g_term_height;
 extern std::string g_base_distro;
 extern std::string g_bundle_dir;
+extern std::string g_sudo_bin_dir;
 
 void load_bundle_dir();
 void load_theme();

--- a/installer/src/Runner.cpp
+++ b/installer/src/Runner.cpp
@@ -449,7 +449,9 @@ void execute() {
 
   // Inject our sudo wrapper into the PATH so step scripts never prompt.
   string current_path = getenv("PATH") ? getenv("PATH") : "/usr/bin";
-  setenv("PATH", ("/tmp/caelestia_bin:" + current_path).c_str(), 1);
+  if (!g_sudo_bin_dir.empty()) {
+    setenv("PATH", (g_sudo_bin_dir + ":" + current_path).c_str(), 1);
+  }
 
   setenv("CONFIRM_ARG", "--noconfirm", 1);
 
@@ -525,8 +527,9 @@ void execute() {
         int st2 = 0;
         waitpid(child, &st2, 0);
         Term::restore();
-        system("rm -rf /tmp/caelestia_pass.txt /tmp/caelestia_askpass.sh "
-               "/tmp/caelestia_bin");
+        if (!g_sudo_bin_dir.empty()) {
+          system(("rm -rf \"" + g_sudo_bin_dir + "\"").c_str());
+        }
         exit(130);
       }
 

--- a/installer/src/UI.cpp
+++ b/installer/src/UI.cpp
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <sys/wait.h>
 #include <sys/stat.h>
+#include <signal.h>
 #include <thread>
 #include <unordered_map>
 #include <unistd.h>
@@ -53,6 +54,29 @@ bool write_file_excl(const string& path, const string& content, int mode) {
     ssize_t written = write(fd, content.c_str(), content.size());
     close(fd);
     return written == static_cast<ssize_t>(content.size());
+}
+
+bool is_systemd_inhibit(pid_t pid) {
+    ifstream cmdline("/proc/" + to_string(pid) + "/cmdline", ios::binary);
+    string command((istreambuf_iterator<char>(cmdline)), istreambuf_iterator<char>());
+    return command.find("systemd-inhibit") != string::npos;
+}
+
+void release_kde_inhibit(const string& cookie_file) {
+    ifstream cookie(cookie_file);
+    string value;
+    getline(cookie, value);
+    if (value.empty())
+        return;
+    pid_t child = fork();
+    if (child == 0) {
+        execlp("qdbus6", "qdbus6", "org.freedesktop.ScreenSaver",
+               "/ScreenSaver", "org.freedesktop.ScreenSaver.UnInhibit",
+               value.c_str(), static_cast<char*>(nullptr));
+        _exit(127);
+    }
+    if (child > 0)
+        waitpid(child, nullptr, 0);
 }
 
 // Sets up the sudo askpass environment after a successful password
@@ -111,14 +135,42 @@ bool setup_sudo_environment(const string& pw) {
     // Reap an inhibitor left by a killed earlier run before starting a fresh
     // one; the shell EXIT trap can't run on SIGKILL or a hard crash. Only kill
     // a process whose command line identifies it as our systemd inhibitor.
-    system(("if [ -f \"" + pid_file + "\" ]; then p=$(cat \"" + pid_file +
-            "\"); if [ -r \"/proc/$p/cmdline\" ] && tr '\\0' ' ' < \"/proc/$p/cmdline\" | grep -q systemd-inhibit; then kill -9 \"$p\" 2>/dev/null; fi; fi").c_str());
-    system(("if [ -f \"" + cookie_file + "\" ]; then qdbus6 org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver.UnInhibit \"$(cat \"" +
-            cookie_file + "\")\" 2>/dev/null; fi").c_str());
+    ifstream old_pid(pid_file);
+    pid_t pid = 0;
+    old_pid >> pid;
+    if (pid > 0 && is_systemd_inhibit(pid))
+        kill(pid, SIGKILL);
+    release_kde_inhibit(cookie_file);
 
     // Start background keep-awake for display (sleep inhibitor)
-    system(("systemd-inhibit --what=idle:sleep --who=\"Caelestia Installer\" --why=\"Installation in progress\" bash -c 'while :; do sleep 600; done' >/dev/null 2>&1 & echo $! > \"" + pid_file + "\"").c_str());
-    system(("qdbus6 org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver.Inhibit \"Caelestia Installer\" \"Installation in progress\" > \"" + cookie_file + "\" 2>/dev/null").c_str());
+    pid = fork();
+    if (pid == 0) {
+        execlp("systemd-inhibit", "systemd-inhibit", "--what=idle:sleep",
+               "--who=Caelestia Installer", "--why=Installation in progress",
+               "bash", "-c", "while :; do sleep 600; done",
+               static_cast<char*>(nullptr));
+        _exit(127);
+    }
+    if (pid > 0) {
+        ofstream pid_out(pid_file);
+        pid_out << pid << '\n';
+    }
+
+    int cookie_fd = open(cookie_file.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
+    pid = fork();
+    if (pid == 0) {
+        if (cookie_fd >= 0)
+            dup2(cookie_fd, STDOUT_FILENO);
+        execlp("qdbus6", "qdbus6", "org.freedesktop.ScreenSaver",
+               "/ScreenSaver", "org.freedesktop.ScreenSaver.Inhibit",
+               "Caelestia Installer", "Installation in progress",
+               static_cast<char*>(nullptr));
+        _exit(127);
+    }
+    if (cookie_fd >= 0)
+        close(cookie_fd);
+    if (pid > 0)
+        waitpid(pid, nullptr, 0);
     return true;
 }
 

--- a/installer/src/UI.cpp
+++ b/installer/src/UI.cpp
@@ -41,20 +41,40 @@ bool write_password_file_secure(const string& path, const string& password) {
     return written == static_cast<ssize_t>(data.size());
 }
 
+// Writes @p content to @p path with O_EXCL, so a file (or symlink) already at
+// that path is never followed or overwritten.
+bool write_file_excl(const string& path, const string& content, int mode) {
+    int fd = open(path.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, mode);
+    if (fd == -1) {
+        return false;
+    }
+    ssize_t written = write(fd, content.c_str(), content.size());
+    close(fd);
+    return written == static_cast<ssize_t>(content.size());
+}
+
 // Sets up the sudo askpass environment after a successful password
 // verification. Creates the password file, askpass helper, sudo wrapper,
 // screen inhibitor, and exports SUDO_PASS.
 void setup_sudo_environment(const string& pw) {
-    system("mkdir -p /tmp/caelestia_bin");
+    // Per-run, user-owned temp dir instead of a fixed, predictable /tmp path.
+    // mkdtemp creates it 0700, and the O_EXCL writes below can't follow a
+    // symlink someone else planted at a known name.
+    char tmpl[] = "/tmp/caelestia-bin.XXXXXX";
+    char* dir = mkdtemp(tmpl);
+    if (!dir) {
+        return;
+    }
+    g_sudo_bin_dir = dir;
 
-    // Write password with secure permissions from the start (no TOCTOU window)
-    write_password_file_secure("/tmp/caelestia_pass.txt", pw);
+    write_password_file_secure(g_sudo_bin_dir + "/pass.txt", pw);
 
-    // Askpass script
-    system("echo '#!/bin/bash\ncat /tmp/caelestia_pass.txt' > /tmp/caelestia_askpass.sh && chmod 700 /tmp/caelestia_askpass.sh");
+    string askpass = "#!/bin/bash\ncat " + g_sudo_bin_dir + "/pass.txt\n";
+    write_file_excl(g_sudo_bin_dir + "/askpass.sh", askpass, 0700);
 
-    // Sudo wrapper to force -A
-    system("echo '#!/bin/bash\nexport SUDO_ASKPASS=/tmp/caelestia_askpass.sh\nexec /usr/bin/sudo -A \"$@\"' > /tmp/caelestia_bin/sudo && chmod 700 /tmp/caelestia_bin/sudo");
+    string wrapper = "#!/bin/bash\nexport SUDO_ASKPASS=" + g_sudo_bin_dir +
+                     "/askpass.sh\nexec /usr/bin/sudo -A \"$@\"\n";
+    write_file_excl(g_sudo_bin_dir + "/sudo", wrapper, 0700);
 
     // Also export SUDO_PASS for some scripts (like 09-system-tweaks.sh) that might rely on it
     setenv("SUDO_PASS", pw.c_str(), 1);

--- a/installer/src/UI.cpp
+++ b/installer/src/UI.cpp
@@ -79,6 +79,11 @@ void setup_sudo_environment(const string& pw) {
     // Also export SUDO_PASS for some scripts (like 09-system-tweaks.sh) that might rely on it
     setenv("SUDO_PASS", pw.c_str(), 1);
 
+    // Reap an inhibitor left by a killed earlier run before starting a fresh
+    // one; the shell EXIT trap can't run on SIGKILL or a hard crash.
+    system("if [ -f /tmp/caelestia_inhibit.pid ]; then kill -9 \"$(cat /tmp/caelestia_inhibit.pid)\" 2>/dev/null; fi");
+    system("if [ -f /tmp/caelestia_kde_inhibit.cookie ]; then qdbus6 org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver.UnInhibit \"$(cat /tmp/caelestia_kde_inhibit.cookie)\" 2>/dev/null; fi");
+
     // Start background keep-awake for display (sleep inhibitor)
     system("systemd-inhibit --what=idle:sleep --who=\"Caelestia Installer\" --why=\"Installation in progress\" bash -c 'while :; do sleep 600; done' >/dev/null 2>&1 & echo $! > /tmp/caelestia_inhibit.pid");
     system("qdbus6 org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver.Inhibit \"Caelestia Installer\" \"Installation in progress\" > /tmp/caelestia_kde_inhibit.cookie 2>/dev/null");

--- a/installer/src/UI.cpp
+++ b/installer/src/UI.cpp
@@ -10,10 +10,12 @@
 #include <cstdlib>
 #include <ctime>
 #include <fcntl.h>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <sys/wait.h>
+#include <sys/stat.h>
 #include <thread>
 #include <unordered_map>
 #include <unistd.h>
@@ -56,37 +58,68 @@ bool write_file_excl(const string& path, const string& content, int mode) {
 // Sets up the sudo askpass environment after a successful password
 // verification. Creates the password file, askpass helper, sudo wrapper,
 // screen inhibitor, and exports SUDO_PASS.
-void setup_sudo_environment(const string& pw) {
+bool setup_sudo_environment(const string& pw) {
     // Per-run, user-owned temp dir instead of a fixed, predictable /tmp path.
     // mkdtemp creates it 0700, and the O_EXCL writes below can't follow a
     // symlink someone else planted at a known name.
     char tmpl[] = "/tmp/caelestia-bin.XXXXXX";
     char* dir = mkdtemp(tmpl);
     if (!dir) {
-        return;
+        return false;
     }
     g_sudo_bin_dir = dir;
 
-    write_password_file_secure(g_sudo_bin_dir + "/pass.txt", pw);
+    if (!write_password_file_secure(g_sudo_bin_dir + "/pass.txt", pw)) {
+        std::filesystem::remove_all(g_sudo_bin_dir);
+        g_sudo_bin_dir.clear();
+        return false;
+    }
 
     string askpass = "#!/bin/bash\ncat " + g_sudo_bin_dir + "/pass.txt\n";
-    write_file_excl(g_sudo_bin_dir + "/askpass.sh", askpass, 0700);
+    if (!write_file_excl(g_sudo_bin_dir + "/askpass.sh", askpass, 0700)) {
+        std::filesystem::remove_all(g_sudo_bin_dir);
+        g_sudo_bin_dir.clear();
+        return false;
+    }
 
     string wrapper = "#!/bin/bash\nexport SUDO_ASKPASS=" + g_sudo_bin_dir +
                      "/askpass.sh\nexec /usr/bin/sudo -A \"$@\"\n";
-    write_file_excl(g_sudo_bin_dir + "/sudo", wrapper, 0700);
+    if (!write_file_excl(g_sudo_bin_dir + "/sudo", wrapper, 0700)) {
+        std::filesystem::remove_all(g_sudo_bin_dir);
+        g_sudo_bin_dir.clear();
+        return false;
+    }
 
     // Also export SUDO_PASS for some scripts (like 09-system-tweaks.sh) that might rely on it
     setenv("SUDO_PASS", pw.c_str(), 1);
 
+    const char* runtime = getenv("XDG_RUNTIME_DIR");
+    const char* home = getenv("HOME");
+    string state_dir = string(runtime ? runtime : (getenv("XDG_STATE_HOME")
+        ? getenv("XDG_STATE_HOME")
+        : (home ? string(home) + "/.local/state" : "/tmp"))) + "/caelestia";
+    std::error_code state_error;
+    std::filesystem::create_directories(state_dir, state_error);
+    if (state_error || chmod(state_dir.c_str(), 0700) != 0) {
+        std::filesystem::remove_all(g_sudo_bin_dir);
+        g_sudo_bin_dir.clear();
+        return false;
+    }
+    const string pid_file = state_dir + "/inhibit.pid";
+    const string cookie_file = state_dir + "/kde_inhibit.cookie";
+
     // Reap an inhibitor left by a killed earlier run before starting a fresh
-    // one; the shell EXIT trap can't run on SIGKILL or a hard crash.
-    system("if [ -f /tmp/caelestia_inhibit.pid ]; then kill -9 \"$(cat /tmp/caelestia_inhibit.pid)\" 2>/dev/null; fi");
-    system("if [ -f /tmp/caelestia_kde_inhibit.cookie ]; then qdbus6 org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver.UnInhibit \"$(cat /tmp/caelestia_kde_inhibit.cookie)\" 2>/dev/null; fi");
+    // one; the shell EXIT trap can't run on SIGKILL or a hard crash. Only kill
+    // a process whose command line identifies it as our systemd inhibitor.
+    system(("if [ -f \"" + pid_file + "\" ]; then p=$(cat \"" + pid_file +
+            "\"); if [ -r \"/proc/$p/cmdline\" ] && tr '\\0' ' ' < \"/proc/$p/cmdline\" | grep -q systemd-inhibit; then kill -9 \"$p\" 2>/dev/null; fi; fi").c_str());
+    system(("if [ -f \"" + cookie_file + "\" ]; then qdbus6 org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver.UnInhibit \"$(cat \"" +
+            cookie_file + "\")\" 2>/dev/null; fi").c_str());
 
     // Start background keep-awake for display (sleep inhibitor)
-    system("systemd-inhibit --what=idle:sleep --who=\"Caelestia Installer\" --why=\"Installation in progress\" bash -c 'while :; do sleep 600; done' >/dev/null 2>&1 & echo $! > /tmp/caelestia_inhibit.pid");
-    system("qdbus6 org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver.Inhibit \"Caelestia Installer\" \"Installation in progress\" > /tmp/caelestia_kde_inhibit.cookie 2>/dev/null");
+    system(("systemd-inhibit --what=idle:sleep --who=\"Caelestia Installer\" --why=\"Installation in progress\" bash -c 'while :; do sleep 600; done' >/dev/null 2>&1 & echo $! > \"" + pid_file + "\"").c_str());
+    system(("qdbus6 org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver.Inhibit \"Caelestia Installer\" \"Installation in progress\" > \"" + cookie_file + "\" 2>/dev/null").c_str());
+    return true;
 }
 
 // Human-readable distro label shown on the welcome screen.
@@ -436,8 +469,11 @@ namespace UI {
                     fflush(pipe);
                     int status = pclose(pipe);
                     if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
-                        setup_sudo_environment(candidate);
-                        return true;
+                        if (setup_sudo_environment(candidate))
+                            return true;
+                        error_msg = "Could not prepare secure sudo helpers.";
+                        pw.clear();
+                        return false;
                     }
                 }
                 attempts++;

--- a/installer/src/main.cpp
+++ b/installer/src/main.cpp
@@ -34,7 +34,9 @@ void check_signals() {
     if (g_sigint_received || g_sigterm_received) {
         g_quit = true;
         Term::restore();
-        system("rm -rf /tmp/caelestia_pass.txt /tmp/caelestia_askpass.sh /tmp/caelestia_bin");
+        if (!g_sudo_bin_dir.empty()) {
+            system(("rm -rf \"" + g_sudo_bin_dir + "\"").c_str());
+        }
         exit(130);
     }
 }
@@ -288,7 +290,9 @@ int main(int argc, char** argv) {
     }
     
     // Secure cleanup of sudo credentials
-    system("rm -rf /tmp/caelestia_pass.txt /tmp/caelestia_askpass.sh /tmp/caelestia_bin");
+    if (!g_sudo_bin_dir.empty()) {
+        system(("rm -rf \"" + g_sudo_bin_dir + "\"").c_str());
+    }
 
     if (g_logout) {
         cout << "\nLogging out...\n";

--- a/scripts/01-ensure-prereqs.sh
+++ b/scripts/01-ensure-prereqs.sh
@@ -44,9 +44,9 @@ if [[ "$BASE_DISTRO" == "arch" ]]; then
     fi
     if [[ -f /etc/makepkg.conf ]] && grep -q '!ccache' /etc/makepkg.conf; then
         info "Enabling ccache in /etc/makepkg.conf (system-wide makepkg setting)..."
-        sudo sed -i 's/!ccache/ccache/' /etc/makepkg.conf
         mkdir -p "${XDG_STATE_HOME:-$HOME/.local/state}/caelestia"
         touch "${XDG_STATE_HOME:-$HOME/.local/state}/caelestia/ccache-enabled"
+        sudo sed -i 's/!ccache/ccache/' /etc/makepkg.conf
     fi
     ok "makepkg ccache configured."
 

--- a/scripts/01-ensure-prereqs.sh
+++ b/scripts/01-ensure-prereqs.sh
@@ -42,8 +42,11 @@ if [[ "$BASE_DISTRO" == "arch" ]]; then
         info "ccache not found, installing..."
         sudo pacman -S --needed --noconfirm ccache
     fi
-    if [[ -f /etc/makepkg.conf ]]; then
+    if [[ -f /etc/makepkg.conf ]] && grep -q '!ccache' /etc/makepkg.conf; then
+        info "Enabling ccache in /etc/makepkg.conf (system-wide makepkg setting)..."
         sudo sed -i 's/!ccache/ccache/' /etc/makepkg.conf
+        mkdir -p "${XDG_STATE_HOME:-$HOME/.local/state}/caelestia"
+        touch "${XDG_STATE_HOME:-$HOME/.local/state}/caelestia/ccache-enabled"
     fi
     ok "makepkg ccache configured."
 

--- a/scripts/04-deploy-kde.sh
+++ b/scripts/04-deploy-kde.sh
@@ -92,7 +92,7 @@ After=graphical-session.target
 
 [Service]
 Type=simple
-ExecStart=/bin/bash -c "wl-paste --type text --watch cliphist store & wl-paste --type image --watch cliphist store & wl-clip-persist --clipboard regular & wait"
+ExecStart=/bin/bash -c 'command -v wl-paste >/dev/null 2>&1 || { echo "missing: wl-paste" >&2; exit 1; }; command -v cliphist >/dev/null 2>&1 || { echo "missing: cliphist" >&2; exit 1; }; command -v wl-clip-persist >/dev/null 2>&1 || { echo "missing: wl-clip-persist" >&2; exit 1; }; wl-paste --type text --watch cliphist store & wl-paste --type image --watch cliphist store & wl-clip-persist --clipboard regular & wait -n'
 Restart=always
 RestartSec=3
 

--- a/scripts/04-deploy-kde.sh
+++ b/scripts/04-deploy-kde.sh
@@ -18,9 +18,12 @@ BUNDLE_DIR="${BUNDLE_DIR:?BUNDLE_DIR not set}"
 
 # True when a Darkly KWin decoration is actually installed and loadable.
 darkly_decoration_installed() {
-    [[ -d /usr/share/kwin/decorations/org.kde.darkly ]] ||
-    [[ -d /usr/local/share/kwin/decorations/org.kde.darkly ]] ||
-    [[ -d "${XDG_DATA_HOME:-$HOME/.local/share}/kwin/decorations/org.kde.darkly" ]]
+    local plugin_dir
+    plugin_dir="$(qtpaths6 --plugin-dir 2>/dev/null || true)"
+    [[ -n "$plugin_dir" && -f "$plugin_dir/org.kde.kdecoration3/org.kde.darkly.so" ]] ||
+    [[ -f /usr/lib/qt6/plugins/org.kde.kdecoration3/org.kde.darkly.so ]] ||
+    [[ -f /usr/local/lib/qt6/plugins/org.kde.kdecoration3/org.kde.darkly.so ]] ||
+    [[ -f "${HOME}/.local/lib/qt6/plugins/org.kde.kdecoration3/org.kde.darkly.so" ]]
 }
 
 echo
@@ -59,7 +62,7 @@ if [[ "${APPLY_DARKLY:-true}" == "true" ]]; then
         kwriteconfig6 --file kwinrc --group "org.kde.kdecoration2" \
             --key "library" "org.kde.breeze" 2>/dev/null || true
         kwriteconfig6 --file kwinrc --group "org.kde.kdecoration2" \
-            --key "theme" "@breeze" 2>/dev/null || true
+            --key "theme" "Breeze" 2>/dev/null || true
     fi
 
 else

--- a/scripts/04-deploy-kde.sh
+++ b/scripts/04-deploy-kde.sh
@@ -16,6 +16,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/log.sh"
 
 BUNDLE_DIR="${BUNDLE_DIR:?BUNDLE_DIR not set}"
 
+# True when a Darkly KWin decoration is actually installed and loadable.
+darkly_decoration_installed() {
+    [[ -d /usr/share/kwin/decorations/org.kde.darkly ]] ||
+    [[ -d /usr/local/share/kwin/decorations/org.kde.darkly ]] ||
+    [[ -d "${XDG_DATA_HOME:-$HOME/.local/share}/kwin/decorations/org.kde.darkly" ]]
+}
+
 echo
 echo ""
 info "Applying KDE settings"
@@ -39,14 +46,21 @@ if [[ "${APPLY_DARKLY:-true}" == "true" ]]; then
     kwriteconfig6 --file kdeglobals --group "KDE" --key "widgetStyle" "darkly" 2>/dev/null || true
     kwriteconfig6 --file kdeglobals --group "General" --key "ColorScheme" "Darkly" 2>/dev/null || true
 
-    #  Darkly: Window decoration 
+    #  Darkly: Window decoration
     info "Applying Darkly window decoration..."
-    kwriteconfig6 --file kwinrc --group "org.kde.kdecoration2" \
-        --key "library" "org.kde.darkly" 2>/dev/null || \
-    kwriteconfig6 --file kwinrc --group "org.kde.kdecoration2" \
-        --key "library" "org.kde.breeze" 2>/dev/null || true
-    kwriteconfig6 --file kwinrc --group "org.kde.kdecoration2" \
-        --key "theme" "@darkly" 2>/dev/null || true
+    if darkly_decoration_installed; then
+        kwriteconfig6 --file kwinrc --group "org.kde.kdecoration2" \
+            --key "library" "org.kde.darkly" 2>/dev/null || true
+        kwriteconfig6 --file kwinrc --group "org.kde.kdecoration2" \
+            --key "theme" "@darkly" 2>/dev/null || true
+    else
+        # kwriteconfig6 can't tell whether a decoration is loadable, so check
+        # ourselves and fall back to Breeze when Darkly isn't installed.
+        kwriteconfig6 --file kwinrc --group "org.kde.kdecoration2" \
+            --key "library" "org.kde.breeze" 2>/dev/null || true
+        kwriteconfig6 --file kwinrc --group "org.kde.kdecoration2" \
+            --key "theme" "@breeze" 2>/dev/null || true
+    fi
 
 else
     skip "Skipping Darkly theme"

--- a/scripts/06-services.sh
+++ b/scripts/06-services.sh
@@ -130,8 +130,14 @@ WantedBy=graphical-session.target
 UNIT
 systemctl --user daemon-reload
 systemctl --user enable ydotoold.service 2>/dev/null || true
-systemctl --user start ydotoold.service 2>/dev/null || \
-    info "ydotoold will start on next login."
+# The 'input' group only applies to new logins; starting the daemon in the
+# same session that just got the group would silently fail to open /dev/uinput.
+if id -nG | grep -q '\binput\b'; then
+    systemctl --user start ydotoold.service 2>/dev/null || \
+        info "ydotoold will start on next login."
+else
+    info "ydotoold starts on next login (input group takes effect then)."
+fi
 ok "ydotoold service configured."
 
 ok "Services configured."

--- a/scripts/08-build-shell.sh
+++ b/scripts/08-build-shell.sh
@@ -330,6 +330,16 @@ else
         exit 1
     fi
 
+    # Snapshot the live shell tree before install overwrites it, so local
+    # edits made per CONTRIBUTING.md survive an update instead of vanishing.
+    QS_CONF="$HOME/.config/quickshell/caelestia"
+    if [[ -d "$QS_CONF" ]]; then
+        _qs_backup_dir="${XDG_CACHE_HOME:-$HOME/.cache}/caelestia-kde/backups"
+        mkdir -p "$_qs_backup_dir"
+        cp -r "$QS_CONF" "$_qs_backup_dir/quickshell-caelestia-$(date +%Y%m%d_%H%M%S)" 2>/dev/null || true
+        ls -1dt "$_qs_backup_dir"/quickshell-caelestia-* 2>/dev/null | tail -n +4 | xargs -r rm -rf
+    fi
+
     info "Installing to user local dir..."
     if ! cmake --install build 2>&1 | tee -a "$BUILD_LOG"; then
         err "Installation failed. Full log: $BUILD_LOG"

--- a/scripts/08-build-shell.sh
+++ b/scripts/08-build-shell.sh
@@ -335,9 +335,21 @@ else
     QS_CONF="$HOME/.config/quickshell/caelestia"
     if [[ -d "$QS_CONF" ]]; then
         _qs_backup_dir="${XDG_CACHE_HOME:-$HOME/.cache}/caelestia-kde/backups"
-        mkdir -p "$_qs_backup_dir"
-        cp -r "$QS_CONF" "$_qs_backup_dir/quickshell-caelestia-$(date +%Y%m%d_%H%M%S)" 2>/dev/null || true
-        ls -1dt "$_qs_backup_dir"/quickshell-caelestia-* 2>/dev/null | tail -n +4 | xargs -r rm -rf
+        mkdir -p "$_qs_backup_dir" || {
+            err "Could not create shell backup directory: $_qs_backup_dir"
+            exit 1
+        }
+        _qs_backup="$_qs_backup_dir/quickshell-caelestia-$(date +%Y%m%d_%H%M%S)"
+        if ! cp -r "$QS_CONF" "$_qs_backup"; then
+            err "Could not back up shell configuration to: $_qs_backup"
+            exit 1
+        fi
+        _qs_backups=( "$_qs_backup_dir"/quickshell-caelestia-* )
+        if [[ -e "${_qs_backups[0]}" ]]; then
+            for ((i = 0; i < ${#_qs_backups[@]} - 3; i++)); do
+                rm -rf -- "${_qs_backups[$i]}"
+            done
+        fi
     fi
 
     info "Installing to user local dir..."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -308,13 +308,21 @@ cleanup_install_state() {
     tput cnorm 2>/dev/null || true
     printf '\033[0m\033[?1049l\033[?25h' 2>/dev/null || true
 
-    if [[ -f /tmp/caelestia_inhibit.pid ]]; then
-        kill -9 "$(cat /tmp/caelestia_inhibit.pid)" 2>/dev/null || true
+    local inhibit_dir="${XDG_RUNTIME_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}}/caelestia"
+    local inhibit_pid="$inhibit_dir/inhibit.pid"
+    local kde_cookie="$inhibit_dir/kde_inhibit.cookie"
+    if [[ -f "$inhibit_pid" ]]; then
+        local pid
+        pid="$(cat "$inhibit_pid")"
+        if [[ -r "/proc/$pid/cmdline" ]] &&
+            tr '\0' ' ' <"/proc/$pid/cmdline" | grep -q systemd-inhibit; then
+            kill -9 "$pid" 2>/dev/null || true
+        fi
     fi
-    if [[ -f /tmp/caelestia_kde_inhibit.cookie ]]; then
-        qdbus6 org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver.UnInhibit "$(cat /tmp/caelestia_kde_inhibit.cookie)" 2>/dev/null || true
+    if [[ -f "$kde_cookie" ]]; then
+        qdbus6 org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver.UnInhibit "$(cat "$kde_cookie")" 2>/dev/null || true
     fi
-    rm -f /tmp/caelestia_inhibit.pid /tmp/caelestia_kde_inhibit.cookie
+    rm -f "$inhibit_pid" "$kde_cookie"
 }
 trap cleanup_install_state EXIT
 

--- a/shell/plugin/src/Caelestia/Services/NmQt.cpp
+++ b/shell/plugin/src/Caelestia/Services/NmQt.cpp
@@ -23,8 +23,10 @@
 #include <QHash>
 #include <QHostAddress>
 #include <QJSEngine>
+#include <QList>
 #include <QLoggingCategory>
 #include <QSet>
+#include <QSharedPointer>
 #include <algorithm>
 
 Q_LOGGING_CATEGORY(lcNmQt, "caelestia.services.nmqt", QtInfoMsg)
@@ -442,6 +444,9 @@ void NmQt::disconnectFromNetwork() {
 }
 
 void NmQt::forgetNetwork(const QString& ssid, QJSValue callback) {
+    // Forget every saved profile with this SSID, not just the first one NM
+    // enumerates. Duplicate profiles happen after a router password change.
+    QList<NetworkManager::Connection::Ptr> matches;
     const auto connPaths = NetworkManager::listConnections();
     for (const auto& conn : connPaths) {
         if (!conn || !conn->settings())
@@ -452,21 +457,27 @@ void NmQt::forgetNetwork(const QString& ssid, QJSValue callback) {
             continue;
 
         auto* wirelessSetting = static_cast<NetworkManager::WirelessSetting*>(ws.data());
-        if (wirelessSetting->ssid() == ssid) {
-            QDBusPendingReply<> reply = conn->remove();
-            auto* watcher = new QDBusPendingCallWatcher(reply, this);
-            connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, callback](QDBusPendingCallWatcher* w) {
-                w->deleteLater();
-                QDBusPendingReply<> r = *w;
-                invokeCallback(callback, !r.isError(), r.isError() ? QString() : QStringLiteral("Deleted"),
-                    r.isError() ? r.error().message() : QString());
-                refreshSavedConnections();
-            });
-            return;
-        }
+        if (wirelessSetting->ssid() == ssid)
+            matches.append(conn);
     }
 
-    invokeCallback(callback, false, {}, "No connection found for SSID", -1);
+    if (matches.isEmpty()) {
+        invokeCallback(callback, false, {}, "No connection found for SSID", -1);
+        return;
+    }
+
+    auto remaining = QSharedPointer<int>(new int(matches.size()));
+    for (const auto& conn : matches) {
+        QDBusPendingReply<> reply = conn->remove();
+        auto* watcher = new QDBusPendingCallWatcher(reply, this);
+        connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, callback, remaining](QDBusPendingCallWatcher* w) {
+            w->deleteLater();
+            if (--*remaining > 0)
+                return;
+            refreshSavedConnections();
+            invokeCallback(callback, true, QStringLiteral("Deleted"));
+        });
+    }
 }
 
 void NmQt::enableWifi(bool enabled, QJSValue callback) {

--- a/shell/plugin/src/Caelestia/Services/NmQt.cpp
+++ b/shell/plugin/src/Caelestia/Services/NmQt.cpp
@@ -467,15 +467,21 @@ void NmQt::forgetNetwork(const QString& ssid, QJSValue callback) {
     }
 
     auto remaining = QSharedPointer<int>(new int(matches.size()));
+    auto failed = QSharedPointer<QString>(new QString);
     for (const auto& conn : matches) {
         QDBusPendingReply<> reply = conn->remove();
         auto* watcher = new QDBusPendingCallWatcher(reply, this);
-        connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, callback, remaining](QDBusPendingCallWatcher* w) {
+        connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, callback, remaining, failed](QDBusPendingCallWatcher* w) {
+            if (w->isError() && failed->isEmpty())
+                *failed = w->error().message();
             w->deleteLater();
             if (--*remaining > 0)
                 return;
             refreshSavedConnections();
-            invokeCallback(callback, true, QStringLiteral("Deleted"));
+            if (failed->isEmpty())
+                invokeCallback(callback, true, QStringLiteral("Deleted"));
+            else
+                invokeCallback(callback, false, {}, *failed, -1);
         });
     }
 }

--- a/shell/plugin/src/Caelestia/Services/minimizegeometry.cpp
+++ b/shell/plugin/src/Caelestia/Services/minimizegeometry.cpp
@@ -50,7 +50,11 @@ void MinimizeGeometry::setGeometry(QQuickItem* anchor, const QString& uuid, int 
     // surface the rect is declared against.
     const auto key = PlasmaWindows::normaliseUuid(uuid);
     const QRect rect(x, y, width, height);
-    if (m_published.value(key) == rect) {
+    // Key by surface too: two monitors with mirrored docks can compute the
+    // same rect for the same window, and the dedupe must not drop the second
+    // surface's publish.
+    const quintptr surfaceKey = reinterpret_cast<quintptr>(surface);
+    if (m_published.value(key).value(surfaceKey) == rect) {
         return;
     }
 
@@ -64,7 +68,7 @@ void MinimizeGeometry::setGeometry(QQuickItem* anchor, const QString& uuid, int 
     handle->set_minimized_geometry(surface, static_cast<uint32_t>(std::max(0, rect.x())),
         static_cast<uint32_t>(std::max(0, rect.y())), static_cast<uint32_t>(rect.width()),
         static_cast<uint32_t>(rect.height()));
-    m_published.insert(key, rect);
+    m_published[key].insert(surfaceKey, rect);
 }
 
 void MinimizeGeometry::clearGeometry(QQuickItem* anchor, const QString& uuid) {
@@ -80,6 +84,10 @@ void MinimizeGeometry::clearGeometry(QQuickItem* anchor, const QString& uuid) {
     if (auto* surface = anchor ? surfaceFor(anchor->window()) : nullptr) {
         if (auto* handle = PlasmaWindows::instance()->handleFor(key)) {
             handle->unset_minimized_geometry(surface);
+        }
+        m_published[key].remove(reinterpret_cast<quintptr>(surface));
+        if (!m_published.value(key).isEmpty()) {
+            return;
         }
     }
     m_published.remove(key);

--- a/shell/plugin/src/Caelestia/Services/minimizegeometry.hpp
+++ b/shell/plugin/src/Caelestia/Services/minimizegeometry.hpp
@@ -51,7 +51,7 @@ public:
     Q_INVOKABLE void clearGeometry(QQuickItem* anchor, const QString& uuid);
 
 private:
-    QHash<QString, QRect> m_published;
+    QHash<QString, QHash<quintptr, QRect>> m_published;
 };
 
 } // namespace caelestia::services

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -599,6 +599,14 @@ if [[ -f /etc/udev/rules.d/80-uinput.rules ]]; then
     ok "Removed udev rule: 80-uinput.rules"
 fi
 
+# Revert the system-wide ccache flip made by 01-ensure-prereqs.sh, if we made it.
+CCACHE_FLAG="${XDG_STATE_HOME:-$HOME/.local/state}/caelestia/ccache-enabled"
+if [[ -f "$CCACHE_FLAG" ]] && [[ -f /etc/makepkg.conf ]]; then
+    sudo sed -i 's/ccache/!ccache/' /etc/makepkg.conf
+    rm -f "$CCACHE_FLAG"
+    ok "Reverted ccache in /etc/makepkg.conf"
+fi
+
 # sudoers file for ydotoold
 if [[ -f /etc/sudoers.d/ydotoold-nopasswd ]]; then
     sudo rm -f /etc/sudoers.d/ydotoold-nopasswd

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -602,9 +602,12 @@ fi
 # Revert the system-wide ccache flip made by 01-ensure-prereqs.sh, if we made it.
 CCACHE_FLAG="${XDG_STATE_HOME:-$HOME/.local/state}/caelestia/ccache-enabled"
 if [[ -f "$CCACHE_FLAG" ]] && [[ -f /etc/makepkg.conf ]]; then
-    sudo sed -i 's/ccache/!ccache/' /etc/makepkg.conf
-    rm -f "$CCACHE_FLAG"
-    ok "Reverted ccache in /etc/makepkg.conf"
+    if sudo sed -i 's/\(^\|[[:space:]]\)ccache\([[:space:]]\|$\)/\1!ccache\2/' /etc/makepkg.conf; then
+        rm -f "$CCACHE_FLAG"
+        ok "Reverted ccache in /etc/makepkg.conf"
+    else
+        warn "Could not revert ccache in /etc/makepkg.conf; retaining ownership marker."
+    fi
 fi
 
 # sudoers file for ydotoold


### PR DESCRIPTION
- installer: per-run private sudo shim dir + O_EXCL writes (#630)
- installer: reap orphaned sleep inhibitor before starting (#628)
- prereqs: disclose ccache flip and revert it on uninstall (#629)
- services: defer ydotoold start until the input group is active (#626)
- nmqt: forget every saved profile for an SSID, not just the first (#624)
- minimize geometry: key the cache by surface, not just rect (#622)
- cliphist: fail fast on missing watchers and use wait -n (#614)
- darkly: fall back to Breeze when the decoration is missing (#612)
- build shell: snapshot the live shell tree before install (#610)

Thanks for contributing! A few quick things help reviewers give you faster feedback.

## What does this change?

<!-- A sentence or two about what this PR does. -->

## Screenshots (if UI change)

<!-- Drag and drop images here. -->

## How did you test it?

<!-- e.g. "Ran setup.sh on a fresh CachyOS install", "Tested the launcher with 50+ apps", etc. -->

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Config / theme
- [ ] Docs
- [ ] Refactor
- [ ] Other

## Notes for reviewers

<!-- Anything tricky, trade-offs you made, or context that helps review. Delete if empty. -->
