### PR TITLE
fix(ci): build libcava from AUR for the prebuilt shell asset

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -208,10 +208,27 @@ jobs:
       - name: Install Shell Build Dependencies
         run: |
           set -euo pipefail
-          pacman -Syu --noconfirm --needed git github-cli cmake ninja \
+          pacman -Syu --noconfirm --needed git github-cli cmake ninja meson autoconf-archive \
             qt6-base qt6-declarative qt6-shadertools qt6-wayland qt6-tools \
             kwindowsystem kguiaddons kglobalaccel kconfig networkmanager-qt pulseaudio-qt \
-            libqalculate pipewire aubio cava lm_sensors extra-cmake-modules
+            libqalculate pipewire libpipewire aubio lm_sensors extra-cmake-modules \
+            fftw ncurses alsa-lib iniparser libglvnd sdl2 portaudio sndio libpulse
+
+      # Arch's `cava` package only ships the CLI binary, not the shared
+      # library/headers the shell links against (see shell/plugin/CMakeLists.txt).
+      # Build `libcava` from AUR instead so pkg-config/find_library actually
+      # picks it up and the audio visualizer is compiled into the release asset.
+      - name: Build and Install libcava (AUR)
+        run: |
+          set -euo pipefail
+          useradd -m builder
+          su builder -c '
+            set -euo pipefail
+            git clone --depth 1 https://aur.archlinux.org/libcava.git /tmp/libcava
+            cd /tmp/libcava
+            makepkg --noconfirm
+          '
+          pacman -U --noconfirm /tmp/libcava/libcava-*.pkg.tar.zst
 
       - name: Load Release Tag
         run: |


### PR DESCRIPTION
Fixes #672.

Arch's cava package only ships the CLI binary. It does not include the shared library or headers that shell/plugin/CMakeLists.txt looks for via pkg-config and find_library to enable audio visualizer support. Since cava support is optional in CMake, the build succeeds silently without it, which is why the prebuilt shell asset ships without a working visualizer.

This change builds libcava from its AUR PKGBUILD in the build-shell job. All of its dependencies are already in the official Arch repos (fftw, ncurses, alsa-lib, iniparser, libglvnd, sdl2, portaudio, sndio, libpulse, libpipewire, meson, autoconf-archive), so no AUR helper is required. The build runs under a user with no root privileges, since makepkg refuses to run as root, and the resulting package is then installed with pacman. The cava CLI package was removed from the install list since it does not provide what the build needs.

I tested this in an archlinux:base-devel container, the same base image the job uses. pacman installs the new dependency list cleanly, libcava builds through makepkg without issues, pacman installs the built package with no conflicts, and pkg-config reports libcava as found afterward, with cavacore.h and libcava.so landing where CMake expects them.

What is still open is a real CI run of build-shell to confirm the shell compiles with cava support end to end, and a check that the release asset actually shows working visualizers once installed.