### PR TITLE
fix(ci): pass --repo to gh release upload in container jobs

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -250,7 +250,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh release upload "$TAG" "$ARTIFACT" --clobber
+          # --repo: this job runs in a container where gh's git-based repo
+          # auto-detection fails ("failed to run git: not a git repository"),
+          # so name the repo explicitly instead of relying on local git state.
+          gh release upload "$TAG" "$ARTIFACT" --repo "$GITHUB_REPOSITORY" --clobber
 
   # ═══════════════════════════════════════════════════════════
   # Prebuilt installer TUI binaries (x86_64 + aarch64) so setup.sh
@@ -301,4 +304,4 @@ jobs:
           set -euo pipefail
           TUI_VERSION="$(tr -d '[:space:]' < installer/tui.version)"
           cp installer/build/caelestia-install "caelestia-install-${{ matrix.arch }}-v${TUI_VERSION}"
-          gh release upload "$TAG" "caelestia-install-${{ matrix.arch }}-v${TUI_VERSION}" --clobber
+          gh release upload "$TAG" "caelestia-install-${{ matrix.arch }}-v${TUI_VERSION}" --repo "$GITHUB_REPOSITORY" --clobber


### PR DESCRIPTION
## Summary

The `build-shell` job (Precompile shell artifacts) builds and stages the shell artifacts, then fails on the final `Attach Shell Artifacts to Release` step in 0s:

    failed to run git: fatal: not a git repository (or any parent up to mount point /)
    Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)

`gh` auto-detects the target repo by running `git` in the working directory. This job runs inside an `archlinux:base-devel` container, where that discovery stops at the container filesystem/mount boundary and never finds a repo, so `gh release upload` aborts before attaching the precompiled shell tarball.

## Change

Add `--repo \"\\"` to both `gh release upload` calls (`build-shell` and `build-installer`) so the target repo is explicit and no local git discovery is needed. `GITHUB_REPOSITORY` is always set in Actions.

## Why main

The version-release workflow only runs off `main` (push to main / workflow_dispatch), so the fix must land on `main` to take effect for the next release. The same single-file change is already on `dev` (34090cb6); this PR carries just that change with a clean base.

## Validation

Failing run: https://github.com/ladybug-me/caelestia-dots-kde/actions/runs/34044406847

No change to the build or staging steps - only the `gh` attach step is made repo-explicit. After merge, re-running the version-release workflow should attach the `caelestia-shell-*-qt*.tar.gz` artifact.
